### PR TITLE
Update WindowsAppSDK version to match MAUI requirements

### DIFF
--- a/src/Samples/Toolkit.SampleApp.Maui/Toolkit.SampleApp.Maui.csproj
+++ b/src/Samples/Toolkit.SampleApp.Maui/Toolkit.SampleApp.Maui.csproj
@@ -54,7 +54,7 @@
     <MauiXaml Remove="Samples\PopupViewerSample.xaml" />
     <MauiXaml Remove="Samples\TimeSliderSample.xaml" />
 
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.1.4" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.1.5" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'" />
   </ItemGroup>
 
 


### PR DESCRIPTION
Current versions of MAUI [depend on WindowsAppSDK 1.1.5](https://www.nuget.org/packages/Microsoft.Maui.Dependencies/6.0.552#dependencies-body-tab) but our MAUI sample project still references 1.1.4, causing a build error:

```
error NU1605: Warning As Error: Detected package downgrade: Microsoft.WindowsAppSDK from 1.1.5 to 1.1.4. Reference the package directly from the project to select a different version. 
error NU1605:  Toolkit.SampleApp.Maui -> Microsoft.Maui.Dependencies 6.0.552 -> Microsoft.WindowsAppSDK (>= 1.1.5) 
error NU1605:  Toolkit.SampleApp.Maui -> Microsoft.WindowsAppSDK (>= 1.1.4)
```