### PR TITLE
Fix cosmetic issues in PopupViewer on small screens

### DIFF
--- a/src/Samples/Toolkit.SampleApp.Maui/Samples/PopupViewerSample.xaml
+++ b/src/Samples/Toolkit.SampleApp.Maui/Samples/PopupViewerSample.xaml
@@ -10,9 +10,9 @@
 
 
             <Border Background="#99ffffff" x:Name="popupPanel" IsVisible="False">
-                <Border HorizontalOptions="Center" VerticalOptions="Center" Background="{AppThemeBinding Dark=Black, Light=White}" Margin="0,50" Padding="20">
+                <Border HorizontalOptions="Center" VerticalOptions="Center" Background="{AppThemeBinding Dark=Black, Light=White}" Margin="0,32" Padding="12">
                     <Grid>
-                        <esriTK:PopupViewer x:Name="popupViewer" Padding="20" MaximumWidthRequest="400" HeightRequest="400" PopupAttachmentClicked="popupViewer_PopupAttachmentClicked" />
+                        <esriTK:PopupViewer x:Name="popupViewer" Padding="12" MaximumWidthRequest="400" MaximumHeightRequest="400" PopupAttachmentClicked="popupViewer_PopupAttachmentClicked" />
                         <Button BorderWidth="0" Text="X" HorizontalOptions="End" VerticalOptions="Start" Clicked="CloseButton_Click" BackgroundColor="Transparent" TextColor="{AppThemeBinding Dark=White, Light=Black}" Margin="5" />
                     </Grid>
                 </Border>


### PR DESCRIPTION
For dotnet-api#11813

Improve appearance of PopupViewer sample on small screens by allowing height smaller than 400 dips, and by slightly reducing margins.  In a more complex app, margins would probably be adjusted by VisualState triggers, but this compromise value keeps things looking decent on all screens.

Before:
![2023-11-06_151804 qemu-system-x86_64](https://github.com/Esri/arcgis-maps-sdk-dotnet-toolkit/assets/587809/a3b38ebf-4280-49e1-a7c5-c25ede5cf886)

After:
![2023-11-06_153647 qemu-system-x86_64](https://github.com/Esri/arcgis-maps-sdk-dotnet-toolkit/assets/587809/5a8cc332-8ac4-46fe-b13a-8e4ed5a8e2c0)
