### PR TITLE
TemplatePicker: Skip ReadOnly layers

### DIFF
--- a/src/Common/Esri.ArcGISRuntime.Toolkit/Controls/TemplatePicker/TemplatePicker.cs
+++ b/src/Common/Esri.ArcGISRuntime.Toolkit/Controls/TemplatePicker/TemplatePicker.cs
@@ -121,7 +121,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Controls
             var templates = new List<TemplateItem>();
             FeatureServiceLayerInfo serviceInfo = null;
             var ft = flayer.FeatureTable;
-            if (ft != null)
+            if (ft != null && !ft.IsReadOnly)
             {
                 if (!(ft is GeodatabaseFeatureServiceTable) || ((GeodatabaseFeatureServiceTable)ft).IsInitialized) // avoid a first chance exception
                 {


### PR DESCRIPTION
@dotMorten In Code Review #31 : Don't display templates for ReadOnly FeatureLayers 
