### PR TITLE
Recognize font-weight CSS property in HTML popups

### DIFF
--- a/src/Toolkit/Toolkit/Internal/HtmlUtility.cs
+++ b/src/Toolkit/Toolkit/Internal/HtmlUtility.cs
@@ -364,6 +364,8 @@ internal class HtmlUtility
                     newNode.FontColor = ParseCssColor(colorString);
                 if (styles.TryGetValue("font-size", out var fontSizeString) && TryParseCssFontSize(fontSizeString, out var fontSize))
                     newNode.FontSize = fontSize;
+                if (styles.TryGetValue("font-weight", out var fontWeightStr) && ParseCssFontWeight(fontWeightStr) is bool isBold)
+                    newNode.IsBold = isBold;
                 if (styles.TryGetValue("text-align", out var alignStr) && Enum.TryParse<HtmlAlignment>(alignStr, true, out var align))
                     newNode.Alignment = align;
                 if (styles.TryGetValue("background-color", out var backColorString))
@@ -481,6 +483,31 @@ internal class HtmlUtility
         };
 
         return !double.IsNaN(emValue);
+    }
+
+    // Parses the value of CSS font-weight into a boolean. Returns null for invalid values.
+    private static bool? ParseCssFontWeight(string rawValue)
+    {
+        if (string.IsNullOrEmpty(rawValue))
+            return null;
+
+        string normalizedValue = rawValue.Trim().ToLowerInvariant();
+        switch (normalizedValue)
+        {
+            case "normal":
+            case "lighter":
+                return false;
+            case "bold":
+            case "bolder":
+                return true;
+            default:
+                if (int.TryParse(normalizedValue, out int numericValue) && numericValue > 0)
+                {
+                    // Any numeric value greater than 400 represents a bolder-than-normal font weight
+                    return numericValue > 400;
+                }
+                return null;
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Fixing another functional gap in HTML PopupViewer.

Some webmaps use CSS to make text bold instead of relying on `<b>`.  We can support this by checking for `font-weight` CSS property.

[Example webmap that uses this functionality.](https://runtime.maps.arcgis.com/apps/mapviewer/index.html?webmap=2c8fdc6267e4439e968837020e7618f3)

### Popup before:
![2023-04-11_001905](https://user-images.githubusercontent.com/587809/231086309-dd150140-7a9b-48aa-8bcd-3aed061bcb72.png)

### Popup with this PR:
![2023-04-11_001840](https://user-images.githubusercontent.com/587809/231086348-19977a3e-eb1d-47c7-aa68-6a96de64a5db.png)
