### PR TITLE
BugFix: Not trimmer friendly in .NET 8

### DIFF
--- a/src/Samples/Toolkit.SampleApp.Maui/Toolkit.SampleApp.Maui.csproj
+++ b/src/Samples/Toolkit.SampleApp.Maui/Toolkit.SampleApp.Maui.csproj
@@ -10,7 +10,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
-    <!-- Display name -->
+	<WarningsAsErrors>$(WarningsAsErrors);IL2036;IL2037</WarningsAsErrors>
+
+	<!-- Display name -->
     <ApplicationTitle>Toolkit.SampleApp.Maui</ApplicationTitle>
 
     <!-- App Identifier -->

--- a/src/Samples/Toolkit.SampleApp.Maui/Toolkit.SampleApp.Maui.csproj
+++ b/src/Samples/Toolkit.SampleApp.Maui/Toolkit.SampleApp.Maui.csproj
@@ -10,9 +10,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
-	<WarningsAsErrors>$(WarningsAsErrors);IL2036;IL2037</WarningsAsErrors>
+    <WarningsAsErrors>$(WarningsAsErrors);IL2036;IL2037</WarningsAsErrors>
 
-	<!-- Display name -->
+    <!-- Display name -->
     <ApplicationTitle>Toolkit.SampleApp.Maui</ApplicationTitle>
 
     <!-- App Identifier -->

--- a/src/Toolkit/Toolkit.Maui/OverviewMap/OverviewMap.cs
+++ b/src/Toolkit/Toolkit.Maui/OverviewMap/OverviewMap.cs
@@ -33,7 +33,7 @@ public class OverviewMap : TemplatedView
     private MapView? _overviewMapView;
 
 
-    [DynamicDependency(nameof(Esri.ArcGISRuntime.Mapping.Map.LoadStatus), "Esri.ArcGISRuntime.Mapping.Map", "Esri.ArcGISRuntime")]
+    [DynamicDependency(nameof(Esri.ArcGISRuntime.Mapping.GeoModel.LoadStatus), "Esri.ArcGISRuntime.Mapping.GeoModel", "Esri.ArcGISRuntime")]
     static OverviewMap()
     {
         DefaultControlTemplate = new ControlTemplate(() =>

--- a/src/Toolkit/Toolkit/UI/Controls/PopupViewer/AttachmentsPopupElementView.Maui.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/PopupViewer/AttachmentsPopupElementView.Maui.cs
@@ -73,11 +73,11 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
         }
 
 
-        [DynamicDependency(nameof(AttachmentViewModel.Thumbnail), "Esri.ArcGISRuntime.Toolkit.Maui.Primitives.AttachmentViewModel","Esri.ArcGISRuntime")]
-        [DynamicDependency(nameof(AttachmentViewModel.Name), "Esri.ArcGISRuntime.Toolkit.Maui.Primitives.AttachmentViewModel", "Esri.ArcGISRuntime")]
-        [DynamicDependency(nameof(AttachmentViewModel.Size), "Esri.ArcGISRuntime.Toolkit.Maui.Primitives.AttachmentViewModel", "Esri.ArcGISRuntime")]
-        [DynamicDependency(nameof(AttachmentViewModel.IsDownloadButtonVisible), "Esri.ArcGISRuntime.Toolkit.Maui.Primitives.AttachmentViewModel", "Esri.ArcGISRuntime")]
-        [DynamicDependency(nameof(AttachmentViewModel.IsDownloading), "Esri.ArcGISRuntime.Toolkit.Maui.Primitives.AttachmentViewModel", "Esri.ArcGISRuntime")]
+        [DynamicDependency(nameof(AttachmentViewModel.Thumbnail), "Esri.ArcGISRuntime.Toolkit.Maui.Primitives.AttachmentsPopupElementView.AttachmentViewModel", "Esri.ArcGISRuntime.Toolkit.Maui")]
+        [DynamicDependency(nameof(AttachmentViewModel.Name), "Esri.ArcGISRuntime.Toolkit.Maui.Primitives.AttachmentsPopupElementView.AttachmentViewModel", "Esri.ArcGISRuntime.Toolkit.Maui")]
+        [DynamicDependency(nameof(AttachmentViewModel.Size), "Esri.ArcGISRuntime.Toolkit.Maui.Primitives.AttachmentsPopupElementView.AttachmentViewModel", "Esri.ArcGISRuntime.Toolkit.Maui")]
+        [DynamicDependency(nameof(AttachmentViewModel.IsDownloadButtonVisible), "Esri.ArcGISRuntime.Toolkit.Maui.Primitives.AttachmentsPopupElementView.AttachmentViewModel", "Esri.ArcGISRuntime.Toolkit.Maui")]
+        [DynamicDependency(nameof(AttachmentViewModel.IsDownloading), "Esri.ArcGISRuntime.Toolkit.Maui.Primitives.AttachmentsPopupElementView.AttachmentViewModel", "Esri.ArcGISRuntime.Toolkit.Maui")]
         private static object BuildDefaultItemTemplate()
         {
             Grid layout = new Grid();
@@ -95,7 +95,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
             layout.Add(image);
             image.SetBinding(Image.SourceProperty, new Binding(nameof(AttachmentViewModel.Thumbnail)));
             Grid.SetRowSpan(image, 2);
-            
+
             Label name = new Label() { VerticalOptions = LayoutOptions.End };
             name.SetBinding(Label.TextProperty, nameof(AttachmentViewModel.Name));
             Grid.SetColumn(name, 1);
@@ -113,7 +113,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
             Grid.SetColumn(image2, 2);
             Grid.SetRowSpan(image2, 2);
             layout.Add(image2);
-            
+
             ActivityIndicator indicator = new ActivityIndicator() { WidthRequest = 24, HeightRequest = 24, IsRunning = true };
             indicator.SetBinding(ActivityIndicator.IsRunningProperty, new Binding(nameof(AttachmentViewModel.IsDownloading)));
             Grid.SetColumn(indicator, 2);
@@ -210,7 +210,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
                     else
                         return $"{Math.Round(size / 1024d / 1024d, 1)} MB";
                 }
-            } 
+            }
 
             private void Attachment_PropertyChanged(object? sender, PropertyChangedEventArgs e)
             {
@@ -241,9 +241,9 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
                     return _thumbnail;
                 }
             }
-            
+
             public bool IsDownloadButtonVisible => !Attachment.IsLocal && Attachment.LoadStatus != LoadStatus.Loaded && Attachment.LoadStatus != LoadStatus.Loading;
-            
+
             public bool IsDownloading => !Attachment.IsLocal && Attachment.LoadStatus == LoadStatus.Loading;
 
             private void CreateThumbnail()


### PR DESCRIPTION
# BugFix: Not trimmer friendly in .NET 8 (Related Issue #538)

   - Fixed namespace for `AttachmentViewModel`.
   - Fixed namespace and ClassName for `LoadStatus` property to reference from `GeoModel` instead of `Map`.
   - Added warnings `IL2036` and `IL2037` to treat them as errors.