### PR TITLE
Basemap URI null check

### DIFF
--- a/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryItem.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryItem.cs
@@ -248,7 +248,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
 
             return other == Basemap || other.Name == Basemap?.Name
                                     || (other.Item?.ItemId != null && other.Item?.ItemId == Basemap?.Item?.ItemId)
-                                    || other.Uri == Basemap?.Uri;
+                                    || (other.Uri != null && other.Uri == Basemap?.Uri);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Two basemaps both with null URI's were incorrectly returning as true. Different basemaps can both have null URI's. Fixes #489 