### PR TITLE
Legend Control doesn't update when layer properties minscale/maxscale/showlegend change.

### DIFF
--- a/src/Common/Esri.ArcGISRuntime.Toolkit/Controls/Legend/LegendTree.cs
+++ b/src/Common/Esri.ArcGISRuntime.Toolkit/Controls/Legend/LegendTree.cs
@@ -111,17 +111,25 @@ namespace Esri.ArcGISRuntime.Toolkit.Controls
 		}
 		#endregion
 
-		private IEnumerable<Layer> _Layers;
+		private IEnumerable<Layer> _layers;
 
 		internal IEnumerable<Layer> Layers
 		{
-			get { return _Layers; }
+			get { return _layers; }
 			set {
-				if (_Layers is INotifyCollectionChanged)
-					(_Layers as INotifyCollectionChanged).CollectionChanged -= Layers_CollectionChanged;
-				_Layers = value;
-				if (_Layers is INotifyCollectionChanged)
-					(_Layers as INotifyCollectionChanged).CollectionChanged += Layers_CollectionChanged;
+				if (_layers is INotifyCollectionChanged)
+					(_layers as INotifyCollectionChanged).CollectionChanged -= Layers_CollectionChanged;
+				if (_layers != null)
+					foreach (var layer in _layers)
+						layer.PropertyChanged -= Layer_PropertyChanged;
+
+				_layers = value;
+
+				if (_layers is INotifyCollectionChanged)
+					(_layers as INotifyCollectionChanged).CollectionChanged += Layers_CollectionChanged;
+				if (_layers != null)
+					foreach (var layer in _layers)
+						layer.PropertyChanged += Layer_PropertyChanged;
 				UpdateMapLayerItems();
 			}
 		}


### PR DESCRIPTION
Issue #6 Legend Control doesn't update when layer properties minscale/maxscale/showlegend change

Code change:
- LegendTree subscribes to Layer.PropertyChanged events.
- Update legend when MinScale, MaxScale or Visibility changes.

@dotMorten For code review
