### PR TITLE
PopupViewer bugfix roundup

### DIFF
--- a/src/Toolkit/Toolkit.WPF/UI/Controls/PopupViewer/TextPopupElementView.cs
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/PopupViewer/TextPopupElementView.cs
@@ -214,7 +214,14 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                             var img = (Image)sender;
                             var taggedUri = (Uri)img.Tag;
                             var ri = new RuntimeImage(taggedUri); // Use Runtime's caching and authentication
-                            img.Source = await ri.ToImageSourceAsync();
+                            try
+                            {
+                                img.Source = await ri.ToImageSourceAsync();
+                            }
+                            catch
+                            {
+                                // Don't let one bad image take down the whole app. Better to ignore a failed image load.
+                            }
                         };
                         return new InlineUIContainer(imageElement);
                     }

--- a/src/Toolkit/Toolkit/Internal/HtmlUtility.cs
+++ b/src/Toolkit/Toolkit/Internal/HtmlUtility.cs
@@ -461,11 +461,13 @@ internal class HtmlUtility
             return false;
 
         fontSizeString = fontSizeString.Trim().ToLowerInvariant();
-        if (fontSizeString.EndsWith("px"))
+        if (fontSizeString.EndsWith("px") || fontSizeString.EndsWith("pt"))
         {
-            if (double.TryParse(fontSizeString.Substring(0, fontSizeString.Length - 2), out var pxValue))
+            if (double.TryParse(fontSizeString.Substring(0, fontSizeString.Length - 2), out var pValue))
             {
-                emValue = pxValue / 16d; // 1em == 16px (approx)
+                // Approximate conversion: 1em == 16px == 12pt
+                var conversionFactor = fontSizeString.EndsWith("px") ? 16 : 12;
+                emValue = pValue / conversionFactor;
                 return true;
             }
         }

--- a/src/Toolkit/Toolkit/Internal/HtmlUtility.cs
+++ b/src/Toolkit/Toolkit/Internal/HtmlUtility.cs
@@ -351,9 +351,9 @@ internal class HtmlUtility
                     break;
             }
 
-            if (name is "div" or "td" or "th" or "tr")
+            if (name is "div" or "p" or "td" or "th" or "tr")
             {
-                if (!attr.TryGetValue("align", out var alignStr) && Enum.TryParse<HtmlAlignment>(alignStr, true, out var align))
+                if (attr.TryGetValue("align", out var alignStr) && Enum.TryParse<HtmlAlignment>(alignStr, true, out var align))
                     newNode.Alignment = align;
             }
 


### PR DESCRIPTION
Three improvements for WPF PopupViewer's text element support:

### Parse font sizes expressed in points (pt)
Ran into this in a few Living Atlas layers, e.g. [National Weather Service Wind Speed Forecast](https://runtimecoretest.maps.arcgis.com/home/item.html?id=47ed83c3b4f943118e848fbfc33d119e):

| Before fix | After fix |
|--|--|
| <img width="300" alt="2023-06-23_083445 Toolkit SampleApp WPF" src="https://github.com/Esri/arcgis-maps-sdk-dotnet-toolkit/assets/587809/558757c5-e7ab-421b-a058-1f4c6412b6d6"> | <img width="300" alt="2023-06-23_083339 Toolkit SampleApp WPF" src="https://github.com/Esri/arcgis-maps-sdk-dotnet-toolkit/assets/587809/2e5f7697-265a-4951-af13-a2b70254499b">

### Don't let image load errors take down the app
When a RuntimeImage representing an `<img>` fails to load (e.g. broken link or unsupported format), an unhandled exception is currently thrown.  I think it's better to suppress it -- users already see a LoadError printed to console.  A broken image link in a popup should not be catastrophic.

### Fix handling of "align" HTML attribute
An accidentally-inverted condition caused all valid align values to be ignored.  Also, `<p>` was missing from the list of tags that can have align attribute.