### PR TITLE
PopupViewer sample: check all results for popups before building new one

### DIFF
--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/PopupViewer/PopupViewerSample.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/PopupViewer/PopupViewerSample.xaml.cs
@@ -1,4 +1,4 @@
-﻿using Esri.ArcGISRuntime.Data;
+using Esri.ArcGISRuntime.Data;
 using Esri.ArcGISRuntime.Mapping.Popups;
 using Esri.ArcGISRuntime.UI;
 using Esri.ArcGISRuntime.UI.Controls;
@@ -31,7 +31,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.PopupViewer
                 var result = await mapView.IdentifyLayersAsync(e.Position, 3, false);
 
                 // Retrieves or builds Popup from IdentifyLayerResult
-                var popup = GetPopup(result);
+                var popup = GetPopup(result) ?? BuildPopupFromGeoElement(result);
                 if (popup != null)
                 {
                     PopupBackground.Visibility = Visibility.Visible;
@@ -47,59 +47,67 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.PopupViewer
         private Popup GetPopup(IdentifyLayerResult result)
         {
             if (result == null)
-            {
                 return null;
-            }
-
             var popup = result.Popups.FirstOrDefault();
             if (popup != null)
             {
+                if (popup.GeoElement is DynamicEntityObservation deo)
+                {
+                    return new Popup(deo.GetDynamicEntity(), popup.PopupDefinition);
+                }
                 return popup;
             }
 
-            var geoElement = result.GeoElements.FirstOrDefault();
-            if (geoElement != null)
-            {
-                if (result.LayerContent is IPopupSource)
-                {
-                    var popupDefinition = ((IPopupSource)result.LayerContent).PopupDefinition;
-                    if (popupDefinition != null)
-                    {
-                        return new Popup(geoElement, popupDefinition);
-                    }
-                }
-
-                return Popup.FromGeoElement(geoElement);
-            }
-
-            return null;
+            return GetPopup(result.SublayerResults);
         }
 
         private Popup GetPopup(IEnumerable<IdentifyLayerResult> results)
         {
             if (results == null)
-            {
                 return null;
-            }
             foreach (var result in results)
             {
                 var popup = GetPopup(result);
                 if (popup != null)
-                {
                     return popup;
-                }
-
-                foreach (var subResult in result.SublayerResults)
-                {
-                    popup = GetPopup(subResult);
-                    if (popup != null)
-                    {
-                        return popup;
-                    }
-                }
             }
 
-            return null; 
+            return null;
+        }
+
+        private Popup BuildPopupFromGeoElement(IdentifyLayerResult result)
+        {
+            if (result == null)
+                return null;
+            var geoElement = result.GeoElements.FirstOrDefault();
+            if (geoElement != null)
+            {
+                if (geoElement is DynamicEntityObservation obs)
+                    geoElement = obs.GetDynamicEntity();
+                if (result.LayerContent is IPopupSource source)
+                {
+                    var popupDefinition = source.PopupDefinition;
+                    if (popupDefinition != null)
+                    {
+                        return new Popup(geoElement, popupDefinition);
+                    }
+                }
+                return Popup.FromGeoElement(geoElement);
+            }
+            return BuildPopupFromGeoElement(result.SublayerResults);
+        }
+
+        private Popup BuildPopupFromGeoElement(IEnumerable<IdentifyLayerResult> results)
+        {
+            if (results == null)
+                return null;
+            foreach (var result in results)
+            {
+                var popup = BuildPopupFromGeoElement(result);
+                if (popup != null)
+                    return popup;
+            }
+            return null;
         }
 
         private void PopupBackground_MouseDown(object sender, System.Windows.Input.MouseButtonEventArgs e)

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/PopupViewer/PopupViewerSample.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/PopupViewer/PopupViewerSample.xaml.cs
@@ -48,7 +48,10 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.PopupViewer
         private Popup GetPopup(IdentifyLayerResult result)
         {
             if (result == null)
+            {
                 return null;
+            }
+
             var popup = result.Popups.FirstOrDefault();
             if (popup != null)
             {
@@ -93,6 +96,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.PopupViewer
                         return new Popup(geoElement, popupDefinition);
                     }
                 }
+
                 return Popup.FromGeoElement(geoElement);
             }
             return BuildPopupFromGeoElement(result.SublayerResults);
@@ -101,12 +105,16 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.PopupViewer
         private Popup BuildPopupFromGeoElement(IEnumerable<IdentifyLayerResult> results)
         {
             if (results == null)
+            {
                 return null;
+            }
             foreach (var result in results)
             {
                 var popup = BuildPopupFromGeoElement(result);
                 if (popup != null)
+                {
                     return popup;
+                }
             }
             return null;
         }

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/PopupViewer/PopupViewerSample.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/PopupViewer/PopupViewerSample.xaml.cs
@@ -1,5 +1,6 @@
 using Esri.ArcGISRuntime.Data;
 using Esri.ArcGISRuntime.Mapping.Popups;
+using Esri.ArcGISRuntime.RealTime;
 using Esri.ArcGISRuntime.UI;
 using Esri.ArcGISRuntime.UI.Controls;
 using System;


### PR DESCRIPTION
# Sample change only
When testing PopupViewer sample with different maps, I noticed that our example often returns different results from the AGOL web viewer &mdash; and different from what I expected the behavior to be.

Our existing code checks each result for popups but then immediately goes into fallback code and builds a popup from a GeoElement.  This means we never get around to check sublayer results, or check the second result.

In contrast, the AGOL map viewer first checks ALL results/sublayers for directly-returned popups, and only then starts looking at GeoElements. I implemented similar behavior by splitting GetPopup into two methods groups: GetPopup (recursively checks for popups only) and BuildPopupFromGeoElement (recursively checks for geoelements and popup definitions).

____
Example of a webmap where this can be seen: https://maps.arcgis.com/apps/mapviewer/index.html?webmap=df8bcc10430f48878b01c96e907a1fc3

In AGOL clicking on a warning zone shows its proper popup:

![2023-04-12_113256 msedge](https://user-images.githubusercontent.com/587809/231552346-abb7550a-f6e6-4742-b3c3-991306c9c4ea.png)

In current toolkit sample, it shows a basic generated popup for the "US States" polygon (which happens to be the first GeoElement in results):

![2023-04-12_113605](https://user-images.githubusercontent.com/587809/231552994-ec20079f-e828-49ed-8386-db1b1a79b7db.png)

With this PR, we now match AGOL behavior:
![2023-04-12_113724](https://user-images.githubusercontent.com/587809/231553303-c1487991-a841-4f07-aae7-661f526fd109.png)
