### PR TITLE
Ensure properties are preserved after trimming

### DIFF
--- a/src/Toolkit/Toolkit/UI/Controls/PopupViewer/AttachmentsPopupElementView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/PopupViewer/AttachmentsPopupElementView.cs
@@ -39,6 +39,10 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
         {
 #if MAUI
             ControlTemplate = DefaultControlTemplate;
+            // Ensure bound properties aren't trimmed:
+            _ = Element?.Title;
+            _ = Element?.Description;
+            _ = Element?.Attachments;
 #else
             DefaultStyleKey = typeof(AttachmentsPopupElementView);
 #endif

--- a/src/Toolkit/Toolkit/UI/Controls/PopupViewer/MediaPopupElementView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/PopupViewer/MediaPopupElementView.cs
@@ -33,6 +33,12 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
         {
 #if MAUI
             ControlTemplate = DefaultControlTemplate;
+            // Ensure bound properties aren't trimmed:
+            _ = Element?.Title;
+            _ = Element?.Description;
+            var m = Element?.Media?.FirstOrDefault();
+            _ = m?.Title;
+            _ = m?.Caption;
 #else
             DefaultStyleKey = typeof(MediaPopupElementView);
 #endif

--- a/src/Toolkit/Toolkit/UI/Controls/PopupViewer/PopupViewer.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/PopupViewer/PopupViewer.cs
@@ -76,6 +76,9 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         {
 #if MAUI
             ControlTemplate = DefaultControlTemplate;
+            // Ensure bound properties aren't trimmed:
+            _ = Popup?.Title;
+            _ = Popup?.EvaluatedElements;
 #else
             DefaultStyleKey = typeof(PopupViewer);
 #endif


### PR DESCRIPTION
The analyzer can't see these are used by bindings and would get trimmed away.

PopupViewer would render empty in release mode on Android.