### PR TITLE
Fix WinUI + UWP BookmarksView sample

### DIFF
--- a/src/Samples/Toolkit.SampleApp.UWP/Samples/BookmarksView/BookmarksViewSample.xaml
+++ b/src/Samples/Toolkit.SampleApp.UWP/Samples/BookmarksView/BookmarksViewSample.xaml
@@ -30,7 +30,7 @@
         </Style>
         <Style x:Key="AlternateItemContainerStyle" TargetType="ListViewItem">
             <Setter Property="Background" Value="Transparent" />
-            <Setter Property="Foreground" Value="Transparent" />
+            <Setter Property="Foreground" Value="Green" />
             <Setter Property="HorizontalContentAlignment" Value="Stretch" />
             <Setter Property="Padding" Value="8" />
             <Setter Property="Template">


### PR DESCRIPTION
Custom container text was incorrectly displaying as transparent text. This has been rectified.