### PR TITLE
Specify package install location for repo

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <config>
+    <add key="repositorypath" value="packages" />
+  </config>
+</configuration>

--- a/samples/WinDesktop/ArcGISRuntime.Toolkit.Samples/ArcGISRuntime.Toolkit.Samples.Desktop.csproj
+++ b/samples/WinDesktop/ArcGISRuntime.Toolkit.Samples/ArcGISRuntime.Toolkit.Samples.Desktop.csproj
@@ -177,12 +177,12 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\net45\Esri.ArcGISRuntime.targets" Condition="Exists('..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\net45\Esri.ArcGISRuntime.targets')" />
+  <Import Project="..\..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\net45\Esri.ArcGISRuntime.targets" Condition="Exists('..\..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\net45\Esri.ArcGISRuntime.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\net45\Esri.ArcGISRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\net45\Esri.ArcGISRuntime.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\net45\Esri.ArcGISRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\net45\Esri.ArcGISRuntime.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/samples/WinPhone/ArcGISRuntime.Toolkit.Samples.Phone/ArcGISRuntime.Toolkit.Samples.Phone.csproj
+++ b/samples/WinPhone/ArcGISRuntime.Toolkit.Samples.Phone/ArcGISRuntime.Toolkit.Samples.Phone.csproj
@@ -171,12 +171,12 @@
   <PropertyGroup>
     <SDKReferenceDirectoryRoot>C:\applications\output\winprt_sdk\;$(SDKReferenceDirectoryRoot)</SDKReferenceDirectoryRoot>
   </PropertyGroup>
-  <Import Project="..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\wpa81\Esri.ArcGISRuntime.targets" Condition="Exists('..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\wpa81\Esri.ArcGISRuntime.targets')" />
+  <Import Project="..\..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\wpa81\Esri.ArcGISRuntime.targets" Condition="Exists('..\..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\wpa81\Esri.ArcGISRuntime.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\wpa81\Esri.ArcGISRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\wpa81\Esri.ArcGISRuntime.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\wpa81\Esri.ArcGISRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\wpa81\Esri.ArcGISRuntime.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/samples/WinStore/ArcGISRuntime.Toolkit.Samples.Windows/ArcGISRuntime.Toolkit.Samples.Windows.csproj
+++ b/samples/WinStore/ArcGISRuntime.Toolkit.Samples.Windows/ArcGISRuntime.Toolkit.Samples.Windows.csproj
@@ -200,12 +200,12 @@
   <PropertyGroup>
     <SDKReferenceDirectoryRoot>C:\applications\output\winrt_sdk\;$(SDKReferenceDirectoryRoot)</SDKReferenceDirectoryRoot>
   </PropertyGroup>
-  <Import Project="..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\win81\Esri.ArcGISRuntime.targets" Condition="Exists('..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\win81\Esri.ArcGISRuntime.targets')" />
+  <Import Project="..\..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\win81\Esri.ArcGISRuntime.targets" Condition="Exists('..\..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\win81\Esri.ArcGISRuntime.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\win81\Esri.ArcGISRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\win81\Esri.ArcGISRuntime.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\win81\Esri.ArcGISRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\win81\Esri.ArcGISRuntime.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/WinDesktop/Esri.ArcGISRuntime.Toolkit/Esri.ArcGISRuntime.Toolkit.WindowsDesktop.csproj
+++ b/src/WinDesktop/Esri.ArcGISRuntime.Toolkit/Esri.ArcGISRuntime.Toolkit.WindowsDesktop.csproj
@@ -88,13 +88,12 @@
   </ItemGroup>
   <Import Project="..\..\Common\Esri.ArcGISRuntime.Toolkit\Esri.ArcGISRuntime.Toolkit.Shared.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\net45\Esri.ArcGISRuntime.targets" Condition="Exists('..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\net45\Esri.ArcGISRuntime.targets')" />
-  <Import Project="..\..\..\samples\packages\Esri.ArcGISRuntime.10.2.4.748\build\net45\Esri.ArcGISRuntime.targets" Condition="Exists('..\..\..\samples\packages\Esri.ArcGISRuntime.10.2.4.748\build\net45\Esri.ArcGISRuntime.targets') And !Exists('..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\net45\Esri.ArcGISRuntime.targets')" />
+  <Import Project="..\..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\net45\Esri.ArcGISRuntime.targets" Condition="Exists('..\..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\net45\Esri.ArcGISRuntime.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\net45\Esri.ArcGISRuntime.targets') And !Exists('..\..\..\samples\packages\Esri.ArcGISRuntime.10.2.4.748\build\net45\Esri.ArcGISRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\net45\Esri.ArcGISRuntime.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\net45\Esri.ArcGISRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\net45\Esri.ArcGISRuntime.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/WinPhone/Esri.ArcGISRuntime.Toolkit/Esri.ArcGISRuntime.Toolkit.WindowsPhone.csproj
+++ b/src/WinPhone/Esri.ArcGISRuntime.Toolkit/Esri.ArcGISRuntime.Toolkit.WindowsPhone.csproj
@@ -118,13 +118,12 @@ xcopy $(TargetDir)$(TargetName)\Themes\Generic.xbf "%25output%25Redist\CommonCon
 
 </PostBuildEvent>
   </PropertyGroup>
-  <Import Project="..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\wpa81\Esri.ArcGISRuntime.targets" Condition="Exists('..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\wpa81\Esri.ArcGISRuntime.targets')" />
-  <Import Project="..\..\..\samples\packages\Esri.ArcGISRuntime.10.2.4.748\build\wpa81\Esri.ArcGISRuntime.targets" Condition="Exists('..\..\..\samples\packages\Esri.ArcGISRuntime.10.2.4.748\build\wpa81\Esri.ArcGISRuntime.targets') And !Exists('..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\wpa81\Esri.ArcGISRuntime.targets')" />
+  <Import Project="..\..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\wpa81\Esri.ArcGISRuntime.targets" Condition="Exists('..\..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\wpa81\Esri.ArcGISRuntime.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\wpa81\Esri.ArcGISRuntime.targets') And !Exists('..\..\..\samples\packages\Esri.ArcGISRuntime.10.2.4.748\build\wpa81\Esri.ArcGISRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\wpa81\Esri.ArcGISRuntime.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\wpa81\Esri.ArcGISRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\wpa81\Esri.ArcGISRuntime.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/WinStore/Esri.ArcGISRuntime.Toolkit/Esri.ArcGISRuntime.Toolkit.WindowsStore.csproj
+++ b/src/WinStore/Esri.ArcGISRuntime.Toolkit/Esri.ArcGISRuntime.Toolkit.WindowsStore.csproj
@@ -140,13 +140,12 @@ xcopy $(TargetDir)$(TargetName)\Themes\Generic.xbf "%25output%25Redist\CommonCon
 
 </PostBuildEvent>
   </PropertyGroup>
-  <Import Project="..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\win81\Esri.ArcGISRuntime.targets" Condition="Exists('..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\win81\Esri.ArcGISRuntime.targets')" />
-  <Import Project="..\..\..\samples\packages\Esri.ArcGISRuntime.10.2.4.748\build\win81\Esri.ArcGISRuntime.targets" Condition="Exists('..\..\..\samples\packages\Esri.ArcGISRuntime.10.2.4.748\build\win81\Esri.ArcGISRuntime.targets') And !Exists('..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\win81\Esri.ArcGISRuntime.targets')" />
+  <Import Project="..\..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\win81\Esri.ArcGISRuntime.targets" Condition="Exists('..\..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\win81\Esri.ArcGISRuntime.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\win81\Esri.ArcGISRuntime.targets') And !Exists('..\..\..\samples\packages\Esri.ArcGISRuntime.10.2.4.748\build\win81\Esri.ArcGISRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\win81\Esri.ArcGISRuntime.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\win81\Esri.ArcGISRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Esri.ArcGISRuntime.10.2.4.748\build\win81\Esri.ArcGISRuntime.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
Fixes issue with package install path specified in NuGet.config outside repo by adding NuGet.config at repo root.  Specifies package location for repo, overriding other locations specified by NuGet.config files.
