### PR TITLE
popup: Implement TextPopupElement view for MAUI

### DIFF
--- a/src/Samples/Toolkit.SampleApp.Maui/Samples/PopupViewerSample.xaml
+++ b/src/Samples/Toolkit.SampleApp.Maui/Samples/PopupViewerSample.xaml
@@ -12,7 +12,7 @@
             <Border Background="#99ffffff" x:Name="popupPanel" IsVisible="False">
                 <Border HorizontalOptions="Center" VerticalOptions="Center" Background="{AppThemeBinding Dark=Black, Light=White}" Margin="0,50" Padding="20">
                     <Grid>
-                        <esriTK:PopupViewer x:Name="popupViewer" Margin="20" MaximumWidthRequest="400" HeightRequest="400" PopupAttachmentClicked="popupViewer_PopupAttachmentClicked" />
+                        <esriTK:PopupViewer x:Name="popupViewer" Padding="20" MaximumWidthRequest="400" HeightRequest="400" PopupAttachmentClicked="popupViewer_PopupAttachmentClicked" />
                         <Button BorderWidth="0" Text="X" HorizontalOptions="End" VerticalOptions="Start" Clicked="CloseButton_Click" BackgroundColor="Transparent" TextColor="{AppThemeBinding Dark=White, Light=Black}" Margin="5" />
                     </Grid>
                 </Border>

--- a/src/Toolkit/Toolkit/Internal/HtmlUtility.cs
+++ b/src/Toolkit/Toolkit/Internal/HtmlUtility.cs
@@ -1,4 +1,4 @@
-#if WPF
+#if WPF || MAUI
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
@@ -71,6 +71,18 @@ internal class MarkupNode
             sb.Append(" children=" + Children.Count);
         sb.Append('}');
         return sb.ToString();
+    }
+
+    public void InheritAttributes(MarkupNode parent)
+    {
+        // Copy style attributes from the parent node, unless overridden on this node
+        IsBold ??= parent.IsBold;
+        IsItalic ??= parent.IsItalic;
+        IsUnderline ??= parent.IsUnderline;
+        FontSize ??= parent.FontSize;
+        FontColor ??= parent.FontColor;
+        BackColor ??= parent.BackColor;
+        Alignment ??= parent.Alignment;
     }
 }
 

--- a/src/Toolkit/Toolkit/UI/Controls/PopupViewer/PopupMediaView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/PopupViewer/PopupMediaView.cs
@@ -211,7 +211,6 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
         // Also used for embedded images in TextPopupElement views
         internal static bool TryCreateImageSource(string? sourceUri, out ImageSource? source)
         {
-            source = null;
             if (sourceUri != null && sourceUri.StartsWith("data:image/"))
             {
                 // might be base64
@@ -223,7 +222,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                         var base64data = sourceUri.Substring(idx + 8);
                         var data = Convert.FromBase64String(base64data);
 #if MAUI
-                        var newSource = new StreamImageSource() { Stream = (token) => Task.FromResult<Stream>(new MemoryStream(data)) };
+                        var newSource = new StreamImageSource { Stream = (token) => Task.FromResult<Stream>(new MemoryStream(data)) };
 #else
                         var newSource = new BitmapImage();
                         newSource.BeginInit();
@@ -245,6 +244,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
 #endif
                 return true;
             }
+            source = null;
             return false;
         }
     }

--- a/src/Toolkit/Toolkit/UI/Controls/PopupViewer/PopupMediaView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/PopupViewer/PopupMediaView.cs
@@ -86,36 +86,9 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                     if (img.Source is not BitmapImage bmi || bmi.UriSource?.OriginalString != sourceUrl)
 #endif
                     {
-                        if (sourceUrl.StartsWith("data:image/"))
+                        if (TryCreateImageSource(sourceUrl, out var source))
                         {
-                            // might be base64
-                            var idx = sourceUrl.IndexOf(";base64,");
-                            if (idx > 11 && sourceUrl.Length > idx + 8)
-                            {
-                                try
-                                {
-                                    var base64data = sourceUrl.Substring(idx + 8);
-                                    var data = Convert.FromBase64String(base64data);
-#if MAUI
-                                    var source = new StreamImageSource() { Stream = (token) => Task.FromResult<Stream>(new MemoryStream(data)) };
-#else
-                                    var source = new BitmapImage();
-                                    source.BeginInit();
-                                    source.StreamSource = new MemoryStream(data);
-                                    source.EndInit();
-#endif
-                                    img.Source = source;
-                                }
-                                catch { }
-                            }
-                        }
-                        else if (sourceUrl != null && Uri.TryCreate(sourceUrl, UriKind.Absolute, out Uri? result))
-                        {
-#if MAUI
-                            img.Source = new RuntimeStreamImageSource(result);
-#else
-                            img.Source = new BitmapImage(result);
-#endif
+                            img.Source = source;
                         }
                     }
                 }
@@ -233,6 +206,46 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
             {
                 InvalidateMeasure(); // Forces recalculation of available space for generating a new chart
             }
+        }
+
+        // Also used for embedded images in TextPopupElement views
+        internal static bool TryCreateImageSource(string? sourceUri, out ImageSource? source)
+        {
+            source = null;
+            if (sourceUri != null && sourceUri.StartsWith("data:image/"))
+            {
+                // might be base64
+                var idx = sourceUri.IndexOf(";base64,");
+                if (idx > 11 && sourceUri.Length > idx + 8)
+                {
+                    try
+                    {
+                        var base64data = sourceUri.Substring(idx + 8);
+                        var data = Convert.FromBase64String(base64data);
+#if MAUI
+                        var newSource = new StreamImageSource() { Stream = (token) => Task.FromResult<Stream>(new MemoryStream(data)) };
+#else
+                        var newSource = new BitmapImage();
+                        newSource.BeginInit();
+                        newSource.StreamSource = new MemoryStream(data);
+                        newSource.EndInit();
+#endif
+                        source = newSource;
+                        return true;
+                    }
+                    catch { }
+                }
+            }
+            else if (Uri.TryCreate(sourceUri, UriKind.Absolute, out Uri? result))
+            {
+#if MAUI
+                source = new RuntimeStreamImageSource(result);
+#else
+                source = new BitmapImage(result);
+#endif
+                return true;
+            }
+            return false;
         }
     }
 }

--- a/src/Toolkit/Toolkit/UI/Controls/PopupViewer/PopupViewer.Maui.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/PopupViewer/PopupViewer.Maui.cs
@@ -71,7 +71,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui
             root.Add(roottitle);
             ScrollView scrollView = new ScrollView() { HorizontalScrollBarVisibility = ScrollBarVisibility.Never };
 #if WINDOWS
-            scrollView.Margin = new Thickness(0, 0, -10, 0);
+            scrollView.Padding = new Thickness(0, 0, 10, 0);
 #endif
             scrollView.SetBinding(ScrollView.VerticalScrollBarVisibilityProperty, new Binding(nameof(VerticalScrollBarVisibility), source: RelativeBindingSource.TemplatedParent));
             Grid.SetRow(scrollView, 1);

--- a/src/Toolkit/Toolkit/UI/Controls/PopupViewer/TextPopupElementView.Maui.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/PopupViewer/TextPopupElementView.Maui.cs
@@ -17,6 +17,11 @@
 #if MAUI
 using Microsoft.Maui.Controls.Internals;
 using Esri.ArcGISRuntime.Mapping.Popups;
+using Esri.ArcGISRuntime.Toolkit.Internal;
+using Microsoft.Maui.ApplicationModel;
+using Esri.ArcGISRuntime.UI;
+using Grid = Microsoft.Maui.Controls.Grid;
+using RuntimeImageExtensions = Esri.ArcGISRuntime.Maui.RuntimeImageExtensions;
 
 namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
 {
@@ -27,9 +32,10 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
     public partial class TextPopupElementView : TemplatedView
     {
         private static readonly ControlTemplate DefaultControlTemplate;
+        private static Thickness ParagraphMargin = new(0, 0, 0, 16);
 
         /// <summary>
-        /// Template name of the <see cref="Label"/> text area.
+        /// Template name of the <see cref="StackLayout"/> text area.
         /// </summary>
         public const string TextAreaName = "TextArea";
 
@@ -40,7 +46,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
 
         private static object BuildDefaultTemplate()
         {
-            Label textArea = new Label();
+            var textArea = new StackLayout();
             INameScope nameScope = new NameScope();
             NameScope.SetNameScope(textArea, nameScope);
             nameScope.RegisterName(TextAreaName, textArea);
@@ -49,17 +55,418 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
 
         private void OnElementPropertyChanged()
         {
-            var label = GetTemplateChild(TextAreaName) as Label;
-            if (label is null) return;
+            var container = GetTemplateChild(TextAreaName) as StackLayout;
             var text = Element?.Text;
-            
+            if (container is null || string.IsNullOrEmpty(text))
+                return;
+
+            try
+            {
+                container.Children.Clear();
+                var htmlRoot = HtmlUtility.BuildDocumentTree(text);
+                var blocks = VisitAndAddBlocks(htmlRoot);
+                foreach (var block in blocks)
+                    container.Children.Add(block);
+            }
+            catch
+            {
+                container.Children.Clear();
+                // Fallback if something went wrong with the parsing:
+                // Just display the text without any markup;
+                var label = new Label();
 #if !WINDOWS
-            label.TextType = TextType.Html;
+                label.TextType = TextType.Html;
 #else
-            if (text != null)
-                text = Toolkit.Internal.StringExtensions.ToPlainText(text);
+                if (text != null)
+                    text = Toolkit.Internal.StringExtensions.ToPlainText(text);
 #endif
-            label.Text = text;
+                label.Text = text;
+                container.Children.Add(label);
+            }
+        }
+
+        private static IEnumerable<View> VisitAndAddBlocks(MarkupNode parent)
+        {
+            List<MarkupNode>? inlineNodes = null;
+            foreach (var node in parent.Children)
+            {
+                node.InheritAttributes(parent);
+                if (MapsToBlock(node) || HasAnyBlocks(node))
+                {
+                    if (inlineNodes != null)
+                    {
+                        var label = VisitAndAddInlines(inlineNodes);
+                        ApplyStyle(label, parent);
+                        inlineNodes = null;
+                        yield return label;
+                    }
+                    yield return VisitBlock(node);
+                }
+                else
+                {
+                    inlineNodes ??= new List<MarkupNode>();
+                    inlineNodes.Add(node);
+                }
+            }
+            if (inlineNodes != null)
+            {
+                var label = VisitAndAddInlines(inlineNodes);
+                ApplyStyle(label, parent);
+                yield return label;
+            }
+        }
+
+        private static View VisitBlock(MarkupNode node)
+        {
+            switch (node.Type)
+            {
+                case MarkupType.List:
+                    // Lists (li and ol) are laid out in a grid, with a narrow column of markers and a wide one for the content.
+                    // +-----+----------------------+
+                    // | 1.  | First item content   |
+                    // +-----+----------------------+
+                    // | 2.  | Second item content  |
+                    // +-----+----------------------+
+                    // | ...                        |
+                    // +-----+----------------------+
+                    // | 3.  | Last item content    |
+                    // +-----+----------------------+
+                    bool isOredered = node.Token?.Name == "ol";
+                    var listGrid = new Grid { Margin = new Thickness(0, 0, 0, 16) };
+                    listGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto }); // bullets
+                    listGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Star }); // contents
+
+                    var childItems = node.Children.Where(n => n.Type == MarkupType.ListItem).ToList(); // ignore a misplaced non-list-item node
+
+                    for (int row = 0; row < childItems.Count; row++)
+                    {
+                        listGrid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+                        var markerText = isOredered ? $"{row + 1}." : "\u2022";
+                        listGrid.Add(new Label { Text = markerText, HorizontalTextAlignment = TextAlignment.End, Margin = new Thickness(5, 0) }, 0, row);
+                        var item = VisitBlock(childItems[row]);
+                        listGrid.Add(item, 1, row);
+                    }
+                    return listGrid;
+
+                case MarkupType.Block:
+                case MarkupType.ListItem:
+                case MarkupType.TableCell:
+                    bool isPara = node.Token?.Name == "p";
+                    View view;
+                    if (HasAnyBlocks(node))
+                    {
+                        var container = new StackLayout();
+                        if (isPara)
+                            container.Margin = ParagraphMargin;
+                        if (node.BackColor.HasValue)
+                            container.BackgroundColor = ConvertColor(node.BackColor.Value);
+
+                        var blocks = VisitAndAddBlocks(node);
+                        foreach (var block in blocks)
+                        {
+                            container.Children.Add(block);
+                        }
+                        view = container;
+                    }
+                    else
+                    {
+                        var label = VisitAndAddInlines(node.Children);
+                        if (isPara)
+                            label.Margin = ParagraphMargin;
+                        ApplyStyle(label, node);
+                        view = label;
+                    }
+                    if (node.Type == MarkupType.TableCell)
+                        return VerticallyAlignTableCell(node, view);
+                    return view;
+
+                case MarkupType.Divider:
+                    return new BoxView { HeightRequest = 1, Color = Colors.Gray }; // TODO: Do we need to set a color?
+
+                case MarkupType.Table:
+                    return ConvertTableToGrid(node);
+
+                case MarkupType.Image:
+                    var imageElement = new Image();
+                    if (Uri.TryCreate(node.Content, UriKind.Absolute, out var imgUri))
+                    {
+                        imageElement.Loaded += OnImageElementLoaded;
+
+                        async void OnImageElementLoaded(object? sender, EventArgs e)
+                        {
+                            imageElement.Loaded -= OnImageElementLoaded;
+                            var taggedUri = imgUri;
+                            var ri = new RuntimeImage(taggedUri); // Use Runtime's caching and authentication
+                            try
+                            {
+                                imageElement.Source = await RuntimeImageExtensions.ToImageSourceAsync(ri);
+                            }
+                            catch
+                            {
+                                // Don't let one bad image take down the whole app. Better to ignore a failed image load.
+                            }
+                        }
+                    }
+                    return imageElement;
+
+                default:
+                    return new Border(); // placeholder for unsupported things
+            }
+
+            static View VerticallyAlignTableCell(MarkupNode node, View cellContent)
+            {
+                cellContent.VerticalOptions = LayoutOptions.Center;
+                // In HTML, table cells are vertically centered by default.
+                if (node.BackColor.HasValue)
+                {
+                    var grid = new Grid { cellContent };
+                    grid.BackgroundColor = ConvertColor(node.BackColor.Value);
+                    return grid;
+                }
+                else
+                {
+                    return cellContent;
+                }
+            }
+        }
+
+        private static Label VisitAndAddInlines(IEnumerable<MarkupNode> nodes)
+        {
+            // Flattens given tree of inline nodes into a single FormattedText
+            var str = new FormattedString();
+            foreach (var node in nodes)
+            {
+                foreach (var span in VisitInline(node))
+                {
+                    str.Spans.Add(span);
+                }
+            }
+            return new Label { FormattedText = str, LineBreakMode = LineBreakMode.WordWrap };
+        }
+
+        private static IEnumerable<Span> VisitInline(MarkupNode node)
+        {
+            switch (node.Type)
+            {
+                case MarkupType.Link:
+                    if (Uri.TryCreate(node.Content, UriKind.Absolute, out var linkUri))
+                    {
+                        // The gesture recognizer will be shared by all the individual spans
+                        var tapRecognizer = new TapGestureRecognizer();
+                        tapRecognizer.Tapped += (s, e) =>
+                        {
+                            try
+                            {
+                                Browser.OpenAsync(node.Content, BrowserLaunchMode.SystemPreferred);
+                            }
+                            catch { }
+                        };
+                        foreach (var subNode in node.Children)
+                        {
+                            subNode.InheritAttributes(node);
+                            foreach (var subSpan in VisitInline(subNode))
+                            {
+                                ApplyStyle(subSpan, node);
+                                if (node.IsUnderline != false) // Add underline to links by default (unless specifically disabled)
+                                    subSpan.TextDecorations = TextDecorations.Underline;
+
+                                if (subSpan.GestureRecognizers.Count == 0)
+                                    subSpan.GestureRecognizers.Add(tapRecognizer);
+                                yield return subSpan;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        // Fallback: treat it as a regular span
+                        goto case MarkupType.Span;
+                    }
+                    break;
+
+                case MarkupType.Span:
+                case MarkupType.Sub: // Font variants are not supported on MAUI
+                case MarkupType.Sup: // Font variants are not supported on MAUI
+                    foreach (var subNode in node.Children)
+                    {
+                        subNode.InheritAttributes(node);
+                        foreach (var subSpan in VisitInline(subNode))
+                        {
+                            yield return subSpan;
+                        }
+                    }
+                    break;
+
+                case MarkupType.Break:
+                    yield return new Span { Text = Environment.NewLine };
+                    break;
+
+                case MarkupType.Text:
+                    var textSpan = new Span { Text = node.Content };
+                    ApplyStyle(textSpan, node);
+                    yield return textSpan;
+                    break;
+
+                default:
+                    break;
+            }
+        }
+
+        private static Grid ConvertTableToGrid(MarkupNode table)
+        {
+            // Determines the dimensions of a grid necessary to hold a given table.
+            // Utilizes a dynamically-sized 2D bitmap (`grid`) to mark occupied cells while iterating over the table.
+            // Expands the grid as necessary based on cell spans and avoids collisions by checking the bitmap.
+            List<List<bool>> gridMap = new List<List<bool>>();
+
+            int maxRowUsed = -1;
+            int maxColUsed = -1;
+
+            var gridView = new Grid();
+
+            int curRow = 0;
+            foreach (MarkupNode tr in table.Children)
+            {
+                tr.InheritAttributes(table);
+                int curCol = 0;
+                foreach (MarkupNode td in tr.Children)
+                {
+                    // Find the next available cell in this row
+                    EnsureColumnExists(curRow, curCol);
+                    while (gridMap[curRow][curCol])
+                    {
+                        curCol++;
+                        EnsureColumnExists(curRow, curCol);
+                    }
+
+                    int rowSpan = 1;
+                    int colSpan = 1;
+
+                    // Create a View for the current table-cell, and add it to the grid.
+                    td.InheritAttributes(tr);
+                    var cellView = VisitBlock(td);
+                    var attr = HtmlUtility.ParseAttributes(td.Token?.Attributes);
+                    if (attr.TryGetValue("colspan", out var colSpanStr) && ushort.TryParse(colSpanStr, out var colSpanFromAttr))
+                    {
+                        colSpan = colSpanFromAttr;
+                        Grid.SetColumnSpan(cellView, colSpan);
+                    }
+                    if (attr.TryGetValue("rowspan", out var rowSpanStr) && ushort.TryParse(rowSpanStr, out var rowSpanFromAttr))
+                    {
+                        rowSpan = rowSpanFromAttr;
+                        Grid.SetRowSpan(cellView, colSpan);
+                    }
+                    gridView.Add(cellView, curCol, curRow);
+
+                    // Mark grid-cells occupied by the current table-cell
+                    for (int i = 0; i < rowSpan; i++)
+                    {
+                        for (int j = 0; j < colSpan; j++)
+                        {
+                            EnsureColumnExists(curRow + i, curCol + j);
+
+                            gridMap[curRow + i][curCol + j] = true;
+
+                            maxRowUsed = Math.Max(maxRowUsed, curRow + i);
+                            maxColUsed = Math.Max(maxColUsed, curCol + j);
+                        }
+                    }
+                    curCol += colSpan;
+                }
+                curRow++;
+            }
+
+            // Now we know exactly how many rows and columns were necessary to hold the table. Allocate them!
+            for (int i = 0; i <= maxRowUsed; i++)
+                gridView.RowDefinitions.Add(new RowDefinition());
+            for (int i = 0; i <= maxColUsed; i++)
+                gridView.ColumnDefinitions.Add(new ColumnDefinition());
+
+            return gridView;
+
+            // Expand the gridMap as needed to make sure that given row/column exists
+            void EnsureColumnExists(int row, int col)
+            {
+                while (gridMap.Count <= row)
+                    gridMap.Add(new List<bool>());
+                while (gridMap[row].Count <= col)
+                    gridMap[row].Add(false);
+            }
+        }
+
+        private static void ApplyStyle(Span el, MarkupNode node)
+        {
+            if (node.IsBold == true)
+                el.FontAttributes |= FontAttributes.Bold;
+            else if (node.IsBold == false)
+                el.FontAttributes &= ~FontAttributes.Bold;
+
+            if (node.IsItalic == true)
+                el.FontAttributes |= FontAttributes.Italic;
+            else if (node.IsItalic == false)
+                el.FontAttributes &= ~FontAttributes.Italic;
+
+            if (node.IsUnderline == true)
+                el.TextDecorations |= TextDecorations.Underline;
+            else if (node.IsUnderline == false)
+                el.TextDecorations &= ~TextDecorations.Underline;
+
+            if (node.FontColor.HasValue)
+                el.TextColor = ConvertColor(node.FontColor.Value);
+            if (node.BackColor.HasValue)
+                el.BackgroundColor = ConvertColor(node.BackColor.Value);
+            if (node.FontSize.HasValue)
+                el.FontSize = 16d * node.FontSize.Value; // based on AGOL's default font size
+        }
+
+        private static void ApplyStyle(Label el, MarkupNode node)
+        {
+            if (node.IsBold == true)
+                el.FontAttributes |= FontAttributes.Bold;
+            else if (node.IsBold == false)
+                el.FontAttributes &= ~FontAttributes.Bold;
+
+            if (node.IsItalic == true)
+                el.FontAttributes |= FontAttributes.Italic;
+            else if (node.IsItalic == false)
+                el.FontAttributes &= ~FontAttributes.Italic;
+
+            if (node.IsUnderline == true)
+                el.TextDecorations |= TextDecorations.Underline;
+            else if (node.IsUnderline == false)
+                el.TextDecorations &= ~TextDecorations.Underline;
+
+            if (node.FontColor.HasValue)
+                el.TextColor = ConvertColor(node.FontColor.Value);
+            if (node.BackColor.HasValue)
+                el.BackgroundColor = ConvertColor(node.BackColor.Value);
+            if (node.FontSize.HasValue)
+                el.FontSize = 16d * node.FontSize.Value; // based on AGOL's default font size
+
+            if (node.Alignment.HasValue)
+                el.HorizontalTextAlignment = ConvertAlignment(node.Alignment);
+        }
+
+        private static TextAlignment ConvertAlignment(HtmlAlignment? alignment) => alignment switch
+        {
+            HtmlAlignment.Left => TextAlignment.Start,
+            HtmlAlignment.Center => TextAlignment.Center,
+            HtmlAlignment.Right => TextAlignment.End,
+            _ => TextAlignment.Start,
+        };
+
+        private static Color ConvertColor(System.Drawing.Color color)
+        {
+            return Color.FromRgba(color.R, color.G, color.B, color.A);
+        }
+
+        private static bool HasAnyBlocks(MarkupNode node)
+        {
+            return node.Children.Any(c => MapsToBlock(c) || HasAnyBlocks(c));
+        }
+
+        private static bool MapsToBlock(MarkupNode node)
+        {
+            return node.Type is MarkupType.List or MarkupType.Table or MarkupType.Block or MarkupType.Divider or MarkupType.Image;
         }
     }
 }

--- a/src/Toolkit/Toolkit/UI/Controls/PopupViewer/TextPopupElementView.Maui.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/PopupViewer/TextPopupElementView.Maui.cs
@@ -19,9 +19,7 @@ using Microsoft.Maui.Controls.Internals;
 using Esri.ArcGISRuntime.Mapping.Popups;
 using Esri.ArcGISRuntime.Toolkit.Internal;
 using Microsoft.Maui.ApplicationModel;
-using Esri.ArcGISRuntime.UI;
 using Grid = Microsoft.Maui.Controls.Grid;
-using RuntimeImageExtensions = Esri.ArcGISRuntime.Maui.RuntimeImageExtensions;
 
 namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
 {

--- a/src/Toolkit/Toolkit/UI/Controls/PopupViewer/TextPopupElementView.Maui.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/PopupViewer/TextPopupElementView.Maui.cs
@@ -191,25 +191,8 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
 
                 case MarkupType.Image:
                     var imageElement = new Image();
-                    if (Uri.TryCreate(node.Content, UriKind.Absolute, out var imgUri))
-                    {
-                        imageElement.Loaded += OnImageElementLoaded;
-
-                        async void OnImageElementLoaded(object? sender, EventArgs e)
-                        {
-                            imageElement.Loaded -= OnImageElementLoaded;
-                            var taggedUri = imgUri;
-                            var ri = new RuntimeImage(taggedUri); // Use Runtime's caching and authentication
-                            try
-                            {
-                                imageElement.Source = await RuntimeImageExtensions.ToImageSourceAsync(ri);
-                            }
-                            catch
-                            {
-                                // Don't let one bad image take down the whole app. Better to ignore a failed image load.
-                            }
-                        }
-                    }
+                    if (PopupMediaView.TryCreateImageSource(node.Content, out var imageSource))
+                        imageElement.Source = imageSource;
                     return imageElement;
 
                 default:

--- a/src/Toolkit/Toolkit/UI/Controls/PopupViewer/TextPopupElementView.Windows.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/PopupViewer/TextPopupElementView.Windows.cs
@@ -190,23 +190,9 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                     return link;
 
                 case MarkupType.Image:
-                    if (Uri.TryCreate(node.Content, UriKind.Absolute, out var imgUri))
+                    if (PopupMediaView.TryCreateImageSource(node.Content, out var imageSource))
                     {
-                        var imageElement = new Image { Tag = imgUri };
-                        imageElement.Loaded += static async (sender, e) => // Start loading the image in the background once the image is actually displayed
-                        {
-                            var img = (Image)sender;
-                            var taggedUri = (Uri)img.Tag;
-                            var ri = new RuntimeImage(taggedUri); // Use Runtime's caching and authentication
-                            try
-                            {
-                                img.Source = await ri.ToImageSourceAsync();
-                            }
-                            catch
-                            {
-                                // Don't let one bad image take down the whole app. Better to ignore a failed image load.
-                            }
-                        };
+                        var imageElement = new Image { Source = imageSource };
                         return new InlineUIContainer(imageElement);
                     }
                     return new Run(); // TODO find a better placeholder when img src is invalid
@@ -287,7 +273,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                 else if (el is ListItem itemEl)
                     itemEl.TextAlignment = ConvertAlignment(node.Alignment);
             }
-            if (node.IsUnderline.HasValue)
+            if (node.IsUnderline == true)
             {
                 if (el is Inline inlineEl)
                     inlineEl.TextDecorations.Add(TextDecorations.Underline);


### PR DESCRIPTION

<table><tr><td>

![2023-09-11_095730](https://github.com/Esri/arcgis-maps-sdk-dotnet-toolkit/assets/587809/8463b9ee-94e8-4806-bb7b-ea5eb7532490)
</td><td>

![2023-09-11_100845](https://github.com/Esri/arcgis-maps-sdk-dotnet-toolkit/assets/587809/4bdfc1a8-116d-4ee0-b648-e7ac3cfd52f0)
</td></tr><tr><td>

![2023-09-11_095809](https://github.com/Esri/arcgis-maps-sdk-dotnet-toolkit/assets/587809/e712f891-4872-46b8-b035-5c3a5190f83d)
</td><td>

![2023-09-11_105216](https://github.com/Esri/arcgis-maps-sdk-dotnet-toolkit/assets/587809/8ad80353-9782-45f8-b8d3-d0ed44b18cd2)

</td></tr></table>

TextElementPopupView is coming to MAUI!

- Text maps to Labels with formatted Spans.
- Blocks (e.g. paragraphs, table cells, list items) map to StackLayouts.
- Lists map to grids (one column for markers, another for content).
- Tables map to grids (with some extra logic to handle row/column assignment and rowspans/colspans).
- Images are loaded through RuntimeImage to take advantage of our authentication and caching stack.

### Known limitations
- Text occasionally has extra space between lines or words.  This is due to MAUI implementation being more sensitive to inconsistent newlines/whitespace than WPF's FlowDocument-based viewer.  I am a preparing a follow-up PR that adds a document tree simplification pass to the HTML parser that will address this.
- Text links are not clickable on some platforms due to https://github.com/dotnet/maui/issues/4734 (might be fixed before NET 8 GA)
- Subscript (`<sub>`) and superscript (`<sup>`) do not have any visual effect, because MAUI does not expose any API to control this font feature.
- Table columns are always equally-spaced, which might inefficiently distribute space between columns with different amounts of content. "Auto" column width does not work well in MAUI because it prevents line-wrapping and causes the table to stretch out-of-bounds.