### PR TITLE
Prevent unhandled exception when FieldsPopupElement.Fields list is empty

### DIFF
--- a/src/Toolkit/Toolkit/UI/Controls/PopupViewer/FieldsPopupElementView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/PopupViewer/FieldsPopupElementView.cs
@@ -83,7 +83,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
         {
             var presenter = GetTemplateChild(TableAreaContentName) as ContentPresenter;
             if (presenter is null) return;
-            if (Element is null)
+            if (Element is null || !Element.Fields.Any())
             {
                 presenter.Content = null;
                 return;


### PR DESCRIPTION
**Issue:** none

**Description:**
When using a popup view with a feature layer that does not have any attributes (e.g. point has no default attributes), a `System.ArgumentException` can occur in the `FieldPopupElementView.RefreshTable()` method (see image below for exception details). This PR introduces a check to see if the `FieldsPopupElement.Fields` list is empty and, if the list is empty, results in the content being set to null and the method returning. This prevents the exception occuring.

![image](https://github.com/Esri/arcgis-maps-sdk-dotnet-toolkit/assets/86665727/11e32191-b11a-4b94-b6bb-b54089d273e0)

**Summary of issue:**
In the `FieldPopupElementView.RefreshTable()` method:

- A local variable `i` is initialised with a value of `0` ([link to code](https://github.com/Esri/arcgis-maps-sdk-dotnet-toolkit/blob/8a43115c1bf9cb567bfb2685b17f603cd4edc3b1/src/Toolkit/Toolkit/UI/Controls/PopupViewer/FieldsPopupElementView.cs#L99)).
- `i` is increased in a loop that progresses up to the number of `Labels` or `FormattedValues`.
- If there are no `Fields`, I believe there can be no `Labels` or `FormattedValues`, so the value of `i` stays as `0`.
- The subsequent call to `Grid.SetRowSpan(verticalDivider, i);` ([link to code](https://github.com/Esri/arcgis-maps-sdk-dotnet-toolkit/blob/8a43115c1bf9cb567bfb2685b17f603cd4edc3b1/src/Toolkit/Toolkit/UI/Controls/PopupViewer/FieldsPopupElementView.cs#L176)) causes the exception because `i` is 0.