### PR TITLE
Adds a GeoView controller to help with common MVVM challenges

### DIFF
--- a/src/Samples/Toolkit.SampleApp.Maui/MauiProgram.cs
+++ b/src/Samples/Toolkit.SampleApp.Maui/MauiProgram.cs
@@ -1,4 +1,5 @@
-﻿using Esri.ArcGISRuntime.Maui;
+﻿using CommunityToolkit.Maui;
+using Esri.ArcGISRuntime.Maui;
 using Esri.ArcGISRuntime.Toolkit.Maui;
 
 namespace Toolkit.SampleApp.Maui;
@@ -14,7 +15,7 @@ public static class MauiProgram
 			{
 				fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
 				fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
-			}).UseArcGISRuntime().UseArcGISToolkit();
+			}).UseArcGISRuntime().UseArcGISToolkit().UseMauiCommunityToolkit();
 
 		return builder.Build();
 	}

--- a/src/Samples/Toolkit.SampleApp.Maui/SampleDatasource.cs
+++ b/src/Samples/Toolkit.SampleApp.Maui/SampleDatasource.cs
@@ -51,7 +51,7 @@ namespace Toolkit.SampleApp.Maui
             if (string.IsNullOrEmpty(Name))
             {
                 //Deduce name from type name
-                Name = Regex.Replace(Page.Name, @"((?<=\p{Ll})\p{Lu})|((?!\A)\p{Lu}(?>\p{Ll}))", " $0").Replace("Arc GIS", "ArcGIS");
+                Name = Regex.Replace(Page.Name, @"((?<=\p{Ll})\p{Lu})|((?!\A)\p{Lu}(?>\p{Ll}))", " $0").Replace("Arc GIS", "ArcGIS").Replace("Geo View", "GeoView");
                 if (Name.EndsWith("Sample"))
                     Name = Name.Substring(0, Name.Length - 6);
             }

--- a/src/Samples/Toolkit.SampleApp.Maui/Samples/GeoViewControllerSample.xaml
+++ b/src/Samples/Toolkit.SampleApp.Maui/Samples/GeoViewControllerSample.xaml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Toolkit.SampleApp.Maui.Samples.GeoViewControllerSample"
+             xmlns:local="clr-namespace:Toolkit.SampleApp.Maui.Samples"
+             xmlns:esri="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui"
+             xmlns:toolkit="clr-namespace:Esri.ArcGISRuntime.Toolkit.Maui;assembly=Esri.ArcGISRuntime.Toolkit.Maui"
+             xmlns:toolkitbase="clr-namespace:Esri.ArcGISRuntime.Toolkit;assembly=Esri.ArcGISRuntime.Toolkit.Maui"
+             xmlns:mauitoolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+             Title="GeoViewController">
+    <ContentPage.Resources>
+        <local:GeoViewControllerSampleVM x:Key="VM" />
+    </ContentPage.Resources>
+    <Grid>
+        <esri:MapView x:Name="MyMapView"
+                      Map="{Binding Map, Source={StaticResource VM}}"
+                      toolkit:GeoViewController.GeoViewController="{Binding Controller, Source={StaticResource VM}}">
+            <esri:MapView.Behaviors>
+                <mauitoolkit:EventToCommandBehavior EventName="GeoViewTapped"
+                                                    x:TypeArguments="esri:GeoViewInputEventArgs"
+                                                    Command="{Binding GeoViewTappedCommand, Source={StaticResource VM}}" />
+            </esri:MapView.Behaviors>
+        </esri:MapView>
+    </Grid>
+</ContentPage>

--- a/src/Samples/Toolkit.SampleApp.Maui/Samples/GeoViewControllerSample.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.Maui/Samples/GeoViewControllerSample.xaml.cs
@@ -1,0 +1,40 @@
+using CommunityToolkit.Mvvm.Input;
+using Esri.ArcGISRuntime.Data;
+using Esri.ArcGISRuntime.Geometry;
+using Esri.ArcGISRuntime.Mapping;
+using Esri.ArcGISRuntime.Maui;
+using Esri.ArcGISRuntime.Toolkit.Maui;
+
+namespace Toolkit.SampleApp.Maui.Samples;
+
+public partial class GeoViewControllerSample : ContentPage
+{
+    public GeoViewControllerSample()
+    {
+        InitializeComponent();
+    }
+}
+
+public partial class GeoViewControllerSampleVM
+{
+    public Map Map { get; } = new Map(new Uri("https://www.arcgis.com/home/item.html?id=9f3a674e998f461580006e626611f9ad"));
+
+    public GeoViewController Controller { get; } = new GeoViewController();
+
+    [RelayCommand]
+    public async Task OnGeoViewTapped(GeoViewInputEventArgs eventArgs) => await Identify(eventArgs.Position, eventArgs.Location);
+
+    public async Task Identify(Point location, MapPoint? mapLocation)
+    {
+        Controller.DismissCallout();
+        var result = await Controller.IdentifyLayersAsync(location, 10);
+        if (result.FirstOrDefault()?.GeoElements?.FirstOrDefault() is GeoElement element)
+        {
+            Controller.ShowCalloutForGeoElement(element, location, new Esri.ArcGISRuntime.UI.CalloutDefinition(element));
+        }
+        else if (mapLocation is not null)
+        {
+            Controller.ShowCalloutAt(mapLocation, new Esri.ArcGISRuntime.UI.CalloutDefinition("No features found"));
+        }
+    }
+}

--- a/src/Samples/Toolkit.SampleApp.Maui/Toolkit.SampleApp.Maui.csproj
+++ b/src/Samples/Toolkit.SampleApp.Maui/Toolkit.SampleApp.Maui.csproj
@@ -53,6 +53,17 @@
     <MauiXaml Remove="Samples\TimeSliderSample.xaml" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="CommunityToolkit.Maui" Version="6.0.0" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <MauiXaml Update="Samples\GeoViewControllerSample.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+  </ItemGroup>
+
 
   <Choose>
     <When Condition="'$(UseNugetPackage)'==''">

--- a/src/Samples/Toolkit.SampleApp.UWP/SampleDatasource.cs
+++ b/src/Samples/Toolkit.SampleApp.UWP/SampleDatasource.cs
@@ -40,7 +40,7 @@ namespace Esri.ArcGISRuntime.Toolkit.SampleApp
                 }
                 if (string.IsNullOrEmpty(sample.Name))
                 {
-                    sample.Name = Regex.Replace(sample.Page.Name, @"((?<=\p{Ll})\p{Lu})|((?!\A)\p{Lu}(?>\p{Ll}))", " $0").Replace("Arc GIS", "ArcGIS");
+                    sample.Name = Regex.Replace(sample.Page.Name, @"((?<=\p{Ll})\p{Lu})|((?!\A)\p{Lu}(?>\p{Ll}))", " $0").Replace("Arc GIS", "ArcGIS").Replace("Geo View", "GeoView").Replace("Geo View", "GeoView");
                     if (sample.Name.EndsWith("Sample"))
                         sample.Name = sample.Name.Substring(0, sample.Name.Length - 6);
                 }

--- a/src/Samples/Toolkit.SampleApp.UWP/Samples/GeoViewController/GeoViewControllerSample.xaml
+++ b/src/Samples/Toolkit.SampleApp.UWP/Samples/GeoViewController/GeoViewControllerSample.xaml
@@ -1,0 +1,19 @@
+﻿<Page
+    x:Class="Esri.ArcGISRuntime.Toolkit.SampleApp.Samples.GeoViewController.GeoViewControllerSample"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Esri.ArcGISRuntime.Toolkit.SampleApp.Samples.GeoViewController"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:esri="using:Esri.ArcGISRuntime.UI.Controls"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:toolkit="using:Esri.ArcGISRuntime.Toolkit.UI.Controls"
+    xmlns:toolkitui="using:Esri.ArcGISRuntime.Toolkit.UI"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid>
+        <esri:MapView x:Name="MyMapView" Map="{x:Bind VM.Map}"
+                      toolkitui:GeoViewController.GeoViewController="{x:Bind VM.Controller}"
+                      GeoViewTapped="{x:Bind VM.OnGeoViewTapped}" />
+    </Grid>
+</Page>

--- a/src/Samples/Toolkit.SampleApp.UWP/Samples/GeoViewController/GeoViewControllerSample.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.UWP/Samples/GeoViewController/GeoViewControllerSample.xaml.cs
@@ -1,0 +1,11 @@
+﻿namespace Esri.ArcGISRuntime.Toolkit.SampleApp.Samples.GeoViewController
+{
+    public sealed partial class GeoViewControllerSample : Page
+    {
+        public GeoViewControllerSample()
+        {
+            this.InitializeComponent();
+        }
+        public GeoViewControllerSampleVM VM { get; } = new GeoViewControllerSampleVM();
+    }
+}

--- a/src/Samples/Toolkit.SampleApp.UWP/Samples/GeoViewController/GeoViewControllerSampleVM.cs
+++ b/src/Samples/Toolkit.SampleApp.UWP/Samples/GeoViewController/GeoViewControllerSampleVM.cs
@@ -16,7 +16,7 @@ public class GeoViewControllerSampleVM
 
     public void OnGeoViewTapped(object sender, GeoViewInputEventArgs eventArgs) => Identify(eventArgs.Position, eventArgs.Location);
 
-    public async void Identify(Point location, MapPoint? mapLocation)
+    public async void Identify(Point location, MapPoint mapLocation)
     {
         Controller.DismissCallout();
         var result = await Controller.IdentifyLayersAsync(location, 10);

--- a/src/Samples/Toolkit.SampleApp.UWP/Samples/GeoViewController/GeoViewControllerSampleVM.cs
+++ b/src/Samples/Toolkit.SampleApp.UWP/Samples/GeoViewController/GeoViewControllerSampleVM.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Linq;
+using Esri.ArcGISRuntime.Data;
+using Esri.ArcGISRuntime.Geometry;
+using Esri.ArcGISRuntime.Mapping;
+using Esri.ArcGISRuntime.UI.Controls;
+using Windows.Foundation;
+
+namespace Esri.ArcGISRuntime.Toolkit.SampleApp.Samples.GeoViewController;
+
+public class GeoViewControllerSampleVM
+{
+    public Map Map { get; } = new Map(new Uri("https://www.arcgis.com/home/item.html?id=9f3a674e998f461580006e626611f9ad"));
+
+    public UI.GeoViewController Controller { get; } = new UI.GeoViewController();
+
+    public void OnGeoViewTapped(object sender, GeoViewInputEventArgs eventArgs) => Identify(eventArgs.Position, eventArgs.Location);
+
+    public async void Identify(Point location, MapPoint? mapLocation)
+    {
+        Controller.DismissCallout();
+        var result = await Controller.IdentifyLayersAsync(location, 10);
+        if (result.FirstOrDefault()?.GeoElements?.FirstOrDefault() is GeoElement element)
+        {
+            Controller.ShowCalloutForGeoElement(element, location, new Esri.ArcGISRuntime.UI.CalloutDefinition(element));
+        }
+        else if (mapLocation is not null)
+        {
+            Controller.ShowCalloutAt(mapLocation, new Esri.ArcGISRuntime.UI.CalloutDefinition("No features found"));
+        }
+    }
+}

--- a/src/Samples/Toolkit.SampleApp.UWP/Toolkit.Samples.UWP.csproj
+++ b/src/Samples/Toolkit.SampleApp.UWP/Toolkit.Samples.UWP.csproj
@@ -134,6 +134,10 @@
     <Compile Include="Samples\FloorFilter\FloorFilterSample.xaml.cs">
       <DependentUpon>FloorFilterSample.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Samples\GeoViewController\GeoViewControllerSample.xaml.cs">
+      <DependentUpon>GeoViewControllerSample.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Samples\GeoViewController\GeoViewControllerSampleVM.cs" />
     <Compile Include="Samples\TimeSlider\TimeSliderSample.xaml.cs">
       <DependentUpon>TimeSliderSample.xaml</DependentUpon>
     </Compile>
@@ -226,6 +230,10 @@
     <Page Include="Samples\FloorFilter\FloorFilterSample.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Samples\GeoViewController\GeoViewControllerSample.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Samples\TimeSlider\TimeSliderSample.xaml">
       <Generator>MSBuild:Compile</Generator>

--- a/src/Samples/Toolkit.SampleApp.WPF/SampleDatasource.cs
+++ b/src/Samples/Toolkit.SampleApp.WPF/SampleDatasource.cs
@@ -43,7 +43,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples
                     sample.Name = sample.Page.Name;
                     if (sample.Name.EndsWith("Sample"))
                         sample.Name = sample.Name.Substring(0, sample.Name.Length - 6);
-                    sample.Name = Regex.Replace(sample.Name, @"((?<=\p{Ll})\p{Lu})|((?!\A)\p{Lu}(?>\p{Ll}))", " $0").Replace("Arc GIS", "ArcGIS");
+                    sample.Name = Regex.Replace(sample.Name, @"((?<=\p{Ll})\p{Lu})|((?!\A)\p{Lu}(?>\p{Ll}))", " $0").Replace("Arc GIS", "ArcGIS").Replace("Geo View", "GeoView");
                 }
                 if (string.IsNullOrEmpty(sample.Category))
                 {

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/GeoViewController/GeoViewControllerSample.xaml
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/GeoViewController/GeoViewControllerSample.xaml
@@ -1,0 +1,25 @@
+﻿<UserControl x:Class="Esri.ArcGISRuntime.Toolkit.Samples.GeoViewController.GeoViewControllerSample"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:Esri.ArcGISRuntime.Toolkit.Samples.GeoViewController"
+             xmlns:esri="http://schemas.esri.com/arcgis/runtime/2013"
+             xmlns:Behaviors="http://schemas.microsoft.com/xaml/behaviors"
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800">
+    <UserControl.Resources>
+        <local:GeoViewControllerSampleVM x:Key="VM" />
+    </UserControl.Resources>
+    <Grid>
+        <esri:MapView x:Name="MyMapView"
+                   Map="{Binding Map, Source={StaticResource VM}}"
+                   esri:GeoViewController.GeoViewController="{Binding Controller, Source={StaticResource VM}}">
+            <Behaviors:Interaction.Triggers>
+                <Behaviors:EventTrigger EventName="GeoViewTapped" >
+                    <Behaviors:InvokeCommandAction Command="{Binding GeoViewTappedCommand, Source={StaticResource VM}}" PassEventArgsToCommand="True" />
+                </Behaviors:EventTrigger>
+            </Behaviors:Interaction.Triggers>
+        </esri:MapView>
+    </Grid>
+</UserControl>

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/GeoViewController/GeoViewControllerSample.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/GeoViewController/GeoViewControllerSample.xaml.cs
@@ -1,0 +1,12 @@
+﻿using System.Windows.Controls;
+
+namespace Esri.ArcGISRuntime.Toolkit.Samples.GeoViewController
+{
+    public partial class GeoViewControllerSample : UserControl
+    {
+        public GeoViewControllerSample()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/GeoViewController/GeoViewControllerSampleVM.cs
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/GeoViewController/GeoViewControllerSampleVM.cs
@@ -1,5 +1,8 @@
-﻿using System;
+﻿#nullable enable
+using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using CommunityToolkit.Mvvm.Input;
@@ -13,11 +16,11 @@ public partial class GeoViewControllerSampleVM
 {
     public Map Map { get; } = new Map(new Uri("https://www.arcgis.com/home/item.html?id=9f3a674e998f461580006e626611f9ad"));
 
-    public UI.GeoViewController Controller { get; } = new UI.GeoViewController();
+    public IMyMapViewController Controller { get; } = new MyMapViewController();
 
     [RelayCommand]
     public async Task OnGeoViewTapped(GeoViewInputEventArgs eventArgs) => await Identify(eventArgs.Position, eventArgs.Location);
-
+    
     public async Task Identify(Point location, MapPoint? mapLocation)
     {
         Controller.DismissCallout();
@@ -25,10 +28,37 @@ public partial class GeoViewControllerSampleVM
         if (result.FirstOrDefault()?.GeoElements?.FirstOrDefault() is GeoElement element)
         {
             Controller.ShowCalloutForGeoElement(element, location, new Esri.ArcGISRuntime.UI.CalloutDefinition(element));
+            _ = Controller.PanToAsync(mapLocation);
         }
         else if (mapLocation is not null)
         {
             Controller.ShowCalloutAt(mapLocation, new Esri.ArcGISRuntime.UI.CalloutDefinition("No features found"));
         }
     }
+}
+
+// Custom controller that extends the toolkit controller
+public class MyMapViewController : UI.GeoViewController, IMyMapViewController
+{
+    public MapView? ConnectedMapView => ConnectedView as MapView;
+
+    public Task PanToAsync(MapPoint? center)
+    {
+        if (center is null)
+            return Task.FromResult(false);
+        return ConnectedMapView?.SetViewpointCenterAsync(center) ?? Task.FromResult(false);
+    }
+
+    public MapPoint? ScreenToLocation(Point screenLocation) => ConnectedMapView?.ScreenToLocation(screenLocation);
+}
+
+// Custom interface for testability of VM
+public interface IMyMapViewController
+{
+    void DismissCallout();
+    void ShowCalloutForGeoElement(GeoElement element, Point tapPosition, ArcGISRuntime.UI.CalloutDefinition definition);
+    void ShowCalloutAt(MapPoint location, ArcGISRuntime.UI.CalloutDefinition definition);
+    Task<IReadOnlyList<IdentifyLayerResult>> IdentifyLayersAsync(Point screenPoint, double tolerance, bool returnPopupsOnly = false, CancellationToken cancellationToken = default);
+    MapPoint? ScreenToLocation(Point screenLocation);
+    Task PanToAsync(MapPoint? center);
 }

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/GeoViewController/GeoViewControllerSampleVM.cs
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/GeoViewController/GeoViewControllerSampleVM.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
+using CommunityToolkit.Mvvm.Input;
+using Esri.ArcGISRuntime.Data;
+using Esri.ArcGISRuntime.Geometry;
+using Esri.ArcGISRuntime.Mapping;
+using Esri.ArcGISRuntime.UI.Controls;
+
+namespace Esri.ArcGISRuntime.Toolkit.Samples.GeoViewController;
+public partial class GeoViewControllerSampleVM
+{
+    public Map Map { get; } = new Map(new Uri("https://www.arcgis.com/home/item.html?id=9f3a674e998f461580006e626611f9ad"));
+
+    public UI.GeoViewController Controller { get; } = new UI.GeoViewController();
+
+    [RelayCommand]
+    public async Task OnGeoViewTapped(GeoViewInputEventArgs eventArgs) => await Identify(eventArgs.Position, eventArgs.Location);
+
+    public async Task Identify(Point location, MapPoint? mapLocation)
+    {
+        Controller.DismissCallout();
+        var result = await Controller.IdentifyLayersAsync(location, 10);
+        if (result.FirstOrDefault()?.GeoElements?.FirstOrDefault() is GeoElement element)
+        {
+            Controller.ShowCalloutForGeoElement(element, location, new Esri.ArcGISRuntime.UI.CalloutDefinition(element));
+        }
+        else if (mapLocation is not null)
+        {
+            Controller.ShowCalloutAt(mapLocation, new Esri.ArcGISRuntime.UI.CalloutDefinition("No features found"));
+        }
+    }
+}

--- a/src/Samples/Toolkit.SampleApp.WPF/Toolkit.SampleApp.WPF.csproj
+++ b/src/Samples/Toolkit.SampleApp.WPF/Toolkit.SampleApp.WPF.csproj
@@ -23,6 +23,11 @@
     </Content>
   </ItemGroup>
 
+    <ItemGroup>
+        <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
+        <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.39" />
+    </ItemGroup>
+
   <Choose>
     <When Condition="'$(UseNugetPackage)'==''">
       <ItemGroup>

--- a/src/Toolkit/Toolkit/GeoViewController.cs
+++ b/src/Toolkit/Toolkit/GeoViewController.cs
@@ -168,11 +168,13 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
         public virtual Task<IReadOnlyList<IdentifyLayerResult>> IdentifyLayersAsync(Point screenPoint, double tolerance, bool returnPopupsOnly = false, CancellationToken cancellationToken = default) =>
             ConnectedView?.IdentifyLayersAsync(screenPoint, tolerance, returnPopupsOnly, cancellationToken) ??
                 Task.FromResult<IReadOnlyList<IdentifyLayerResult>>(Array.Empty<IdentifyLayerResult>());
-        
+
         /// <inheritdoc cref="GeoView.IdentifyLayerAsync(Layer, Point, double, bool, CancellationToken)"/>
-        public virtual Task<IdentifyLayerResult> IdentifyLayerAsync(Layer layer, Point screenPoint, double tolerance, bool returnPopupsOnly = false, CancellationToken cancellationToken = default) =>
-            ConnectedView?.IdentifyLayerAsync(layer, screenPoint, tolerance, returnPopupsOnly, cancellationToken) ??
-                Task.FromResult<IdentifyLayerResult>(null!);
+        public virtual async Task<IdentifyLayerResult?> IdentifyLayerAsync(Layer layer, Point screenPoint, double tolerance, bool returnPopupsOnly = false, CancellationToken cancellationToken = default)
+        {
+            if (ConnectedView is null) return null;
+            return await ConnectedView.IdentifyLayerAsync(layer, screenPoint, tolerance, returnPopupsOnly, cancellationToken).ConfigureAwait(false);
+        }
 
         /// <inheritdoc cref="GeoView.IdentifyGraphicsOverlaysAsync(Point, double, bool, long)" />
         public virtual Task<IReadOnlyList<IdentifyGraphicsOverlayResult>> IdentifyGraphicsOverlaysAsync(Point screenPoint, double tolerance, bool returnPopupsOnly = false, long maximumResultsPerOverlay = 1) =>
@@ -180,9 +182,12 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
                 Task.FromResult<IReadOnlyList<IdentifyGraphicsOverlayResult>>(Array.Empty<IdentifyGraphicsOverlayResult>());
 
         /// <inheritdoc cref="GeoView.IdentifyGraphicsOverlaysAsync(Point, double, bool, long)" />
-        public virtual Task<IdentifyGraphicsOverlayResult> IdentifyGraphicsOverlayAsync(GraphicsOverlay overlay, Point screenPoint, double tolerance, bool returnPopupsOnly = false, long maximumResults = 1) =>
-            ConnectedView?.IdentifyGraphicsOverlayAsync(overlay, screenPoint, tolerance, returnPopupsOnly, maximumResults) ??
-                Task.FromResult<IdentifyGraphicsOverlayResult>(null!);
+        public virtual async Task<IdentifyGraphicsOverlayResult?> IdentifyGraphicsOverlayAsync(GraphicsOverlay overlay, Point screenPoint, double tolerance, bool returnPopupsOnly = false, long maximumResults = 1)
+        {
+            if (ConnectedView is null) return null;
+            return await ConnectedView.IdentifyGraphicsOverlayAsync(overlay, screenPoint, tolerance, returnPopupsOnly, maximumResults).ConfigureAwait(false);
+        }
+
         #endregion Identify
 
         #region Callouts
@@ -253,7 +258,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
         /// </summary>
         /// <param name="geoView">The target <see cref="GeoView"/> on which to set the <see cref="GeoViewController.GeoViewController"/> XAML attached property.</param>
         /// <param name="value">The property value to set.</param>
-        public static void SetGeoViewController(GeoViewDPType geoView, GeoViewController? value) => geoView?.SetValue(GeoViewControllerProperty, value) ?? throw new System.ArgumentNullException(nameof(geoView));
+        public static void SetGeoViewController(GeoViewDPType geoView, GeoViewController? value) => geoView?.SetValue(GeoViewControllerProperty, value);
 
         private static void OnGeoViewControllerChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {

--- a/src/Toolkit/Toolkit/GeoViewController.cs
+++ b/src/Toolkit/Toolkit/GeoViewController.cs
@@ -201,7 +201,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
         /// <summary>
         /// Identifies the <see cref="GeoViewController"/> attached property.
         /// </summary>
-        public static BindableProperty GeoViewControllerProperty =
+        public static readonly BindableProperty GeoViewControllerProperty =
             BindableProperty.CreateAttached(
                 "GeoViewController",
                 typeof(GeoViewController),

--- a/src/Toolkit/Toolkit/GeoViewController.cs
+++ b/src/Toolkit/Toolkit/GeoViewController.cs
@@ -177,7 +177,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
         /// <inheritdoc cref="GeoView.IdentifyGraphicsOverlaysAsync(Point, double, bool, long)" />
         public virtual Task<IReadOnlyList<IdentifyGraphicsOverlayResult>> IdentifyGraphicsOverlaysAsync(Point screenPoint, double tolerance, bool returnPopupsOnly = false, long maximumResultsPerOverlay = 1) =>
             ConnectedView?.IdentifyGraphicsOverlaysAsync(screenPoint, tolerance, returnPopupsOnly, maximumResultsPerOverlay) ??
-                Task.FromResult<IReadOnlyList<IdentifyGraphicsOverlayResult>>(new List<IdentifyGraphicsOverlayResult>().AsReadOnly());
+                Task.FromResult<IReadOnlyList<IdentifyGraphicsOverlayResult>>(Array.Empty<IdentifyGraphicsOverlayResult>());
 
         /// <inheritdoc cref="GeoView.IdentifyGraphicsOverlaysAsync(Point, double, bool, long)" />
         public virtual Task<IdentifyGraphicsOverlayResult> IdentifyGraphicsOverlayAsync(GraphicsOverlay overlay, Point screenPoint, double tolerance, bool returnPopupsOnly = false, long maximumResults = 1) =>

--- a/src/Toolkit/Toolkit/GeoViewController.cs
+++ b/src/Toolkit/Toolkit/GeoViewController.cs
@@ -246,14 +246,14 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
         /// </summary>
         /// <param name="geoView">The <see cref="GeoView"/> from which to read the property value.</param>
         /// <returns>The value of the <see cref="GeoViewController.GeoViewController"/> XAML attached property on the target element.</returns>
-        public static GeoViewController? GetGeoViewController(GeoViewDPType geoView) => geoView.GetValue(GeoViewControllerProperty) as GeoViewController;
+        public static GeoViewController? GetGeoViewController(GeoViewDPType geoView) => geoView?.GetValue(GeoViewControllerProperty) as GeoViewController;
 
         /// <summary>
         /// Sets the value of the <see cref="GeoViewController.GeoViewController"/> XAML attached property on the specified object.
         /// </summary>
         /// <param name="geoView">The target <see cref="GeoView"/> on which to set the <see cref="GeoViewController.GeoViewController"/> XAML attached property.</param>
         /// <param name="value">The property value to set.</param>
-        public static void SetGeoViewController(GeoViewDPType geoView, GeoViewController? value) => geoView.SetValue(GeoViewControllerProperty, value);
+        public static void SetGeoViewController(GeoViewDPType geoView, GeoViewController? value) => geoView?.SetValue(GeoViewControllerProperty, value) ?? throw new System.ArgumentNullException(nameof(geoView));
 
         private static void OnGeoViewControllerChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {

--- a/src/Toolkit/Toolkit/GeoViewController.cs
+++ b/src/Toolkit/Toolkit/GeoViewController.cs
@@ -1,0 +1,264 @@
+﻿#nullable enable
+using Esri.ArcGISRuntime.Data;
+using Esri.ArcGISRuntime.Mapping;
+using Esri.ArcGISRuntime.Toolkit.Internal;
+using Esri.ArcGISRuntime.UI;
+using System.Diagnostics;
+#if WINUI 
+using Point = Windows.Foundation.Point;
+using LoadedEventArgs = Microsoft.UI.Xaml.RoutedEventArgs;
+#elif WINDOWS_UWP
+using Point = Windows.Foundation.Point;
+using LoadedEventArgs = Windows.UI.Xaml.RoutedEventArgs;
+#else
+using LoadedEventArgs = System.EventArgs;
+#endif
+#if WINUI
+using GeoViewDPType = Microsoft.UI.Xaml.DependencyObject;
+#elif !MAUI
+using GeoViewDPType = Esri.ArcGISRuntime.UI.Controls.GeoView;
+#endif
+
+#if MAUI
+namespace Esri.ArcGISRuntime.Toolkit.Maui
+#else
+namespace Esri.ArcGISRuntime.Toolkit.UI
+#endif
+{
+    /// <summary>
+    /// Helper class for separating GeoView and ViewModel in an MVVM pattern, while allowing operations on the view from the ViewModel.
+    /// </summary>
+    public class GeoViewController
+    {
+        private WeakReference<GeoView>? _geoViewWeak;
+        private WeakEventListener<GeoViewController, GeoView, object?, LoadedEventArgs>? _loadedListener;
+        private WeakEventListener<GeoViewController, GeoView, object?, LoadedEventArgs>? _unloadedListener;
+
+        /// <summary>
+        /// Gets a reference to the GeoView this controller is currently connected to.
+        /// </summary>
+        protected GeoView? ConnectedView => _geoViewWeak?.TryGetTarget(out var view) == true ? view : null;
+
+        private void AttachToGeoView(GeoView mv)
+        {
+            var connectedView = ConnectedView;
+            if (connectedView == mv)
+            {
+                return;
+            }
+            if (connectedView != null)
+            {
+                Trace.WriteLine("Warning: GeoViewController already connected to a GeoView - Moving GeoViewController to a new GeoView", "ArcGIS Maps SDK Toolkit");
+                DetachFromGeoView(connectedView);
+                connectedView = null;
+            }
+            // All event listeners must be weak to avoid holding on to the GeoView if the GeoViewController stays alive
+            _geoViewWeak = new WeakReference<GeoView>(mv);
+            _loadedListener = new WeakEventListener<GeoViewController, GeoView, object?, LoadedEventArgs>(this, mv)
+            {
+                OnEventAction = static (instance, source, eventArgs) => instance.GeoView_Loaded((GeoView)source!),
+                OnDetachAction = static (instance, source, weakEventListener) => source.Loaded -= weakEventListener.OnEvent,
+            };
+            mv.Loaded += _loadedListener.OnEvent;
+
+            _unloadedListener = new WeakEventListener<GeoViewController, GeoView, object?, LoadedEventArgs>(this, mv)
+            {
+                OnEventAction = static (instance, source, eventArgs) => instance.GeoView_Unloaded((GeoView)source!),
+                OnDetachAction = static (instance, source, weakEventListener) => source.Unloaded -= weakEventListener.OnEvent,
+            };
+            mv.Loaded += _loadedListener.OnEvent;
+            mv.Unloaded += _unloadedListener.OnEvent;
+            OnGeoViewAttached(mv);
+            if (mv.IsLoaded)
+                GeoView_Loaded(mv);
+        }
+
+        private void DetachFromGeoView(GeoView mv)
+        {
+            var connectedView = ConnectedView;
+            if (connectedView != null && connectedView == mv)
+            {
+                _loadedListener?.Detach();
+                _unloadedListener?.Detach();
+                if (connectedView.IsLoaded)
+                    GeoView_Unloaded(mv);
+                OnGeoViewDetached(connectedView);
+                _geoViewWeak = null;
+            }
+        }
+
+        /// <summary>
+        /// Raised when the <see cref="GeoViewController"/> has been attached to a <see cref="GeoView"/>.
+        /// </summary>
+        /// <param name="geoView"></param>
+        protected virtual void OnGeoViewAttached(GeoView geoView)
+        {
+        }
+
+        /// <summary>
+        /// Raised when the <see cref="GeoViewController"/> has been detached from a <see cref="GeoView"/>.
+        /// </summary>
+        /// <param name="geoView"></param>
+        protected virtual void OnGeoViewDetached(GeoView geoView)
+        {
+        }
+
+        /// <summary>
+        /// Raised when the attached <see cref="GeoView"/> loads into the active view.
+        /// </summary>
+        /// <param name="geoView">GeoView that was loaded</param>
+        protected virtual void OnGeoViewLoaded(GeoView geoView)
+        {
+        }
+
+        /// <summary>
+        /// Raised when the attached <see cref="GeoView"/> unloads from the active view.
+        /// </summary>
+        /// <param name="geoView">GeoView that was unloaded</param>
+        protected virtual void OnGeoViewUnloaded(GeoView geoView)
+        {
+        }
+
+        private void GeoView_Loaded(GeoView sender)
+        {
+            Debug.Assert(sender == ConnectedView && ConnectedView is not null);
+            OnGeoViewLoaded(sender);
+        }
+
+        private void GeoView_Unloaded(GeoView sender)
+        {
+            Debug.Assert(sender == ConnectedView && ConnectedView is not null);
+            OnGeoViewUnloaded(sender);
+        }
+
+        #region Viewpoints
+
+        /// <inheritdoc cref="GeoView.GetCurrentViewpoint(ViewpointType)"/>
+        public Viewpoint? GetCurrentViewpoint(ViewpointType viewpointType) => ConnectedView?.GetCurrentViewpoint(viewpointType);
+
+        /// <inheritdoc cref="GeoView.SetViewpointAsync(Viewpoint)"/>
+        public Task<bool> SetViewpointAsync(Viewpoint viewpoint) => ConnectedView?.SetViewpointAsync(viewpoint) ?? Task.FromResult(false);
+
+        /// <inheritdoc cref="GeoView.SetViewpointAsync(Viewpoint, TimeSpan)"/>
+        public Task<bool> SetViewpointAsync(Viewpoint viewpoint, TimeSpan duration) => ConnectedView?.SetViewpointAsync(viewpoint, duration) ?? Task.FromResult(false);
+
+        /// <inheritdoc cref="GeoView.SetViewpoint(Viewpoint)"/>
+        public void SetViewpoint(Viewpoint viewpoint) => ConnectedView?.SetViewpoint(viewpoint);
+
+        #endregion Viewpoints
+
+        #region Identify
+        
+        /// <inheritdoc cref="GeoView.IdentifyLayersAsync(Point, double, bool, CancellationToken)"/>
+        public Task<IReadOnlyList<IdentifyLayerResult>> IdentifyLayersAsync(Point screenPoint, double tolerance, bool returnPopupsOnly = false, CancellationToken cancellationToken = default) =>
+            ConnectedView?.IdentifyLayersAsync(screenPoint, tolerance, returnPopupsOnly, cancellationToken) ??
+                Task.FromResult<IReadOnlyList<IdentifyLayerResult>>(new List<IdentifyLayerResult>().AsReadOnly());
+        
+        /// <inheritdoc cref="GeoView.IdentifyLayerAsync(Layer, Point, double, bool, CancellationToken)"/>
+        public Task<IdentifyLayerResult> IdentifyLayerAsync(Layer layer, Point screenPoint, double tolerance, bool returnPopupsOnly = false, CancellationToken cancellationToken = default) =>
+            ConnectedView?.IdentifyLayerAsync(layer, screenPoint, tolerance, returnPopupsOnly, cancellationToken) ??
+                Task.FromResult<IdentifyLayerResult>(null!);
+
+        /// <inheritdoc cref="GeoView.IdentifyGraphicsOverlaysAsync(Point, double, bool, long)" />
+        public Task<IReadOnlyList<IdentifyGraphicsOverlayResult>> IdentifyGraphicsOverlaysAsync(Point screenPoint, double tolerance, bool returnPopupsOnly = false, long maximumResultsPerOverlay = 1) =>
+            ConnectedView?.IdentifyGraphicsOverlaysAsync(screenPoint, tolerance, returnPopupsOnly, maximumResultsPerOverlay) ??
+                Task.FromResult<IReadOnlyList<IdentifyGraphicsOverlayResult>>(new List<IdentifyGraphicsOverlayResult>().AsReadOnly());
+
+        /// <inheritdoc cref="GeoView.IdentifyGraphicsOverlaysAsync(Point, double, bool, long)" />
+        public Task<IdentifyGraphicsOverlayResult> IdentifyGraphicsOverlayAsync(GraphicsOverlay overlay, Point screenPoint, double tolerance, bool returnPopupsOnly = false, long maximumResults = 1) =>
+            ConnectedView?.IdentifyGraphicsOverlayAsync(overlay, screenPoint, tolerance, returnPopupsOnly, maximumResults) ??
+                Task.FromResult<IdentifyGraphicsOverlayResult>(null!);
+        #endregion Identify
+
+        #region Callouts
+
+        /// <inheritdoc cref="GeoView.DismissCallout()" />
+        public void DismissCallout() => ConnectedView?.DismissCallout();
+
+        /// <inheritdoc cref="GeoView.ShowCalloutAt(Geometry.MapPoint, CalloutDefinition)" />
+        public void ShowCalloutAt(Esri.ArcGISRuntime.Geometry.MapPoint location, CalloutDefinition definition) => ConnectedView?.ShowCalloutAt(location, definition);
+
+        /// <inheritdoc cref="GeoView.ShowCalloutForGeoElement(GeoElement, Point, CalloutDefinition)" />
+        public void ShowCalloutForGeoElement(GeoElement element, Point tapPosition, CalloutDefinition definition) => ConnectedView?.ShowCalloutForGeoElement(element, tapPosition, definition);
+        #endregion Callouts
+
+#if MAUI
+        /// <summary>
+        /// Identifies the <see cref="GeoViewController"/> attached property.
+        /// </summary>
+        public static BindableProperty GeoViewControllerProperty =
+            BindableProperty.CreateAttached(
+                "GeoViewController",
+                typeof(GeoViewController),
+                typeof(GeoViewController),
+                null,
+                propertyChanged: OnGeoViewControllerChanged
+            );
+
+        private static void OnGeoViewControllerChanged(BindableObject bindable, object oldValue, object newValue)
+        {
+            if (bindable is GeoView geoView)
+            {
+                if (oldValue is GeoViewController controllerOld)
+                {
+                    controllerOld.DetachFromGeoView(geoView);
+                }
+
+                if (newValue is GeoViewController controllerNew)
+                {
+                    controllerNew.AttachToGeoView(geoView);
+                }
+            }
+            else
+            {
+                throw new InvalidOperationException("This property must be attached to a GeoView.");
+            }
+        }
+#else
+        /// <summary>
+        /// Identifies the <see cref="GeoViewController"/> attached property.
+        /// </summary>
+        public static readonly DependencyProperty GeoViewControllerProperty =
+            DependencyProperty.RegisterAttached(
+                "GeoViewController",
+                typeof(GeoViewController),
+                typeof(GeoViewController),
+                new PropertyMetadata(null, OnGeoViewControllerChanged)
+            );
+
+        /// <summary>
+        /// Gets the value of the <see cref="GeoViewController.GeoViewController"/> XAML attached property from the specified <see cref="GeoView"/>.
+        /// </summary>
+        /// <param name="geoView">The <see cref="GeoView"/> from which to read the property value.</param>
+        /// <returns>The value of the <see cref="GeoViewController.GeoViewController"/> XAML attached property on the target element.</returns>
+        public static GeoViewController? GetGeoViewController(GeoViewDPType geoView) => geoView.GetValue(GeoViewControllerProperty) as GeoViewController;
+
+        /// <summary>
+        /// Sets the value of the <see cref="GeoViewController.GeoViewController"/> XAML attached property on the specified object.
+        /// </summary>
+        /// <param name="geoView">The target <see cref="GeoView"/> on which to set the <see cref="GeoViewController.GeoViewController"/> XAML attached property.</param>
+        /// <param name="value">The property value to set.</param>
+        public static void SetGeoViewController(GeoViewDPType geoView, GeoViewController? value) => geoView.SetValue(GeoViewControllerProperty, value);
+
+        private static void OnGeoViewControllerChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is GeoView geoView)
+            {
+                if (e.OldValue is GeoViewController controllerOld)
+                {
+                    controllerOld.DetachFromGeoView(geoView);
+                }
+
+                if (e.NewValue is GeoViewController controllerNew)
+                {
+                    controllerNew.AttachToGeoView(geoView);
+                }
+            }
+            else
+            {
+                throw new InvalidOperationException("This property must be attached to a GeoView.");
+            }
+        }
+#endif
+    }
+}

--- a/src/Toolkit/Toolkit/GeoViewController.cs
+++ b/src/Toolkit/Toolkit/GeoViewController.cs
@@ -167,7 +167,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
         /// <inheritdoc cref="GeoView.IdentifyLayersAsync(Point, double, bool, CancellationToken)"/>
         public virtual Task<IReadOnlyList<IdentifyLayerResult>> IdentifyLayersAsync(Point screenPoint, double tolerance, bool returnPopupsOnly = false, CancellationToken cancellationToken = default) =>
             ConnectedView?.IdentifyLayersAsync(screenPoint, tolerance, returnPopupsOnly, cancellationToken) ??
-                Task.FromResult<IReadOnlyList<IdentifyLayerResult>>(new List<IdentifyLayerResult>().AsReadOnly());
+                Task.FromResult<IReadOnlyList<IdentifyLayerResult>>(Array.Empty<IdentifyLayerResult>());
         
         /// <inheritdoc cref="GeoView.IdentifyLayerAsync(Layer, Point, double, bool, CancellationToken)"/>
         public virtual Task<IdentifyLayerResult> IdentifyLayerAsync(Layer layer, Point screenPoint, double tolerance, bool returnPopupsOnly = false, CancellationToken cancellationToken = default) =>


### PR DESCRIPTION
Helper class for allowing you to perform view operations on the MapView from your ViewModel, through an attached proxy-object that ensures you keep VM and View separated.

Design choices:
- Basic controller for most common operations like setting viewpoint, performing identify and showing callouts. No specific mapview or sceneview operation.
- Extensible, so you can add your own custom map and scene operations, or interface for allowing testing (see WPF sample)
- No events exposed - use `EventToCommand` or similar already established approaches to forward view events back to the view model (see samples)