### PR TITLE
Fix paragraph spacing in WPF text popups

### DIFF
--- a/src/Toolkit/Toolkit.WPF/UI/Controls/PopupViewer/TextPopupElementView.cs
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/PopupViewer/TextPopupElementView.cs
@@ -1,4 +1,4 @@
-﻿// /*******************************************************************************
+// /*******************************************************************************
 //  * Copyright 2012-2018 Esri
 //  *
 //  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -91,6 +91,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                 {
                     if (inlineHolder != null)
                     {
+                        AdjustSpacing(inlineHolder, null);
                         yield return inlineHolder;
                         inlineHolder = null;
                     }
@@ -155,6 +156,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                         var para = new Paragraph();
                         ApplyStyle(para, node);
                         para.Inlines.AddRange(VisitAndAddInlines(node.Children));
+                        AdjustSpacing(para, node);
                         return para;
                     }
 
@@ -246,6 +248,19 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                 default:
                     return new Run(); // placeholder for unsupported types
             }
+        }
+
+        private static void AdjustSpacing(Paragraph para, MarkupNode? blockNode)
+        {
+            // WPF LineBreaks behave differently from HTML breaks.
+            // In HTML, a <br> is needed inside empty blocks to prevent block height from collapsing.
+            // But in WPF, that <br> just adds an unwanted second line, so we skip it.
+            if (para.Inlines.Count == 1 && para.Inlines.First() is LineBreak lastBreak)
+                para.Inlines.Remove(lastBreak);
+            // In HTML, <p> has default margin but other blocks (like <div>) do not.
+            // In WPF, all of these map to Paragraphs that *does* have a default margin.
+            if (blockNode?.Token?.Name != "p")
+                para.Margin = new Thickness(0);
         }
 
         private static bool HasAnyBlocks(MarkupNode node)


### PR DESCRIPTION
This PR fixes some paragraph spacing problems in the current WPF PopupViewer.

This is a WPF-specific fix that removes extra whitespace, e.g. as seen in [this Living Atlas webmap](https://runtime.maps.arcgis.com/apps/mapviewer/index.html?webmap=8385771034394f99920886bc6d51590f):

| Before fix | After fix |
|---|---|
| ![2023-04-12_133953](https://user-images.githubusercontent.com/587809/231580128-a7e93f76-59cf-45e5-b50c-0b83e1867bbc.png) | ![2023-04-12_133925](https://user-images.githubusercontent.com/587809/231580165-50e4ad2e-6634-4e70-9814-51d9f99087ae.png)