### PR TITLE
Adapt controls to Desktop: Create static constructors

### DIFF
--- a/src/Common/Esri.ArcGISRuntime.Toolkit/Controls/Attribution/Attribution.cs
+++ b/src/Common/Esri.ArcGISRuntime.Toolkit/Controls/Attribution/Attribution.cs
@@ -31,8 +31,18 @@ namespace Esri.ArcGISRuntime.Toolkit.Controls
 		/// </summary>
 		public Attribution()
 		{
+#if NETFX_CORE || WINDOWS_PHONE
 			DefaultStyleKey = typeof(Attribution);
+#endif
 		}
+
+#if !NETFX_CORE && !WINDOWS_PHONE
+		static Attribution()
+		{
+			DefaultStyleKeyProperty.OverrideMetadata(typeof(Attribution),
+				new FrameworkPropertyMetadata(typeof(Attribution)));
+		}
+#endif
 		#endregion
 
 		#region DependencyProperty Layers

--- a/src/Common/Esri.ArcGISRuntime.Toolkit/Controls/Legend/Legend.cs
+++ b/src/Common/Esri.ArcGISRuntime.Toolkit/Controls/Legend/Legend.cs
@@ -37,11 +37,21 @@ namespace Esri.ArcGISRuntime.Toolkit.Controls
 		/// </summary>
 		public Legend()
 		{
+#if NETFX_CORE || WINDOWS_PHONE
 			DefaultStyleKey = typeof(Legend);
+#endif
 			_legendTree = new LegendTree();
 			_legendTree.Refreshed += OnRefreshed;
 			_legendTree.PropertyChanged += LegendTree_PropertyChanged;
 		}
+
+#if !NETFX_CORE && !WINDOWS_PHONE
+		static Legend()
+		{
+			DefaultStyleKeyProperty.OverrideMetadata(typeof(Legend),
+				new FrameworkPropertyMetadata(typeof(Legend)));
+		}
+#endif
 
 		void LegendTree_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
 		{
@@ -70,10 +80,10 @@ namespace Esri.ArcGISRuntime.Toolkit.Controls
 
 		private static void OnScalePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
 		{
-			((Legend)d).OnLayersPropertyChanged((double)e.NewValue);
+			((Legend)d).OnScalePropertyChanged((double)e.NewValue);
 		}
 
-		private void OnLayersPropertyChanged(double scale)
+		private void OnScalePropertyChanged(double scale)
 		{
 			if (!_isLoaded)
 				return; // defer initialization until all parameters are well known

--- a/src/Common/Esri.ArcGISRuntime.Toolkit/Controls/ScaleLine/ScaleLine.cs
+++ b/src/Common/Esri.ArcGISRuntime.Toolkit/Controls/ScaleLine/ScaleLine.cs
@@ -41,12 +41,21 @@ namespace Esri.ArcGISRuntime.Toolkit.Controls
         /// <summary>
         /// Initializes a new instance of the <see cref="ScaleLine"/> class.
         /// </summary>
-        public ScaleLine()
-        {
+		public ScaleLine()
+		{
+#if NETFX_CORE || WINDOWS_PHONE
 			DefaultStyleKey = typeof(ScaleLine);
-        }       
+#endif
+		}
 
-        #endregion Constructor
+#if !NETFX_CORE && !WINDOWS_PHONE
+		static ScaleLine()
+		{
+			DefaultStyleKeyProperty.OverrideMetadata(typeof(ScaleLine),
+				new FrameworkPropertyMetadata(typeof(ScaleLine)));
+		}
+#endif
+		#endregion Constructor
 
         #region OnApplyTemplate
 


### PR DESCRIPTION
Desktop only: Set DefaultStyleKey by using OverrideMetadata
