### PR TITLE
Attribution: Added Scale and Extent Dependency Properties.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,15 @@ ArcGIS Toolkit for .NET includes:
   xmlns:esriTK="using:Esri.ArcGISRuntime.Toolkit.Controls" 
 ```
 
-<i>Note: Some of the following examples assumes an ArcGIS map control named 'MyMap' is present.</i>
+<i>Note: Some of the following examples assumes an ArcGIS map view control named 'MyMapView' containing an ArcGIS map named 'MyMap' is present.</i>
 
 ####Legend
 Set the `Layers` property to the collection of layers you want to show legend for.
 If you only want to display layers that are visible at the current scale range, also set the `Scale` property. Set this to 'NaN' (or don't set it) to avoid filtering by layer scale visibility.
-Both of these properties are available for binding directly from the map. Example:
+Both of these properties are available for binding directly from the map and the map view. Example:
 ```xml
   <esriTK:Legend Layers="{Binding Layers, ElementName=MyMap}" 
-    Scale="{Binding Scale, ElementName=MyMap}" />
+    Scale="{Binding Scale, ElementName=MyMapView}" />
 ```
 Other useful properties:
 * `ShowOnlyVisibleLayers` - Don't show legend for layers not currently visible
@@ -41,13 +41,25 @@ Other useful properties:
 
 ####Attribution
 Simply set the `Layers` property to those layers that you want to display attribution for. Note that the terms of use for many services requires you to display some form of attribution, and this control will make that easy for you.
+Attribution is displayed for visible layers only.
 ```xml
   <esriTK:Attribution Layers="{Binding Layers, ElementName=MyMap}" />
+```
+If you only want to display attribution for layers that are visible at the current scale range, also set the `Scale` property. Set this to 'NaN' (or don't set it) to avoid filtering by layer scale visibility.
+```xml
+  <esriTK:Attribution Layers="{Binding Layers, ElementName=MyMap}" 
+    Scale={Binding Scale, ElementName=MyMapView} />
+```
+For a support of layers with attribution depending on the current extent and scale also set the `Extent` property.
+```xml
+  <esriTK:Attribution Layers="{Binding Layers, ElementName=MyMap}" 
+    Scale={Binding Scale, ElementName=MyMapView} 
+    Extent={Binding Extent, ElementName=MyMapView} />
 ```
 
 ####ScaleLine
 ```xml
-   <esriTK:ScaleLine Scale="{Binding Scale, ElementName=MyMap}" />
+   <esriTK:ScaleLine Scale="{Binding Scale, ElementName=MyMapView}" />
 ```
 
 ####SignInDialog (Desktop only)

--- a/src/Common/Esri.ArcGISRuntime.Toolkit/Controls/Attribution/Attribution.cs
+++ b/src/Common/Esri.ArcGISRuntime.Toolkit/Controls/Attribution/Attribution.cs
@@ -9,6 +9,8 @@ using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
 using Esri.ArcGISRuntime.Toolkit.Internal;
+using Esri.ArcGISRuntime.Controls;
+using Esri.ArcGISRuntime.Geometry;
 #if NETFX_CORE
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -88,6 +90,53 @@ namespace Esri.ArcGISRuntime.Toolkit.Controls
 
         #endregion
 
+        #region DependencyProperty Scale
+        /// <summary>
+        /// Gets or sets the scale for filtering layers by their visible scale range and for getting the copyrights that may depend on the scale.
+        /// </summary>
+        public double Scale
+        {
+            get { return (double)GetValue(ScaleProperty); }
+            set { SetValue(ScaleProperty, value); }
+        }
+
+        /// <summary>
+        /// Identifies the <see cref="Scale"/> Dependency property.
+        /// </summary>
+        public static readonly DependencyProperty ScaleProperty =
+            DependencyProperty.Register("Scale", typeof(double), typeof(Attribution), new PropertyMetadata(double.NaN, OnScalePropertyChanged));
+
+        private static void OnScalePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var attribution = d as Attribution;
+            attribution.UpdateAttributionItems();
+        }
+        #endregion
+
+        #region DependencyProperty Extent
+        /// <summary>
+        /// Gets or sets the extent for which the layer copyrights are displayed.
+        /// </summary>
+        /// <seealso cref="IQueryCopyright"/>
+        public Envelope Extent
+        {
+            get { return (Envelope)GetValue(ExtentProperty); }
+            set { SetValue(ExtentProperty, value); }
+        }
+
+        /// <summary>
+        /// Identifies the <see cref="Extent"/> Dependency property.
+        /// </summary>
+        public static readonly DependencyProperty ExtentProperty =
+            DependencyProperty.Register("Extent", typeof(Envelope), typeof(Attribution), new PropertyMetadata(null, OnExtentPropertyChanged));
+
+        private static void OnExtentPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var attribution = d as Attribution;
+            attribution.UpdateAttributionItems();
+        }
+        #endregion
+
         #region Items Dependency Property
 
         /// <summary>
@@ -137,6 +186,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Controls
         private void AttachLayerHandler(Layer layer)
         {
             _layerPropertyChangedListeners.Attach(layer, "IsVisible");
+            _layerPropertyChangedListeners.Attach(layer, "Status");
             layer.PropertyChanged += Layer_PropertyChanged;
         }
 
@@ -148,8 +198,8 @@ namespace Esri.ArcGISRuntime.Toolkit.Controls
 
         private void Layer_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            if (e.PropertyName == "CopyrightText" || e.PropertyName == "IsVisible")
-            	UpdateAttributionItems();
+            if (e.PropertyName == "CopyrightText" || e.PropertyName == "IsVisible" || e.PropertyName == "Status")
+                UpdateAttributionItems();
         }
 
 
@@ -172,16 +222,55 @@ namespace Esri.ArcGISRuntime.Toolkit.Controls
 
         #region Private Methods
 
+        private ThrottleTimer _updateItemsTimer;
         private void UpdateAttributionItems()
+        {
+            // wait for the map to stop navigating so
+            //map navigation performance doesn't suffer from it.
+            if (_updateItemsTimer == null)
+            {
+                _updateItemsTimer = new ThrottleTimer(100) { Action = UpdateAttributionItemsImpl };
+            }
+            _updateItemsTimer.Invoke();
+        }
+
+        private void UpdateAttributionItemsImpl()
         {
             if (Layers == null)
                 Items = null;
             else
             {
-                var visibleCopyrights = Layers.Where(layer => layer.IsVisible).OfType<ICopyright>();
-                Items = visibleCopyrights.Select(cpr => cpr.CopyrightText).Where(cpr => !string.IsNullOrEmpty(cpr))
-                    .Select(cpr => cpr.Trim()).Distinct().ToList();
+                string[] items = Layers.Where(layer => layer.IsVisible && IsInScaleRange(layer))
+                                       .Select(CopyrightText).Where(cpr => !string.IsNullOrEmpty(cpr))
+                                       .Select(cpr => cpr.Trim()).Distinct()
+                                       .ToArray();
+                if (!AreEquals(Items as string[], items)) // Avoid changing Items if the list didn't change
+                    Items = items;
             }
+        }
+
+        private bool AreEquals(string[] strings1, string[] strings2)
+        {
+            return strings1 != null && strings2 != null && strings1.Length == strings2.Length && strings1.Zip(strings2, (string1, string2) => string1 == string2).All(b => b);
+        }
+
+        private bool IsInScaleRange(Layer layer)
+        {
+            return !(Scale > 0.0) || (!(layer.MinScale < Scale) && !(layer.MaxScale > Scale)); // Note: '!' useful for managing correctly NaN cases 
+        }
+
+        private string CopyrightText(Layer l)
+        {
+            if (l is IQueryCopyright)
+            {
+                return ((IQueryCopyright)l).QueryCopyright(Extent, Scale);
+            }
+            else if (l is ICopyright)
+            {
+                return ((ICopyright)l).CopyrightText;
+            }
+            else
+                return null;
         }
 
         #endregion


### PR DESCRIPTION
Support for layers implementing IQueryCopyright (i.e layers having a Copyright depending on Extent/Scale).
If scale is set, don't show attribution of layers out of visible scale range.
Use throttle timer to update the items.
Updated README.
