### PR TITLE
wpf: PopupViewer bugfixes wave 2

### DIFF
--- a/src/Toolkit/Toolkit/Internal/HtmlUtility.cs
+++ b/src/Toolkit/Toolkit/Internal/HtmlUtility.cs
@@ -477,7 +477,7 @@ internal class HtmlUtility
             "x-small" => ParseHtmlFontSize(1),
             "small" => ParseHtmlFontSize(2),
             "medium" => ParseHtmlFontSize(3),
-            "large " => ParseHtmlFontSize(4),
+            "large" => ParseHtmlFontSize(4),
             "x-large" => ParseHtmlFontSize(5),
             "xx-large" => ParseHtmlFontSize(6),
             "xxx-large" => ParseHtmlFontSize(7),

--- a/src/Toolkit/Toolkit/UI/Controls/PopupViewer/TextPopupElementView.Windows.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/PopupViewer/TextPopupElementView.Windows.cs
@@ -269,8 +269,16 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                 el.Background = new SolidColorBrush(ConvertColor(node.BackColor.Value));
             if (node.FontSize.HasValue)
                 el.FontSize = 16d * node.FontSize.Value; // based on AGOL's default font size
-            if (node.Alignment.HasValue && el is Block blockEl)
-                blockEl.TextAlignment = ConvertAlignment(node.Alignment);
+            if (node.Alignment.HasValue)
+            {
+                // Unfortunately the TextAlignment property is separately defined for these FlowDocument elements
+                if (el is Block blockEl)
+                    blockEl.TextAlignment = ConvertAlignment(node.Alignment);
+                else if (el is TableCell cellEl)
+                    cellEl.TextAlignment = ConvertAlignment(node.Alignment);
+                else if (el is ListItem itemEl)
+                    itemEl.TextAlignment = ConvertAlignment(node.Alignment);
+            }
             if (node.IsUnderline.HasValue)
             {
                 if (el is Inline inlineEl)

--- a/src/Toolkit/Toolkit/UI/Controls/PopupViewer/TextPopupElementView.Windows.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/PopupViewer/TextPopupElementView.Windows.cs
@@ -178,6 +178,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                         link.RequestNavigate += NavigateToUri;
                     } // else If we can't create a URL, we can't make a link clickable
                     link.Inlines.AddRange(VisitAndAddInlines(node.Children));
+                    ApplyStyle(link, node);
                     return link;
 
                 case MarkupType.Image:

--- a/src/Toolkit/Toolkit/UI/Controls/PopupViewer/TextPopupElementView.Windows.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/PopupViewer/TextPopupElementView.Windows.cs
@@ -39,7 +39,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
             // Full list of supported tags and attributes here: https://doc.arcgis.com/en/arcgis-online/reference/supported-html.htm
             if (!string.IsNullOrEmpty(Element?.Text) && GetTemplateChild(TextAreaName) is RichTextBox rtb)
             {
-                var doc = new FlowDocument();
+                var doc = new FlowDocument { FontSize = 14d }; // match the default "content" font size on AGOL
                 try
                 {
                     var htmlRoot = HtmlUtility.BuildDocumentTree(Element.Text);

--- a/src/Toolkit/Toolkit/UI/Controls/PopupViewer/TextPopupElementView.Windows.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/PopupViewer/TextPopupElementView.Windows.cs
@@ -153,6 +153,14 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                         {
                             var cell = new TableCell();
                             ApplyStyle(cell, cellNode);
+
+                            // Apply colspan and rowspan, for non-uniform tables
+                            var attr = HtmlUtility.ParseAttributes(cellNode.Token?.Attributes);
+                            if (attr.TryGetValue("colspan", out var colSpanStr) && byte.TryParse(colSpanStr, out var colSpan))
+                                cell.ColumnSpan = colSpan;
+                            if (attr.TryGetValue("rowspan", out var rowSpanStr) && byte.TryParse(rowSpanStr, out var rowSpan))
+                                cell.RowSpan = rowSpan;
+
                             cell.Blocks.AddRange(VisitAndAddBlocks(cellNode.Children));
                             row.Cells.Add(cell);
                         }


### PR DESCRIPTION
I found and fixed a few bugs in WPF PopupViewer during the past 3 months, but didn't get a chance to do a write-up and submit them yet.  Here is batch 2 of 3.

## Font size fixes
FlowDocument's default font size is smaller than intended (12 instead of 14).  This means we defaulted to "small" instead of "medium", which threw all relative sizing off.  Also, an extra space prevented "large" font size from parsing properly.  [Example from the Living Atlas](https://www.arcgis.com/home/item.html?id=8dcf5d4e124f480fa8c529fbe25ba04e):

<table><tr>
<td align="center"><img  alt="Before" src="https://github.com/Esri/arcgis-maps-sdk-dotnet-toolkit/assets/587809/9bbcbe1e-a24b-4569-86f2-9233c112ad15"><br>Before</td>
<td align="center"><img alt="After" src="https://github.com/Esri/arcgis-maps-sdk-dotnet-toolkit/assets/587809/9a0fadc0-4cc7-4eba-994d-5c3c61ee8db8"><br>After</td></tr><tr>
<td  align="center" colspan="2"><img  alt="Reference" src="https://github.com/Esri/arcgis-maps-sdk-dotnet-toolkit/assets/587809/20842083-184b-4a22-af2a-128fa4814abb"><br>Reference (AGOL)</figure></td>
</tr></table>

## Implement colspan and rowspan for tables

WPF tables already support rowspan/colspan, so this was a trivial TODO to implement.  [Example from the Living Atlas](https://runtime.maps.arcgis.com/apps/mapviewer/index.html?webmap=e46c737f1f1341df9338f1bf17540f80)

<table><tr>
<td align="center"><img  alt="Before" src="https://github.com/Esri/arcgis-maps-sdk-dotnet-toolkit/assets/587809/c9f89608-e7f2-46ad-8049-9df6e63e02b1"><br>Before</td>
<td align="center"><img alt="After" src="https://github.com/Esri/arcgis-maps-sdk-dotnet-toolkit/assets/587809/c4d2f692-1fa2-4917-8d76-023c682da2ad"><br>After</td></tr><tr>
<td  align="center" colspan="2"><img  alt="Reference" src="https://github.com/Esri/arcgis-maps-sdk-dotnet-toolkit/assets/587809/d8615dc8-160c-457a-a354-72e7a9b5991e"><br>Reference (AGOL)</figure></td>
</tr></table>

## Apply alignment to TableCells and ListItems
Turns out TableCells and ListItems do not extend Block in WPF, but instead have their own copies of the TextAlignment property.  This resulted in badly-aligned tables on a few maps, e.g. the on the infamous "road signs" one.  This thing is like an [Acid test](https://www.acidtests.org/) for popup rendering.  We can't match reference rendering yet, but we're getting closer! 🙂 

![2023-06-26_094911 Toolkit SampleApp WPF](https://github.com/Esri/arcgis-maps-sdk-dotnet-toolkit/assets/587809/65320a05-9014-43b0-b47a-5d57ea9f7284) < Before
<img  alt="2023-06-24_223639 Toolkit SampleApp WPF" src="https://github.com/Esri/arcgis-maps-sdk-dotnet-toolkit/assets/587809/bbd5526c-36d6-4606-902b-dfac8a1c5d73"> < After
<img  alt="2023-06-24_223746 msedge" src="https://github.com/Esri/arcgis-maps-sdk-dotnet-toolkit/assets/587809/53202508-cd76-4c05-85dc-51692b954026"> < Reference (AGOL)

## Apply style to links
There was a missing call to ApplyStyle when rendering links in WPF.  This means links always had default styling and didn't pick up e.g. color / bold / italic attributes.