### PR TITLE
Update FloorFilter with Indoors support

### DIFF
--- a/docs/floor-filter.md
+++ b/docs/floor-filter.md
@@ -20,6 +20,7 @@ FloorFilter allows users to take advantage of floor-aware maps and scenes by sur
 - Exposes a full range of template and style properties for easy customization
 - Adjusts layout and presentation to work well regardless of positioning - left/right and top/bottom
 - Keeps the selected facility visible in the list while the selection is changing in response to map navigation
+- When used with a MapView with location display configured with a floor-aware data source, the FloorFilter will automatically select the floor from the location data source, if the incoming location is within the currently selected facility and automatic floor selection is enabled.
 
 ## Customization
 

--- a/src/Samples/Toolkit.SampleApp.Maui/Samples/FloorFilterSample.xaml
+++ b/src/Samples/Toolkit.SampleApp.Maui/Samples/FloorFilterSample.xaml
@@ -19,6 +19,19 @@
                 HorizontalOptions="Start"
                 MaximumHeightRequest="400"
                 VerticalOptions="End" />
+            <Border
+                Margin="8"
+                Padding="8"
+                Background="{AppThemeBinding Light=White,
+                                             Dark=Black}"
+                HorizontalOptions="End"
+                MaximumWidthRequest="120"
+                VerticalOptions="Start">
+                <VerticalStackLayout>
+                    <Entry x:Name="TestTextbox" BackgroundColor="Gray" />
+                    <Label Text="Click to set location with floor" />
+                </VerticalStackLayout>
+            </Border>
         </Grid>
     </ContentPage.Content>
 </ContentPage>

--- a/src/Samples/Toolkit.SampleApp.Maui/Samples/FloorFilterSample.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.Maui/Samples/FloorFilterSample.xaml.cs
@@ -1,13 +1,73 @@
-﻿namespace Toolkit.SampleApp.Maui.Samples
+﻿using Esri.ArcGISRuntime.Geometry;
+using Esri.ArcGISRuntime.Location;
+using Esri.ArcGISRuntime.Maui;
+using Location = Esri.ArcGISRuntime.Location.Location;
+
+namespace Toolkit.SampleApp.Maui.Samples
 {
     [XamlCompilation(XamlCompilationOptions.Compile)]
     [SampleInfoAttribute(Category = "FloorFilter", Description = "Demonstrates FloorFilter with a floor-aware map.")]
     public partial class FloorFilterSample : ContentPage
     {
+        private ClickLocationSource _locationSource = new ClickLocationSource();
         public FloorFilterSample()
         {
             InitializeComponent();
             MyMapView.Map = new Esri.ArcGISRuntime.Mapping.Map(new Uri("https://www.arcgis.com/home/item.html?id=b4b599a43a474d33946cf0df526426f5"));
+            try
+            {
+                MyMapView.LocationDisplay.DataSource = _locationSource;
+                MyMapView.LocationDisplay.DataSource.StartAsync();
+            }
+            catch(Exception ex)
+            {
+                // Ignore - sometimes LocationDisplay is null
+            }
+            MyMapView.GeoViewTapped += MyMapView_GeoViewTapped;
+        }
+
+        private void MyMapView_GeoViewTapped(object? sender, GeoViewInputEventArgs e)
+        {
+            if (MyMapView.LocationDisplay != null && MyMapView.LocationDisplay.DataSource != _locationSource)
+            {
+                MyMapView.LocationDisplay.DataSource = _locationSource;
+                MyMapView.LocationDisplay.DataSource.StartAsync();
+            }
+            if (e.Location != null)
+            {
+                _locationSource.PushLocation(e.Location, TestTextbox.Text);
+            }
+        }
+    }
+
+    public class ClickLocationSource : LocationDataSource
+    {
+        private bool _isStarted;
+        protected override Task OnStartAsync()
+        {
+            _isStarted = true;
+            return Task.CompletedTask;
+        }
+
+        protected override Task OnStopAsync()
+        {
+            _isStarted = false;
+            return Task.CompletedTask;
+        }
+        public void PushLocation(MapPoint pointLocation, string? floor)
+        {
+            if (int.TryParse(floor, out int id))
+            {
+                UpdateLocation(new Location(DateTimeOffset.Now, pointLocation, 50, 60, 0, 0, false, new[] { new KeyValuePair<string, object?>(LocationSourcePropertyKeys.Floor, id) }));
+            }
+            else if (!string.IsNullOrEmpty(floor))
+            {
+                UpdateLocation(new Location(DateTimeOffset.Now, pointLocation, 50, 60, 0, 0, false, new[] { new KeyValuePair<string, object?>(LocationSourcePropertyKeys.Floor, floor) }));
+            }
+            else
+            {
+                UpdateLocation(new Location(DateTimeOffset.Now, pointLocation, 50, 60, 0, 0, false));
+            }
         }
     }
 }

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/FloorFilter/SimpleFloorFilterSample.xaml
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/FloorFilter/SimpleFloorFilterSample.xaml
@@ -11,5 +11,28 @@
     <Grid>
         <esri:MapView x:Name="MyMapView" />
         <esri:FloorFilter GeoView="{Binding ElementName=MyMapView}" />
+        <Border
+            Margin="8"
+            Padding="8"
+            HorizontalAlignment="Left"
+            VerticalAlignment="Top"
+            Background="White">
+            <StackPanel MaxWidth="140">
+                <TextBlock
+                    Margin="0,0,0,4"
+                    FontWeight="SemiBold"
+                    Text="Click map to test location" />
+                <TextBox x:Name="TestTextbox" Text="" />
+                <TextBlock
+                    MaxWidth="180"
+                    Margin="0,4,0,4"
+                    Text="value above will be used as floor input. This should be passed a value equivalent to vertical order. If the value successfully parsed as int, int will be passed; otherwise string will be passed; if string is empty, no value is provided."
+                    TextWrapping="Wrap" />
+                <TextBlock
+                    Foreground="Red"
+                    Text="Expectation: if the vertical order for the location matches a floor in the currently selected facility and the point falls within that facility's bounding box, the floor will be selected."
+                    TextWrapping="Wrap" />
+            </StackPanel>
+        </Border>
     </Grid>
 </UserControl>

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/FloorFilter/SimpleFloorFilterSample.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/FloorFilter/SimpleFloorFilterSample.xaml.cs
@@ -1,16 +1,61 @@
 
+using Esri.ArcGISRuntime.Geometry;
+using Esri.ArcGISRuntime.Location;
 using Esri.ArcGISRuntime.Mapping;
 using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using System.Windows.Controls;
 
 namespace Esri.ArcGISRuntime.Toolkit.Samples.FloorFilter
 {
     public partial class SimpleFloorFilterSample: UserControl
     {
+        private ClickLocationSource _locationSource = new ClickLocationSource();
         public SimpleFloorFilterSample()
         {
             InitializeComponent();
             MyMapView.Map = new Esri.ArcGISRuntime.Mapping.Map(new Uri("https://www.arcgis.com/home/item.html?id=b4b599a43a474d33946cf0df526426f5"));
+            MyMapView.LocationDisplay.DataSource = _locationSource;
+            MyMapView.GeoViewTapped += MyMapView_GeoViewTapped;
+            MyMapView.LocationDisplay.DataSource.StartAsync();
+        }
+
+        private void MyMapView_GeoViewTapped(object sender, ArcGISRuntime.UI.Controls.GeoViewInputEventArgs e)
+        {
+            if(e.Location != null)
+            _locationSource.PushLocation(e.Location, TestTextbox.Text);
+        }
+    }
+
+    public class ClickLocationSource : LocationDataSource
+    {
+        private bool _isStarted;
+        protected override Task OnStartAsync()
+        {
+            _isStarted = true;
+            return Task.CompletedTask;
+        }
+
+        protected override Task OnStopAsync()
+        {
+            _isStarted = false;
+            return Task.CompletedTask;
+        }
+        public void PushLocation(MapPoint pointLocation, string? floor)
+        {
+            if (int.TryParse(floor, out int id))
+            {
+                UpdateLocation(new Location.Location(DateTimeOffset.Now, pointLocation, 50, 60, 0, 0, false, new[] { new KeyValuePair<string, object>(LocationSourcePropertyKeys.Floor, id) }));
+            }
+            else if (!string.IsNullOrEmpty(floor))
+            {
+                UpdateLocation(new Location.Location(DateTimeOffset.Now, pointLocation, 50, 60, 0, 0, false, new[] { new KeyValuePair<string,object>(LocationSourcePropertyKeys.Floor, floor) }));
+            }
+            else
+            {
+                UpdateLocation(new Location.Location(DateTimeOffset.Now, pointLocation, 50, 60, 0, 0, false));
+            }
         }
     }
 }

--- a/src/Toolkit/Toolkit.UI.Controls/FloorFilter/FloorFilter.cs
+++ b/src/Toolkit/Toolkit.UI.Controls/FloorFilter/FloorFilter.cs
@@ -420,6 +420,11 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
 #endif
                 }
 
+                if (oldView is MapView mv && mv.LocationDisplay != null)
+                {
+                    mv.LocationDisplay.LocationChanged += LocationDisplay_LocationChanged;
+                }
+
                 oldView.ViewpointChanged -= HandleGeoViewViewpointChanged;
                 oldView.NavigationCompleted -= HandleGeoViewNavigationCompleted;
             }
@@ -443,6 +448,11 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
 #endif
                 }
 
+                if (newView is MapView mv && mv.LocationDisplay != null)
+                {
+                    mv.LocationDisplay.LocationChanged += LocationDisplay_LocationChanged;
+                }
+
                 newView.ViewpointChanged += HandleGeoViewViewpointChanged;
                 newView.NavigationCompleted += HandleGeoViewNavigationCompleted;
 
@@ -451,6 +461,32 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             }
 
             OnPropertyChanged(nameof(ShowAllFloorsButton));
+        }
+
+        private void LocationDisplay_LocationChanged(object? sender, Location.Location? e)
+        {
+            if (e == null)
+            {
+                return;
+            }
+
+            try
+            {
+#if NETFX_CORE
+            _ = Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () =>
+#elif WINUI
+                DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Normal, () =>
+#else
+            Dispatcher.Invoke(() =>
+#endif
+                {
+                    _controller.ProcessUpdatedLocation(e);
+                });
+            }
+            catch (Exception)
+            {
+                // Ignore
+            }
         }
 
         private void HandleGeoViewViewpointChanged(object? sender, EventArgs e)


### PR DESCRIPTION
This PR updates the core floorfilter controller with support for applying extended location information. It also updates the MAUI and windows UI implementations to take advantage of this feature and adds a sample feature for testing.

Implementation will only set the floor if the incoming point is within the currently selected facility's bounding rectangle.

Sample supports testing with empty and invalid floor information.


https://user-images.githubusercontent.com/29742178/225439724-05b712fd-9dcd-45fc-931f-f31f765c3cae.mp4

