### PR TITLE
Update OnApplyTemplate() in BasemapGallery.Appearance.cs 

### DIFF
--- a/src/Toolkit/Toolkit.UI.Controls/BasemapGallery/BasemapGallery.Appearance.cs
+++ b/src/Toolkit/Toolkit.UI.Controls/BasemapGallery/BasemapGallery.Appearance.cs
@@ -54,6 +54,12 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             ListView = GetTemplateChild("PART_InnerListView") as ListView;
             _loadingScrim = GetTemplateChild("PART_LoadingScrim") as UIElement;
 
+            if (AvailableBasemaps.Count != 0)
+            {
+                _loadingScrim.Visibility = Visibility.Collapsed;
+                ListView.ItemsSource = AvailableBasemaps;
+            }
+
             SetNewStyle(ActualWidth);
         }
 


### PR DESCRIPTION
Under NetFramework 472, BasemapGallery does not work when started as Collapsed.   This update will allow BasemapGallery starts as Collapsed and when Visibility changed to Visible  basemap items will be shown.   