### PR TITLE
Fix issue with BasemapGalleryAppearanceSample

### DIFF
--- a/src/Samples/Toolkit.SampleApp.Maui/Samples/BasemapGalleryAppearanceSample.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.Maui/Samples/BasemapGalleryAppearanceSample.xaml.cs
@@ -31,7 +31,7 @@ namespace Toolkit.SampleApp.Maui.Samples
         {
             if (Gallery.AvailableBasemaps?.Any() == true)
             {
-                Gallery.AvailableBasemaps.Remove(Gallery.AvailableBasemaps.Last());
+                Gallery.AvailableBasemaps.RemoveAt(Gallery.AvailableBasemaps.Count - 1);
             }
         }
     }


### PR DESCRIPTION
The function to delete the last item in the BasemapGallery is not working as expected. 

This change works around this issue to provide the expected action.