### PR TITLE
Require .NET 7 for MAUI targets

### DIFF
--- a/src/ARSamples/ARToolkit.Samples.Maui/ARToolkit.Samples.Maui.csproj
+++ b/src/ARSamples/ARToolkit.Samples.Maui/ARToolkit.Samples.Maui.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net6.0-android;net6.0-ios</TargetFrameworks>
+		<TargetFrameworks>net7.0-android;net7.0-ios</TargetFrameworks>
 		<OutputType>Exe</OutputType>
 		<RootNamespace>ARToolkit.Samples.Maui</RootNamespace>
 		<UseMaui>true</UseMaui>

--- a/src/ARToolkit.Maui/Esri.ArcGISRuntime.ARToolkit.Maui.csproj
+++ b/src/ARToolkit.Maui/Esri.ArcGISRuntime.ARToolkit.Maui.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;$(NetAndroidTargetFramework);$(NetiOSTargetFramework)</TargetFrameworks>
+    <TargetFrameworks>net7.0;$(NetAndroidTargetFramework);$(NetiOSTargetFramework)</TargetFrameworks>
     <Description>ArcGIS Maps SDK for .NET Augmented Reality (AR) controls and utilities for .NET MAUI apps including .NET for Android and .NET for iOS</Description>
     <PackageTags>ArcGIS Cartography Geo Geographic Geography Geolocation Geospatial GIS Latitude Location Longitude Map Mapping Maps Places Spatial Augmented Reality AR 3D .NET MAUI Android iOS toolkit</PackageTags>
     <UseMaui>true</UseMaui>
@@ -15,7 +15,7 @@
     <AndroidGenerateResourceDesigner>false</AndroidGenerateResourceDesigner>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net7.0'">
     <DefineConstants>$(DefineConstants);NETSTANDARD;NETSTANDARD2_0</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/CommonProperties.targets
+++ b/src/CommonProperties.targets
@@ -13,6 +13,7 @@
   <PropertyGroup>
     <DefineConstants Condition="$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net5.0'))">$(DefineConstants);NET5_0_OR_GREATER</DefineConstants>
     <DefineConstants Condition="$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net6.0'))">$(DefineConstants);NET6_0_OR_GREATER</DefineConstants>
+    <DefineConstants Condition="$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net7.0'))">$(DefineConstants);NET7_0_OR_GREATER</DefineConstants>
     <DefineConstants Condition="'$(IsTargetingWindows)'=='true'">$(DefineConstants);WINDOWS</DefineConstants>
     <DefineConstants Condition="'$(IsTargetingAndroid)'=='true' OR '$(IsTargetingiOS)'=='true'">$(DefineConstants);XAMARIN</DefineConstants>
     <Nullable Condition="'$(SupportsNullable)'=='true'">enable</Nullable>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -38,9 +38,10 @@
     <DotNetTargetFramework>net472</DotNetTargetFramework>
     <UWPTargetFramework>uap10.0.$(WindowsSDKTargetBuild)</UWPTargetFramework>
     <NetWindowsTargetFramework>net6.0-windows10.0.$(WindowsSDKTargetBuild).0</NetWindowsTargetFramework>
-    <NetAndroidTargetFramework>net6.0-android31.0</NetAndroidTargetFramework>
-    <NetCatalystTargetFramework Condition="$(ArcGISRuntimePackageVersion.StartsWith('200.'))">net6.0-maccatalyst14.2</NetCatalystTargetFramework>
-    <NetiOSTargetFramework>net6.0-ios14.0</NetiOSTargetFramework>
+	<NetMauiWindowsTargetFramework>net7.0-windows10.0.$(WindowsSDKTargetBuild).0</NetMauiWindowsTargetFramework>
+    <NetAndroidTargetFramework>net7.0-android33.0</NetAndroidTargetFramework>
+    <NetCatalystTargetFramework>net7.0-maccatalyst16.1</NetCatalystTargetFramework>
+    <NetiOSTargetFramework>net7.0-ios16.1</NetiOSTargetFramework>
     <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
 
     <!--Output paths-->

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -38,7 +38,7 @@
     <DotNetTargetFramework>net472</DotNetTargetFramework>
     <UWPTargetFramework>uap10.0.$(WindowsSDKTargetBuild)</UWPTargetFramework>
     <NetWindowsTargetFramework>net6.0-windows10.0.$(WindowsSDKTargetBuild).0</NetWindowsTargetFramework>
-	<NetMauiWindowsTargetFramework>net7.0-windows10.0.$(WindowsSDKTargetBuild).0</NetMauiWindowsTargetFramework>
+    <NetMauiWindowsTargetFramework>net7.0-windows10.0.$(WindowsSDKTargetBuild).0</NetMauiWindowsTargetFramework>
     <NetAndroidTargetFramework>net7.0-android33.0</NetAndroidTargetFramework>
     <NetCatalystTargetFramework>net7.0-maccatalyst16.1</NetCatalystTargetFramework>
     <NetiOSTargetFramework>net7.0-ios16.1</NetiOSTargetFramework>

--- a/src/Samples/Toolkit.SampleApp.Maui/Toolkit.SampleApp.Maui.csproj
+++ b/src/Samples/Toolkit.SampleApp.Maui/Toolkit.SampleApp.Maui.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0-android;net6.0-ios;net6.0-maccatalyst</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);$(NetWindowsTargetFramework)</TargetFrameworks>
+    <TargetFrameworks>net7.0-android;net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);$(NetMauiWindowsTargetFramework)</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RootNamespace>Toolkit.SampleApp.Maui</RootNamespace>
     <UseMaui>true</UseMaui>
@@ -54,7 +54,6 @@
     <MauiXaml Remove="Samples\PopupViewerSample.xaml" />
     <MauiXaml Remove="Samples\TimeSliderSample.xaml" />
 
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.1.5" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'" />
   </ItemGroup>
 
 

--- a/src/Toolkit/Toolkit.Maui/Esri.ArcGISRuntime.Toolkit.Maui.csproj
+++ b/src/Toolkit/Toolkit.Maui/Esri.ArcGISRuntime.Toolkit.Maui.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;$(NetAndroidTargetFramework);$(NetiOSTargetFramework);$(NetCatalystTargetFramework)</TargetFrameworks>
+        <TargetFrameworks>net7.0;$(NetAndroidTargetFramework);$(NetiOSTargetFramework);$(NetCatalystTargetFramework)</TargetFrameworks>
         <Description>ArcGIS Maps SDK for .NET controls and utilities for .NET MAUI apps including .NET for Android, .NET for iOS, .NET for macOS, or Windows UI 3 (WinUI 3)</Description>
         <PackageTags>ArcGIS Cartography Geo Geographic Geography Geolocation Geospatial GIS Latitude Location Longitude Map Mapping Maps Places Spatial 3D WinUI Android iOS Mac Catalyst MacCatalyst Windows UI 3 toolkit</PackageTags>
-        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);$(NetWindowsTargetFramework)</TargetFrameworks>
+        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);$(NetMauiWindowsTargetFramework)</TargetFrameworks>
         <UseMaui>true</UseMaui>
         <SingleProject>true</SingleProject>
         <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
.NET 6 is no longer supported for MAUI as of May 8, 2023. See https://dotnet.microsoft.com/en-us/platform/support/policy/maui