### PR TITLE
popup: Simplify HTML tree to fix spacing

### DIFF
--- a/src/Toolkit/Toolkit/Internal/HtmlUtility.cs
+++ b/src/Toolkit/Toolkit/Internal/HtmlUtility.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
 using System.Globalization;
-using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using Color = System.Drawing.Color;
@@ -44,7 +43,7 @@ internal class MarkupNode
     public Color? FontColor { get; set; }
     public Color? BackColor { get; set; }
     public HtmlAlignment? Alignment { get; set; }
-    public IList<MarkupNode> Children { get; } = new List<MarkupNode>();
+    public List<MarkupNode> Children { get; } = new List<MarkupNode>();
     public string? Content { get; set; }
 
     public override string ToString()
@@ -153,7 +152,7 @@ internal class HtmlUtility
                     "lt" => "<",
                     "gt" => ">",
                     // Common HTML entities used for typography
-                    "nbsp" => " ",
+                    "nbsp" => "\xA0",
                     "copy" => "\xA9",
                     "deg" => "\xB0",
                     "para" => "\xB6",
@@ -203,6 +202,7 @@ internal class HtmlUtility
     internal static MarkupNode BuildDocumentTree(string snippet)
     {
         var stack = new Stack<MarkupNode>();
+        var hiddenNodes = new HashSet<MarkupNode>(); // We have to parse hidden nodes and their children, but don't add them to the document tree
         var root = new MarkupNode { Type = MarkupType.Document };
         stack.Push(root);
         var tokenator = new HtmlTokenParser(snippet);
@@ -384,13 +384,16 @@ internal class HtmlUtility
                     newNode.BackColor = ParseCssColor(backColorString);
                 else if (styles.TryGetValue("background", out var backString))
                     newNode.BackColor = ParseCssColor(backString); // fallback if background-color is not available
+                if (styles.TryGetValue("display", out var display) && display == "none")
+                    hiddenNodes.Add(newNode);
                 // TODO padding?
                 // TODO margin?
             }
 
             if (tokenType == HtmlTokenType.OpenTag)
             {
-                parent.Children.Add(newNode);
+                if (!hiddenNodes.Contains(newNode))
+                    parent.Children.Add(newNode);
                 stack.Push(newNode);
                 if (t.Name == "p")
                     isInParagraph = true;
@@ -407,7 +410,7 @@ internal class HtmlUtility
                 if (!stack.Any())
                 {
                     // We walked all the way up to root, no more nodes left to close. Give up and return what we have so far.
-                    RemoveTrailingBreaks(root);
+                    SimplifySubtree(root);
                     return root;
                 }
                 var openTag = stack.Pop();
@@ -416,34 +419,283 @@ internal class HtmlUtility
             }
             else
             {
-                parent.Children.Add(newNode);
+                if (!hiddenNodes.Contains(newNode))
+                    parent.Children.Add(newNode);
             }
         }
-        RemoveTrailingBreaks(root);
+        SimplifySubtree(root);
         return root;
     }
 
-    private static void RemoveTrailingBreaks(MarkupNode node, bool isLastChildInBlock = false)
-    {
-        // Per HTML spec, last <br> inside a non-empty block element should be ignored
-        // See https://stackoverflow.com/a/62523690
-        if (node.Children.Count == 0)
-            return;
-        var lastChild = node.Children.Last();
+    #region Tree Simplification
 
-        bool thisIsBlock = node.Type is MarkupType.Document or MarkupType.ListItem or MarkupType.TableCell or MarkupType.Block;
-        if ((isLastChildInBlock || thisIsBlock)
-            && node.Children.Count > 1
-            && lastChild.Type == MarkupType.Break)
+    // Simplify the document tree to make it easier to map to GUI components.
+    // This method tries to remove unnecessary nodes, merge nodes that can be combined, and trim collapsible whitespace.
+    private static void SimplifySubtree(MarkupNode parent)
+    {
+        if (parent.Children.Count == 0)
+            return;
+
+        var optimizedChildren = new List<MarkupNode>();
+
+        // Recursively optimize all internal nodes, depth-first.
+        foreach (var child in parent.Children)
         {
-            node.Children.RemoveAt(node.Children.Count - 1);
+            SimplifySubtree(child);
+            switch (AnalyzeNode(child))
+            {
+                case NodeAction.None:
+                    optimizedChildren.Add(child);
+                    break;
+                case NodeAction.MergeUp:
+                    // Eliminate grandchild, merge it up
+                    optimizedChildren.Add(Merge(child, child.Children[0], child.Type));
+                    break;
+                case NodeAction.MergeDown:
+                    // Eliminate child, merge it down
+                    optimizedChildren.Add(Merge(child, child.Children[0], child.Children[0].Type));
+                    break;
+                case NodeAction.Skip:
+                    continue;
+            }
         }
-        foreach (var child in node.Children)
+
+        // Remove redundant empty text nodes
+        if (IsBlockContainer(parent) || IsInlineContainer(parent))
         {
-            bool isLast = ReferenceEquals(child, lastChild);
-            RemoveTrailingBreaks(child, isLast && (thisIsBlock || isLastChildInBlock));
+            for (int i = 0; i < optimizedChildren.Count; i++)
+            {
+                if (optimizedChildren[i].Type == MarkupType.Text && optimizedChildren[i].Content == " ")
+                {
+                    // A whitespace node is considered redundant if it is adjacent to a blocky node, or immediately follows/precedes whitespace in another text node
+                    var prev = i > 0 ? optimizedChildren[i - 1] : null;
+                    var next = i < optimizedChildren.Count - 1 ? optimizedChildren[i + 1] : null;
+                    if (prev != null && (!IsInlineContainer(prev) && prev.Type != MarkupType.Text || EndsWithSpace(prev)) ||
+                        next != null && (!IsInlineContainer(next) && next.Type != MarkupType.Text || StartsWithSpace(next)))
+                    {
+                        // This whitespace is redundant, remove it
+                        optimizedChildren.RemoveAt(i);
+                        i--;
+                    }
+                }
+            }
+        }
+
+        if (IsBlockContainer(parent) && optimizedChildren.Count > 0)
+            optimizedChildren = FixWhitespace(optimizedChildren);
+
+        parent.Children.Clear();
+        parent.Children.AddRange(optimizedChildren);
+    }
+    
+    // Trims leading whitespace, trailing whitespace, and the last trailing break from blocky elements.
+    private static List<MarkupNode> FixWhitespace(List<MarkupNode> optimizedChildren)
+    {
+        var newChildren = new List<MarkupNode>();
+
+        // Go over all children and find groups of inline nodes (i.e. IsInlineContainer, Text, or Break).
+        // There might be one group, or many groups, or none. Each group should have at least 1 member.
+        // Groups are separated by one or more block (non-inline) nodes.
+        var inlineGroup = new List<MarkupNode>();
+        for (int i = 0; i < optimizedChildren.Count; i++)
+        {
+            var child = optimizedChildren[i];
+            if (IsInlineContainer(child) || child.Type == MarkupType.Text || child.Type == MarkupType.Break)
+            {
+                inlineGroup.Add(child);
+            }
+            else
+            {
+                ProcessInlineGroup();
+                newChildren.Add(child);
+            }
+        }
+        ProcessInlineGroup();
+
+        void ProcessInlineGroup()
+        {
+            if (inlineGroup.Count > 0)
+            {
+                TrimLeadingWhitespace(inlineGroup);
+                TrimTrailingWhitespace(inlineGroup);
+                if ((HasContent(inlineGroup) || CountBreaks(inlineGroup) > 1) && TrimLastLineBreak(inlineGroup))
+                {
+                    // Remove trailing whitespace that was before <br> too
+                    TrimTrailingWhitespace(inlineGroup);
+                }
+                newChildren.AddRange(inlineGroup);
+                // End the current group
+                inlineGroup.Clear();
+            }
+        }
+        optimizedChildren = newChildren;
+        return optimizedChildren;
+    }
+
+    private static void TrimLeadingWhitespace(List<MarkupNode> group)
+    {
+        while (group.Count > 0)
+        {
+            var firstChild = group[0];
+            if (firstChild.Type != MarkupType.Text)
+                break;
+            firstChild.Content = firstChild.Content?.TrimStart(' ');
+            if (!string.IsNullOrEmpty(firstChild.Content))
+                break;
+            group.RemoveAt(0);
         }
     }
+
+    private static void TrimTrailingWhitespace(List<MarkupNode> group)
+    {
+        while (group.Count > 0)
+        {
+            var lastChild = group.Last();
+            if (lastChild.Type is MarkupType.Span or MarkupType.Link)
+            {
+                TrimTrailingWhitespace(lastChild.Children);
+                if (lastChild.Children.Count > 0)
+                    break;
+            }
+            else if (lastChild.Type == MarkupType.Text)
+            {
+                lastChild.Content = lastChild.Content?.TrimEnd(' ');
+                if (!string.IsNullOrEmpty(lastChild.Content))
+                    break;
+            }
+            else
+            {
+                break;
+            }
+            group.RemoveAt(group.Count - 1);
+        }
+    }
+
+    // Returns true if a group of nodes contain any content
+    // (i.e. anything other than linebreaks and empty spans)
+    private static bool HasContent(List<MarkupNode> group)
+    {
+        foreach (var child in group)
+        {
+            if (!IsInlineContainer(child) && child.Type != MarkupType.Break)
+                return true;
+            if (HasContent(child.Children))
+                return true;
+        }
+        return false;
+    }
+    
+    // Recursively counts the number of descendant nodes of Type Break
+    private static int CountBreaks(List<MarkupNode> group)
+    {
+        int count = 0;
+        foreach (var node in group)
+        {
+            if (node.Type == MarkupType.Break)
+                count++;
+            else
+                count += CountBreaks(node.Children);
+        }
+        return count;
+    }
+
+    // Per HTML spec, last <br> inside a non-empty block element should be ignored
+    // See https://stackoverflow.com/a/62523690
+    private static bool TrimLastLineBreak(List<MarkupNode> group)
+    {
+        if (group.Count == 0)
+            return false;
+        var lastNode = group.Last();
+        if (lastNode.Type == MarkupType.Break)
+        {
+            group.RemoveAt(group.Count - 1);
+            return true;
+        }
+        else if (IsInlineContainer(lastNode))
+        {
+            // Recurse into inline containers (such as span).
+            // From HTML's perspective, 
+            return TrimLastLineBreak(lastNode.Children);
+        }
+        return false;
+    }
+    
+    // True if the last leaf node in this subtree is a Text node that ends with a space.
+    // Stops search and returns false if we encounter a non-inline node.
+    private static bool EndsWithSpace(MarkupNode node)
+    {
+        if (node.Type == MarkupType.Text && node.Content != null)
+            return node.Content.EndsWith(" ");
+        if (IsInlineContainer(node))
+            return node.Children.Count > 0 && EndsWithSpace(node.Children.Last());
+        return false;
+    }
+    
+    // True if the first leaf node in this subtree is a Text node that ends with a space.
+    // Stops search and returns false if we encounter a non-inline node.
+    private static bool StartsWithSpace(MarkupNode node)
+    {
+        if (node.Type == MarkupType.Text && node.Content != null)
+            return node.Content.StartsWith(" ");
+        if (IsInlineContainer(node))
+            return node.Children.Count > 0 && StartsWithSpace(node.Children.First());
+        return false;
+    }
+
+    enum NodeAction { None, MergeUp, MergeDown, Skip }
+
+    private static NodeAction AnalyzeNode(MarkupNode node)
+    {
+        // Remove insignificant empty nodes (e.g. <b></b>)
+        if (node.Children.Count == 0 && (node.Type is MarkupType.Block || IsInlineContainer(node)))
+            return NodeAction.Skip;
+
+        // The rest of the analysis only looks at single-child nodes
+        if (node.Children.Count != 1)
+            return NodeAction.None;
+        var child = node.Children[0];
+
+        // inline node with a single child,
+        // e.g. the span in <span><b>foo</b></span> ==> <b>foo</b>
+        if (node.Type is MarkupType.Span)
+            return NodeAction.MergeDown;
+
+        // link with a single inline child,
+        // e.g. the b in <a href="..."><b>foo</b></a> ==> <a href="..." style="...">foo</a>
+        if (node.Type is MarkupType.Link && child.Type is MarkupType.Span)
+            return NodeAction.MergeUp;
+
+        // block node with a single block child,
+        // e.g. the div in <td><div>foo</div></td> ==> <td>foo</td>
+        if (node.Type is MarkupType.Block && child.Type is (MarkupType.List or MarkupType.Table or MarkupType.Block or MarkupType.Divider))
+            return NodeAction.MergeDown;
+
+        return NodeAction.None;
+    }
+
+    // Remove the parent and apply its attributes to the child.
+    // In case of conflict, child attributes take precedence.
+    // New node's type depends on whether we are merging "down" (eliminating a parent) or "up" (eliminating a child).
+    private static MarkupNode Merge(MarkupNode parent, MarkupNode child, MarkupType newType)
+    {
+        var newNode = new MarkupNode
+        {
+            Token = child.Token,
+            Type = newType,
+            IsBold = child.IsBold ?? parent.IsBold,
+            IsItalic = child.IsItalic ?? parent.IsItalic,
+            IsUnderline = child.IsUnderline ?? parent.IsUnderline,
+            FontSize = child.FontSize ?? parent.FontSize,
+            FontColor = child.FontColor ?? parent.FontColor,
+            BackColor = child.BackColor ?? parent.BackColor,
+            Alignment = child.Alignment ?? parent.Alignment,
+            Content = child.Content,
+        };
+        newNode.Children.AddRange(child.Children);
+        return newNode;
+    }
+
+    #endregion
 
     // True if tags of given tokenType cannot have any children/content.
     private static bool IsVoidElement(string tagName) => tagName is "br" or "hr" or "img" or "source";
@@ -451,6 +703,10 @@ internal class HtmlUtility
     private static bool CanContainText(string? parentTag) => parentTag is not ("table" or "dl" or "tr" or "ol" or "ul");
 
     private static bool IsBlockContent(string tagName) => tagName is "div" or "h1" or "h2" or "h3" or "h4" or "h5" or "h6" or "figure" or "ol" or "ul" or "dl" or "hr" or "table" or "p";
+
+    private static bool IsInlineContainer(MarkupNode node) => node.Type is MarkupType.Span or MarkupType.Link or MarkupType.Sub or MarkupType.Sup;
+
+    private static bool IsBlockContainer(MarkupNode node) => node.Type is MarkupType.Document or MarkupType.Block or MarkupType.ListItem or MarkupType.TableCell;
 
     // Approximation based on https://stackoverflow.com/a/819121
     private static double ParseHtmlFontSize(int fontSize) =>
@@ -761,7 +1017,6 @@ internal class HtmlTokenParser
         var nextTokenIdx = _html.IndexOf('<', _idx) + 1;
         if (nextTokenIdx > _idx + 1)
         {
-            // TODO collapse whitespace
             var text = ProcessText(_html.Substring(_idx, nextTokenIdx - _idx - 1));
             token = new HtmlToken(text, null, HtmlTokenType.PlainText);
             _idx = nextTokenIdx - 1;
@@ -771,7 +1026,6 @@ internal class HtmlTokenParser
             // no more tokens
             if (_idx < _html.Length)
             {
-                // TODO collapse whitespace
                 var text = ProcessText(_html.Substring(_idx));
                 token = new HtmlToken(text, null, HtmlTokenType.PlainText);
                 _idx = _html.Length;
@@ -819,10 +1073,11 @@ internal class HtmlTokenParser
 
     private static string ProcessText(string rawText)
     {
-        // replace HTML entities with their equivalent symbols
+        // Replace HTML entities with their equivalent symbols.
         var unescaped = HtmlUtility.UnescapeHtml(rawText);
-        // trim newlines and collapse remaining whitespace
-        return Regex.Replace(unescaped.Trim('\r', '\n'), @"\s+", " ");
+        // Trim newlines and collapse remaining whitespace,
+        // but leave unbreakable spaces (nbsp / 0x00A0) untouched.
+        return Regex.Replace(unescaped, @"[^\S\u00A0]+", " ");
     }
 }
 

--- a/src/Toolkit/Toolkit/UI/Controls/PopupViewer/TextPopupElementView.Maui.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/PopupViewer/TextPopupElementView.Maui.cs
@@ -171,6 +171,8 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
                     }
                     else
                     {
+                        foreach (var child in node.Children) // We have to copy the style down to FormattedText's elements
+                            child.InheritAttributes(node);
                         var label = CreateFormattedText(node.Children);
                         if (isPara)
                             label.Margin = ParagraphMargin;

--- a/src/Toolkit/Toolkit/UI/Controls/PopupViewer/TextPopupElementView.Windows.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/PopupViewer/TextPopupElementView.Windows.cs
@@ -142,7 +142,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                     return new BlockUIContainer(new Separator());
 
                 case MarkupType.Table:
-                    var table = new Table();
+                    var table = new Table { Margin = new Thickness(0) };
                     var columnCount = node.Children.Max(rowNode => rowNode.Children.Count);
                     for (int i = 0; i < columnCount; i++)
                         table.Columns.Add(new TableColumn());


### PR DESCRIPTION
This is a result of a little background project I've been working on since July.  This PR teaches our HTML parser to simplify the document structure and remove most spacing-related quirks that plague HTML.  It also implements support for `display:none` attribute and unbreakable spaces (`&nbsp;`), seen in a number of Living Atlas maps.

New code walks the node tree, skips empty/useless nodes, and merges as many single-child nodes as possible.  It then finds groups of inline nodes that flow together, and adjusts trailing/leading whitespace among and around these nodes.

Although this adds some complexity to our HTML parser, it benefits all supported platforms in terms of fidelity (more accurate rendering) and performance (much fewer UI element needed to render a popup).  Here are some concrete examples:

## Example 1: Social Vulnerability Index
https://www.arcgis.com/apps/mapviewer/index.html?webmap=2c8fdc6267e4439e968837020e7618f3
This popup has a number of empty paragraphs, which were getting collapsed by browsers, but wasted a lot of space in PopupViewer.

<table>
<tr><th>Before:</th><th>After:</th></tr>
<tr><td><img src="https://github.com/Esri/arcgis-maps-sdk-dotnet-toolkit/assets/587809/38e5f7f7-c9d6-4a0f-8fef-418e9878695f"/></td><td><img src="https://github.com/Esri/arcgis-maps-sdk-dotnet-toolkit/assets/587809/41b31496-d647-4674-a37f-adb0c7760ea6"/>
</td></tr>
</table>

<details><summary>Popup HTML</summary>

```html
<div>
  <p>
    <span><font size="3">2018 Overall SVI Score:</font></span>
  </p>
  <p>
    <span style="font-weight:bold;"><font size="5">0.82</font></span>
  </p>
  <p>
    <font size="3"><span></span></font>
  </p>
  <p>
    <font size="3"><span>Possible scores range from </span><span style="font-weight:bold;">0 </span><span>(lowest vulnerability) to </span><span style="font-weight:bold;">1</span><span> (highest vulnerability).</span></font>
  </p>
  <p>
    <font size="3"><span></span></font>
  </p>
  <p>
    <font size="3"><span>A score of </span><span style="font-weight:bold;">0.82 </span><span>indicates </span><span style="font-weight:bold;">high </span><span>vulnerability.</span></font>
  </p>
  <p>
    <font size="3"><span></span></font>
  </p>
  <p>
    <a href="https://svi.cdc.gov/Documents/Data/2018_SVI_Data/SVI2018Documentation.pdf" rel="nofollow ugc" style="color:#6D6D6D;text-decoration:underline;">
      <span><font size="3">Data Dictionary </font></span>
    </a>
  </p>
  <p><span></span></p>
</div>
```

</details>

<details><summary>Original document tree</summary>

```
Document { children=1 }
  Block { children=9 }
    Block { children=1 }
      Span { children=1 }
        Span { size=1 children=1 }
          Text { text="2018 Overall SVI Score:" }
    Block { children=1 }
      Span { bold=True children=1 }
        Span { size=1.5 children=1 }
          Text { text="0.82" }
    Block { children=1 }
      Span { size=1 children=1 }
        Span { }
    Block { children=1 }
      Span { size=1 children=5 }
        Span { children=1 }
          Text { text="Possible scores range from " }
        Span { bold=True children=1 }
          Text { text="0 " }
        Span { children=1 }
          Text { text="(lowest vulnerability) to " }
        Span { bold=True children=1 }
          Text { text="1" }
        Span { children=1 }
          Text { text=" (highest vulnerability)." }
    Block { children=1 }
      Span { size=1 children=1 }
        Span { }
    Block { children=1 }
      Span { size=1 children=5 }
        Span { children=1 }
          Text { text="A score of " }
        Span { bold=True children=1 }
          Text { text="0.82 " }
        Span { children=1 }
          Text { text="indicates " }
        Span { bold=True children=1 }
          Text { text="high " }
        Span { children=1 }
          Text { text="vulnerability." }
    Block { children=1 }
      Span { size=1 children=1 }
        Span { }
    Block { children=1 }
      Link { color=Color [A=255, R=109, G=109, B=109] text="https://svi.cdc.gov/Documents/Data/2018_SVI_Data/SVI2018Documentation.pdf" children=1 }
        Span { children=1 }
          Span { size=1 children=1 }
            Text { text="Data Dictionary " }
    Block { children=1 }
      Span { }
```

</details>

<details><summary>Simplified document tree</summary>

```
Document { children=1 }
  Block { children=5 }
    Block { children=1 }
      Text { size=1 text="2018 Overall SVI Score:" }
    Block { children=1 }
      Text { bold=True size=1.5 text="0.82" }
    Block { size=1 children=5 }
      Text { text="Possible scores range from " }
      Text { bold=True text="0 " }
      Text { text="(lowest vulnerability) to " }
      Text { bold=True text="1" }
      Text { text=" (highest vulnerability)." }
    Block { size=1 children=5 }
      Text { text="A score of " }
      Text { bold=True text="0.82 " }
      Text { text="indicates " }
      Text { bold=True text="high " }
      Text { text="vulnerability." }
    Block { children=1 }
      Link { color=Color [A=255, R=109, G=109, B=109] text="https://svi.cdc.gov/Documents/Data/2018_SVI_Data/SVI2018Documentation.pdf" children=1 }
        Text { size=1 text="Data Dictionary" }
```

</details>

## Example 2: NWS Wind Speed forecast
https://www.arcgis.com/apps/mapviewer/index.html?webmap=a7b007939f02406ca2b8559a821c08ab
These popups have many ignorable line break and extra spaces/newlines between paragraphs, which caused bad spacing and bloated the visual tree.

<table>
<tr><th>Before:</th><th>After:</th></tr>
<tr><td><img src="https://github.com/Esri/arcgis-maps-sdk-dotnet-toolkit/assets/587809/6f4c7162-4d4f-4217-881b-63c916632584"/></td><td><img src="https://github.com/Esri/arcgis-maps-sdk-dotnet-toolkit/assets/587809/c4d0abdf-7e90-4c2a-bea1-311a36677739"/>
</td></tr>
</table>

<details><summary>Popup HTML</summary>

```html
<p align='center' style='margin-bottom: 0.0001pt; text-align: center;'><b><span style='font-size: 18pt; font-family: Verdana, sans-serif;'>Wind Speed Forecast</span></b><span style='font-size: 9pt; font-family: Verdana, sans-serif;'><br />
</span><span style='font-size: 10pt; font-family: Verdana, sans-serif;'> </span><span style='font-size: 9pt; font-family: Verdana, sans-serif;'></span></p>

<p align='center' style='margin-bottom: 0.0001pt; text-align: center;'><b><span style='font-size: 13.5pt; font-family: Verdana, sans-serif;'><font color='#0000ff'>Fresh Breeze (18-24mph, 29-38km/h)</font></span></b><span style='font-size: 9pt; font-family: Verdana, sans-serif;'></span></p>

<p style='margin-bottom: 0.0001pt;'><span style='font-size:12.0pt;font-family:&quot;Times New Roman&quot;,&quot;serif&quot;;
mso-fareast-font-family:&quot;Times New Roman&quot;'> </span></p>

<p align='center' style='margin-bottom: 0.0001pt; text-align: center;'><span style='font-size: 13.5pt; font-family: Verdana, sans-serif;'>From</span><span style='font-size: 9pt; font-family: Verdana, sans-serif;'></span></p>

<p align='center' style='margin-bottom: 0.0001pt; text-align: center;'><b><span style='font-size: 9pt; font-family: Verdana, sans-serif;'>10/12/2023 02:00 PM<br />
 </span></b><span style='font-size: 9pt; font-family: Verdana, sans-serif;'></span></p>

<p align='center' style='margin-bottom: 0.0001pt; text-align: center;'><span style='font-size: 13.5pt; font-family: Verdana, sans-serif;'>Until</span><span style='font-size: 9pt; font-family: Verdana, sans-serif;'></span></p>

<p align='center' style='margin-bottom: 12pt; text-align: center;'><b><span style='font-size: 9pt; font-family: Verdana, sans-serif;'>10/12/2023 04:58 PM</span></b><i><span style='font-size:9.0pt;font-family:
&quot;Verdana&quot;,&quot;sans-serif&quot;;mso-fareast-font-family:&quot;Times New Roman&quot;;mso-bidi-font-family:
&quot;Times New Roman&quot;;color:dimgray'></span></i></p>

<p style='margin-bottom: 0.0001pt;'><i><span style='font-size:9.0pt;font-family:&quot;Verdana&quot;,&quot;sans-serif&quot;;
mso-fareast-font-family:&quot;Times New Roman&quot;;mso-bidi-font-family:&quot;Times New Roman&quot;;
color:dimgray'>Source: The National Digital Forecast Database produced by
the National Weather Service<br />
 </span></i></p>

<p><i><span style='font-size:9.0pt;line-height:115%;font-family:
&quot;Verdana&quot;,&quot;sans-serif&quot;;mso-fareast-font-family:&quot;Times New Roman&quot;;mso-bidi-font-family:
&quot;Times New Roman&quot;;color:dimgray'>Data updated every 3 hours</span></i></p>
```

</details>

<details><summary>Original document tree</summary>

```
Document { children=17 }
  Block { align=Center children=4 }
    Span { bold=True children=1 }
      Span { size=1.5 children=1 }
        Text { text="Wind Speed Forecast" }
    Span { size=0.75 children=2 }
      Break { }
      Text { text=" " }
    Span { size=0.8333333333333334 children=1 }
      Text { text=" " }
    Span { size=0.75 }
  Text { text=" " }
  Block { align=Center children=2 }
    Span { bold=True children=1 }
      Span { size=1.125 children=1 }
        Span { color=Color [A=255, R=0, G=0, B=255] children=1 }
          Text { text="Fresh Breeze (18-24mph, 29-38km/h)" }
    Span { size=0.75 }
  Text { text=" " }
  Block { children=1 }
    Span { size=1 children=1 }
      Text { text=" " }
  Text { text=" " }
  Block { align=Center children=2 }
    Span { size=1.125 children=1 }
      Text { text="From" }
    Span { size=0.75 }
  Text { text=" " }
  Block { align=Center children=2 }
    Span { bold=True children=1 }
      Span { size=0.75 children=3 }
        Text { text="10/12/2023 02:00 PM" }
        Break { }
        Text { text=" " }
    Span { size=0.75 }
  Text { text=" " }
  Block { align=Center children=2 }
    Span { size=1.125 children=1 }
      Text { text="Until" }
    Span { size=0.75 }
  Text { text=" " }
  Block { align=Center children=2 }
    Span { bold=True children=1 }
      Span { size=0.75 children=1 }
        Text { text="10/12/2023 04:58 PM" }
    Span { italic=True children=1 }
      Span { size=0.75 color=Color [A=255, R=105, G=105, B=105] }
  Text { text=" " }
  Block { children=1 }
    Span { italic=True children=1 }
      Span { size=0.75 color=Color [A=255, R=105, G=105, B=105] children=3 }
        Text { text="Source: The National Digital Forecast Database produced by the National Weather Service" }
        Break { }
        Text { text=" " }
  Text { text=" " }
  Block { children=1 }
    Span { italic=True children=1 }
      Span { size=0.75 color=Color [A=255, R=105, G=105, B=105] children=1 }
        Text { text="Data updated every 3 hours" }
```

</details>

<details><summary>Simplified document tree</summary>

```
Document { children=8 }
  Block { align=Center children=1 }
    Text { bold=True size=1.5 text="Wind Speed Forecast" }
  Block { align=Center children=1 }
    Text { bold=True size=1.125 color=Color [A=255, R=0, G=0, B=255] text="Fresh Breeze (18-24mph, 29-38km/h)" }
  Block { align=Center children=1 }
    Text { size=1.125 text="From" }
  Block { bold=True size=0.75 align=Center children=1 }
    Text { text="10/12/2023 02:00 PM" }
  Block { align=Center children=1 }
    Text { size=1.125 text="Until" }
  Block { align=Center children=1 }
    Text { bold=True size=0.75 text="10/12/2023 04:58 PM" }
  Block { italic=True size=0.75 color=Color [A=255, R=105, G=105, B=105] children=1 }
    Text { text="Source: The National Digital Forecast Database produced by the National Weather Service" }
  Block { children=1 }
    Text { italic=True size=0.75 color=Color [A=255, R=105, G=105, B=105] text="Data updated every 3 hours" }
```

</details>

## Example 3: Energielabels (Netherlands Enterprise Agency)
https://www.arcgis.com/apps/mapviewer/index.html?webmap=22f951f0951f4922b800021b0ba98539
These popups have many collapsible table rows/cells and hidden elements, which caused Runtime to render completely differently from the browser.

<table>
<tr><th>Before:</th><th>After:</th></tr>
<tr><td><img src="https://github.com/Esri/arcgis-maps-sdk-dotnet-toolkit/assets/587809/23c70e30-bb4a-47b9-a5f5-a23a62134421"/></td><td><img src="https://github.com/Esri/arcgis-maps-sdk-dotnet-toolkit/assets/587809/7ffcfc7d-2667-47ff-be47-09e468ac822e"/></td></tr>
</table>

<details><summary>Popup HTML</summary>

```html
Er is 1 energielabel geregistreerd in dit pand met bouwjaar  1888<br /><br />
<table>
<tbody><tr style='display: none' valign='middle'>
<td>
<img alt='' src='https://arcgis.com/sharing/rest/content/items/f179492056fe42318fa0948a9c38d138/data' style='width:80px;height:40px;' /> </td><td>  <div></div></td>
</tr>
<tr style='display: none' valign='middle'>
<td>
<img alt='' src='https://arcgis.com/sharing/rest/content/items/f179492056fe42318fa0948a9c38d138/data' style='width:80px;height:40px;' /></td><td> Meest zuinig <div></div></td>
</tr>
<tr valign='middle'>
</tr>
<tr style='display: none' valign='middle'>
<td>
<img alt='' src='https://arcgis.com/sharing/rest/content/items/f179492056fe42318fa0948a9c38d138/data' style='width:80px;height:40px;' /></td><td> Minst zuinig</td>
</tr>
<tr style='' valign='middle'>
<td>
<img alt='' src='https://arcgis.com/sharing/rest/content/items/f179492056fe42318fa0948a9c38d138/data' style='width:80px;height:40px;' /></td>
<td>  <div></div></td>
</tr>
</tbody></table><br />Dit pand bevat in totaal <b>9</b> verblijfsobject(en), met de volgende gebruiksfunctie(s):<br /> <br />
<table>
<tbody><tr style='display: none'><td>• Winkelfunctie: 0<br /></td></tr>
<tr style=''><td>• Woonfunctie: 8<br /></td></tr>
<tr style='display: none'><td>• Kantoorfunctie: 0<br /></td></tr>
<tr style=''><td>• Bijeenkomstfunctie: 1<br /></td></tr>
<tr style='display: none'><td>• Gezondheidszorgfunctie: 0<br /></td></tr>
<tr style='display: none'><td>• Industriefunctie: 0<br /></td></tr>
<tr style='display: none'><td>• Logiesfunctie: 0<br /></td></tr>
<tr style='display: none'><td>• Celfunctie: 0<br /></td></tr>
<tr style='display: none'><td>• Onderwijsfunctie: 0<br /></td></tr>
<tr style='display: none'><td>• Sportfunctie: 0<br /></td></tr>
<tr style='display: none'><td>• Overige gebruiksfuncties: 0</td></tr>
</tbody></table>
```

</details>

<details><summary>Original document tree</summary>

```
Document { children=14 }
  Text { text="Er is 1 energielabel geregistreerd in dit pand met bouwjaar 1888" }
  Break { }
  Break { }
  Text { text=" " }
  Table { children=5 }
    TableRow { children=2 }
      TableCell { children=3 }
        Text { text=" " }
        Image { text="https://arcgis.com/sharing/rest/content/items/f179492056fe42318fa0948a9c38d138/data" }
        Text { text=" " }
      TableCell { children=2 }
        Text { text=" " }
        Block { }
    TableRow { children=2 }
      TableCell { children=2 }
        Text { text=" " }
        Image { text="https://arcgis.com/sharing/rest/content/items/f179492056fe42318fa0948a9c38d138/data" }
      TableCell { children=2 }
        Text { text=" Meest zuinig " }
        Block { }
    TableRow { }
    TableRow { children=2 }
      TableCell { children=2 }
        Text { text=" " }
        Image { text="https://arcgis.com/sharing/rest/content/items/f179492056fe42318fa0948a9c38d138/data" }
      TableCell { children=1 }
        Text { text=" Minst zuinig" }
    TableRow { children=2 }
      TableCell { children=2 }
        Text { text=" " }
        Image { text="https://arcgis.com/sharing/rest/content/items/f179492056fe42318fa0948a9c38d138/data" }
      TableCell { children=2 }
        Text { text=" " }
        Block { }
  Break { }
  Text { text="Dit pand bevat in totaal " }
  Span { bold=True children=1 }
    Text { text="9" }
  Text { text=" verblijfsobject(en), met de volgende gebruiksfunctie(s):" }
  Break { }
  Text { text=" " }
  Break { }
  Text { text=" " }
  Table { children=11 }
    TableRow { children=1 }
      TableCell { children=2 }
        Text { text="• Winkelfunctie: 0" }
        Break { }
    TableRow { children=1 }
      TableCell { children=2 }
        Text { text="• Woonfunctie: 8" }
        Break { }
    TableRow { children=1 }
      TableCell { children=2 }
        Text { text="• Kantoorfunctie: 0" }
        Break { }
    TableRow { children=1 }
      TableCell { children=2 }
        Text { text="• Bijeenkomstfunctie: 1" }
        Break { }
    TableRow { children=1 }
      TableCell { children=2 }
        Text { text="• Gezondheidszorgfunctie: 0" }
        Break { }
    TableRow { children=1 }
      TableCell { children=2 }
        Text { text="• Industriefunctie: 0" }
        Break { }
    TableRow { children=1 }
      TableCell { children=2 }
        Text { text="• Logiesfunctie: 0" }
        Break { }
    TableRow { children=1 }
      TableCell { children=2 }
        Text { text="• Celfunctie: 0" }
        Break { }
    TableRow { children=1 }
      TableCell { children=2 }
        Text { text="• Onderwijsfunctie: 0" }
        Break { }
    TableRow { children=1 }
      TableCell { children=2 }
        Text { text="• Sportfunctie: 0" }
        Break { }
    TableRow { children=1 }
      TableCell { children=1 }
        Text { text="• Overige gebruiksfuncties: 0" }
```

</details>

<details><summary>Simplified document tree</summary>

```
Document { children=10 }
  Text { text="Er is 1 energielabel geregistreerd in dit pand met bouwjaar 1888" }
  Break { }
  Table { children=2 }
    TableRow { }
    TableRow { children=2 }
      TableCell { children=1 }
        Image { text="https://arcgis.com/sharing/rest/content/items/f179492056fe42318fa0948a9c38d138/data" }
      TableCell { }
  Break { }
  Text { text="Dit pand bevat in totaal " }
  Text { bold=True text="9" }
  Text { text=" verblijfsobject(en), met de volgende gebruiksfunctie(s):" }
  Break { }
  Text { text=" " }
  Table { children=2 }
    TableRow { children=1 }
      TableCell { children=1 }
        Text { text="• Woonfunctie: 8" }
    TableRow { children=1 }
      TableCell { children=1 }
        Text { text="• Bijeenkomstfunctie: 1" }
```

</details>
