### PR TITLE
Fix list items missing from WPF PopupViewer

### DIFF
--- a/src/Toolkit/Toolkit.WPF/UI/Controls/PopupViewer/TextPopupElementView.cs
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/PopupViewer/TextPopupElementView.cs
@@ -1,4 +1,4 @@
-﻿// /*******************************************************************************
+// /*******************************************************************************
 //  * Copyright 2012-2018 Esri
 //  *
 //  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -130,13 +130,14 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                     if (node.Token?.Name == "ol")
                         list.MarkerStyle = TextMarkerStyle.Decimal;
                     else
-                        list.MarkerStyle = TextMarkerStyle.Circle;
+                        list.MarkerStyle = TextMarkerStyle.Disc;
                     foreach (var itemNode in node.Children)
                     {
                         if (itemNode.Type == MarkupType.ListItem)
                         {
                             var listItem = new ListItem();
                             listItem.Blocks.AddRange(VisitAndAddBlocks(itemNode.Children));
+                            list.ListItems.Add(listItem);
                         }
                         // else ignore a misplaced non-list-item node
                     }


### PR DESCRIPTION
Follow-up to https://github.com/Esri/arcgis-maps-sdk-dotnet-toolkit/pull/504

I think my original PopupViewer test data didn't have enough variety, because I missed a pretty basic bug: ListItems were not getting added to the List.  I also used the wrong marker style (large hollow circles instead of small solid discs).

[Example of a map that shows the buggy behavior.](https://runtime.maps.arcgis.com/apps/mapviewer/index.html?webmap=b76dec26742c48768ec152dd6db05962)

### Before the fix:
![2023-04-10_232146](https://user-images.githubusercontent.com/587809/231073592-ba5c0a21-602c-4705-8cad-8d42537e71f2.png)

### After the fix:
![2023-04-10_232205](https://user-images.githubusercontent.com/587809/231073609-442deac5-1120-46e2-8262-e65d0ac31511.png)

[Another example](https://runtime.maps.arcgis.com/apps/mapviewer/index.html?webmap=0a082752c7e548db8c71b1d9eafb3ecb).