### PR TITLE
utilnet: localize trace tool

### DIFF
--- a/src/Toolkit/Toolkit.Maui/UtilityNetworkTraceTool/UtilityNetworkTraceTool.Appearance.cs
+++ b/src/Toolkit/Toolkit.Maui/UtilityNetworkTraceTool/UtilityNetworkTraceTool.Appearance.cs
@@ -69,6 +69,26 @@ public partial class UtilityNetworkTraceTool
     {
         const string backgroundColor = "{AppThemeBinding Dark=#353535, Light=#F8F8F8}";
         const string foregroundColor = "{AppThemeBinding Dark=#ffffff, Light=#151515}";
+
+        var noUtilityNetworks = Properties.Resources.GetString("UtilityNetworkTraceToolNoUtilityNetworks");
+        var utilityNetworks = Properties.Resources.GetString("UtilityNetworkTraceToolUtilityNetworks");
+        var traceTypes = Properties.Resources.GetString("UtilityNetworkTraceToolTraceTypes");
+        var addStartingPoint = Properties.Resources.GetString("UtilityNetworkTraceToolAddStartingPoint");
+        var cancel = Properties.Resources.GetString("UtilityNetworkTraceToolCancel");
+        var notEnoughStartingPoints = Properties.Resources.GetString("UtilityNetworkTraceToolNotEnoughStartingPoints");
+        var moreThanRequiredStartingPoints = Properties.Resources.GetString("UtilityNetworkTraceToolMoreThanRequiredStartingPoints");
+        var duplicateTrace = Properties.Resources.GetString("UtilityNetworkTraceToolDuplicateTrace");
+        var runTrace = Properties.Resources.GetString("UtilityNetworkTraceToolRunTrace");
+        var noResults = Properties.Resources.GetString("UtilityNetworkTraceToolNoResults");
+        var noFeatureResults = Properties.Resources.GetString("UtilityNetworkTraceToolNoFeatureResults");
+        var noFunctionResults = Properties.Resources.GetString("UtilityNetworkTraceToolNoFunctionResults");
+        var featureResults = Properties.Resources.GetString("UtilityNetworkTraceToolFeatureResults");
+        var functionResults = Properties.Resources.GetString("UtilityNetworkTraceToolFunctionResults");
+        var visualizationOptions = Properties.Resources.GetString("UtilityNetworkTraceToolVisualizationOptions");
+        var showGraphics = Properties.Resources.GetString("UtilityNetworkTraceToolShowGraphics");
+        var selectFeatures = Properties.Resources.GetString("UtilityNetworkTraceToolSelectFeatures");
+        var discardResult = Properties.Resources.GetString("UtilityNetworkTraceToolDiscardResult");
+
         string template =
 $@"<ControlTemplate xmlns=""http://schemas.microsoft.com/dotnet/2021/maui"" xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
 xmlns:ios=""clr-namespace:Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific;assembly=Microsoft.Maui.Controls""
@@ -86,13 +106,13 @@ xmlns:esriTK=""clr-namespace:Esri.ArcGISRuntime.Toolkit.Maui;assembly=Esri.ArcGI
         <RowDefinition Height=""*"" />
     </Grid.RowDefinitions>
     <Frame x:Name=""{nameof(PART_NoNetworksWarning)}"" BorderColor=""{{AppThemeBinding Light=#D83020, Dark=#FE583E}}"" CornerRadius=""4"" Margin=""4"" Grid.RowSpan=""3"" IsVisible=""false"">
-        <Label Text=""No utility networks found."" />
+        <Label Text=""{noUtilityNetworks}"" />
     </Frame>
     <esriTKPrim:SegmentedControl x:Name=""{nameof(PART_NavigationSegment)}"" Grid.Row=""1"" HeightRequest=""30"" />
     <VerticalStackLayout x:Name=""{nameof(PART_SelectContainer)}"" Grid.Row=""2"" Spacing=""8"">
-        <Label x:Name=""{nameof(PART_LabelNetworks)}"" Text=""Networks"" FontAttributes=""Bold"" IsVisible=""false"" />
+        <Label x:Name=""{nameof(PART_LabelNetworks)}"" Text=""{utilityNetworks}"" FontAttributes=""Bold"" IsVisible=""false"" />
         <Picker x:Name=""{nameof(PART_ListViewNetworks)}"" ItemDisplayBinding=""{{Binding Name}}"" IsVisible=""false"" BackgroundColor=""{{AppThemeBinding Light=#eaeaea,Dark=#151515}}"" Title=""Select a Utility Network"" />
-        <Label x:Name=""{nameof(PART_LabelTraceTypes)}"" Text=""Named trace configurations"" FontAttributes=""Bold"" IsVisible=""false"" />
+        <Label x:Name=""{nameof(PART_LabelTraceTypes)}"" Text=""{traceTypes}"" FontAttributes=""Bold"" IsVisible=""false"" />
         <Picker x:Name=""{nameof(PART_ListViewTraceTypes)}"" IsVisible=""false"" ItemDisplayBinding=""{{Binding Name}}"" BackgroundColor=""{{AppThemeBinding Light=#eaeaea,Dark=#151515}}"" Title=""Select a trace configuration""  />
     </VerticalStackLayout>
     <Grid x:Name=""{nameof(PART_ConfigureContainer)}"" Grid.Row=""2"">
@@ -100,8 +120,8 @@ xmlns:esriTK=""clr-namespace:Esri.ArcGISRuntime.Toolkit.Maui;assembly=Esri.ArcGI
             <RowDefinition Height=""Auto"" />
             <RowDefinition Height=""*"" />
         </Grid.RowDefinitions>
-        <Button x:Name=""{nameof(PART_ButtonAddStartingPoint)}"" Text=""Add starting point"" IsVisible=""false"" Grid.Row=""0"" />
-        <Button x:Name=""{nameof(PART_ButtonCancelAddStartingPoint)}"" Text=""Cancel"" IsVisible=""false"" Grid.Row=""0""/>
+        <Button x:Name=""{nameof(PART_ButtonAddStartingPoint)}"" Text=""{addStartingPoint}"" IsVisible=""false"" Grid.Row=""0"" />
+        <Button x:Name=""{nameof(PART_ButtonCancelAddStartingPoint)}"" Text=""{cancel}"" IsVisible=""false"" Grid.Row=""0""/>
         <CollectionView x:Name=""{nameof(PART_ListViewStartingPoints)}"" Background=""{backgroundColor}"" SelectionMode=""Single"" IsVisible=""false"" Grid.Row=""1"">
             <CollectionView.ItemTemplate>
                 <DataTemplate>
@@ -133,19 +153,19 @@ xmlns:esriTK=""clr-namespace:Esri.ArcGISRuntime.Toolkit.Maui;assembly=Esri.ArcGI
             <RowDefinition Height=""Auto"" />
         </Grid.RowDefinitions>
         <Frame x:Name=""{nameof(PART_NeedMoreStartingPointsWarning)}"" BorderColor=""{{AppThemeBinding Light=#EDD317,Dark=#FFC900}}"" CornerRadius=""4"" Margin=""4"" IsVisible=""false"" Grid.Row=""0"">
-            <Label Text=""Not enough starting points. Use the 'Configure' section to add starting points."" TextColor=""{foregroundColor}""  />
+            <Label Text=""{notEnoughStartingPoints}"" TextColor=""{foregroundColor}""  />
         </Frame>
         <Frame x:Name=""{nameof(PART_ExtraStartingPointsWarning)}"" BorderColor=""{{AppThemeBinding Light=#007AC2, Dark=#009AF2}}"" CornerRadius=""4"" Margin=""4"" IsVisible=""false"" Grid.Row=""0"">
-            <Label Text=""There are more starting points than required for the selected trace configuration."" TextColor=""{foregroundColor}""  />
+            <Label Text=""{moreThanRequiredStartingPoints}"" TextColor=""{foregroundColor}""  />
         </Frame>
         <Frame x:Name=""{nameof(PART_DuplicateTraceWarning)}"" BorderColor=""{{AppThemeBinding Light=#EDD317,Dark=#FFC900}}"" CornerRadius=""4"" Margin=""4"" IsVisible=""false"" Grid.Row=""0"">
-            <Label Text=""The selected trace configuration has already been run with the selected starting points."" TextColor=""{foregroundColor}""  />
+            <Label Text=""{duplicateTrace}"" TextColor=""{foregroundColor}""  />
         </Frame>
-        <Button x:Name=""{nameof(PART_ButtonRunTrace)}"" Text=""Run Trace"" IsVisible=""false"" Grid.Row=""2"" />
+        <Button x:Name=""{nameof(PART_ButtonRunTrace)}"" Text=""{runTrace}"" IsVisible=""false"" Grid.Row=""2"" />
     </Grid>
     <Grid x:Name=""{nameof(PART_ViewContainer)}"" Grid.Row=""2"">
         <Frame x:Name=""{nameof(PART_NoResultsWarning)}"" BorderColor=""{{AppThemeBinding Light=#D83020, Dark=#FE583E}}"" CornerRadius=""4"" Margin=""4"" IsVisible=""false"">
-            <Label Text=""No results."" TextColor=""{foregroundColor}""  />
+            <Label Text=""{noResults}"" TextColor=""{foregroundColor}""  />
         </Frame>
         <Grid x:Name=""{nameof(PART_GridResultsDisplay)}"" IsVisible=""false"">
             <BindableLayout.ItemTemplate>
@@ -153,7 +173,7 @@ xmlns:esriTK=""clr-namespace:Esri.ArcGISRuntime.Toolkit.Maui;assembly=Esri.ArcGI
                     <ScrollView>
                     <StackLayout Spacing=""8"">
                         <Label Text=""{{Binding Name}}"" FontSize=""18"" FontAttributes=""Bold"" TextColor=""{foregroundColor}""  />
-                        <Label Text=""Function results"" FontSize=""14"" TextColor=""{foregroundColor}""  />
+                        <Label Text=""{functionResults}"" FontSize=""14"" TextColor=""{foregroundColor}""  />
                         <StackLayout BindableLayout.ItemsSource=""{{Binding FunctionResults}}"">
                             <BindableLayout.ItemTemplate>
                                 <DataTemplate>
@@ -175,12 +195,12 @@ xmlns:esriTK=""clr-namespace:Esri.ArcGISRuntime.Toolkit.Maui;assembly=Esri.ArcGI
                             <BindableLayout.EmptyViewTemplate>
                                 <DataTemplate>
                                     <Frame BorderColor=""#D83020"" CornerRadius=""4"" Margin=""4"" Grid.RowSpan=""3"">
-                                        <Label Text=""No function results."" HorizontalOptions=""Center"" Padding=""16"" TextColor=""{foregroundColor}""  />
+                                        <Label Text=""{noFunctionResults}"" HorizontalOptions=""Center"" Padding=""16"" TextColor=""{foregroundColor}""  />
                                     </Frame> 
                                 </DataTemplate>
                             </BindableLayout.EmptyViewTemplate>
                         </StackLayout>
-                        <Label Text=""Feature results"" FontSize=""14"" />
+                        <Label Text=""{featureResults}"" FontSize=""14"" />
                         <StackLayout BindableLayout.ItemsSource=""{{Binding ElementResultsGrouped}}"">
                             <BindableLayout.ItemTemplate>
                                 <DataTemplate>
@@ -196,20 +216,20 @@ xmlns:esriTK=""clr-namespace:Esri.ArcGISRuntime.Toolkit.Maui;assembly=Esri.ArcGI
                             </BindableLayout.ItemTemplate>
                             <BindableLayout.EmptyViewTemplate>
                                 <DataTemplate>
-                                    <Label Text=""No feature results"" HorizontalOptions=""Center"" Padding=""16"" TextColor=""{foregroundColor}""  />
+                                    <Label Text=""{noFeatureResults}"" HorizontalOptions=""Center"" Padding=""16"" TextColor=""{foregroundColor}""  />
                                 </DataTemplate>
                             </BindableLayout.EmptyViewTemplate>
                         </StackLayout>
-                        <Label Text=""Visualization options"" FontSize=""14"" />
+                        <Label Text=""{visualizationOptions}"" FontSize=""14"" />
                         <StackLayout Orientation=""Horizontal"" Spacing=""4"">
                             <CheckBox IsChecked=""{{Binding AreGraphicsShown}}"" />
-                            <Label Text=""Show graphics on map"" VerticalOptions=""Center"" TextColor=""{foregroundColor}""  />
+                            <Label Text=""{showGraphics}"" VerticalOptions=""Center"" TextColor=""{foregroundColor}""  />
                         </StackLayout>
                         <StackLayout Orientation=""Horizontal"" Spacing=""4"">
                             <CheckBox IsChecked=""{{Binding AreFeaturesSelected}}"" />
-                            <Label Text=""Select features on map"" VerticalOptions=""Center""  TextColor=""{foregroundColor}"" />
+                            <Label Text=""{selectFeatures}"" VerticalOptions=""Center""  TextColor=""{foregroundColor}"" />
                         </StackLayout>
-                        <Button Text=""Delete result"" Command=""{{Binding DeleteCommand}}"" CommandParameter=""{{Binding}}"" />
+                        <Button Text=""{discardResult}"" Command=""{{Binding DeleteCommand}}"" CommandParameter=""{{Binding}}"" />
                     </StackLayout>
                     </ScrollView>
                 </DataTemplate>
@@ -219,7 +239,7 @@ xmlns:esriTK=""clr-namespace:Esri.ArcGISRuntime.Toolkit.Maui;assembly=Esri.ArcGI
     <Frame x:Name=""{nameof(PART_ActivityIndicator)}"" IsVisible=""false"" Grid.RowSpan=""3"" VerticalOptions=""FillAndExpand"" HorizontalOptions=""FillAndExpand"" Background=""{backgroundColor}"" HasShadow=""False"" CornerRadius=""0"" BorderColor=""{backgroundColor}"">
         <StackLayout Spacing=""8"" VerticalOptions=""Center"" HorizontalOptions=""CenterAndExpand"">
             <ActivityIndicator IsRunning=""True"" Color=""{{AppThemeBinding Light=#007AC2,Dark=#009AF2}}"" />
-            <Button x:Name=""{nameof(PART_ButtonCancelActivity)}"" Text=""Cancel"" />
+            <Button x:Name=""{nameof(PART_ButtonCancelActivity)}"" Text=""{cancel}"" />
         </StackLayout>
     </Frame>
 </Grid>

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/UtilityNetworkTraceTool/StartingPointListView.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/UtilityNetworkTraceTool/StartingPointListView.Theme.xaml
@@ -54,7 +54,7 @@
                         Margin="8,4,0,4"
                         VerticalAlignment="Center"
                         Command="{TemplateBinding CloseInspectorCommand}"
-                        Content="Close"
+                        Content="{internal:LocalizedString Key=UtilityNetworkTraceToolClose}"
                         Style="{StaticResource UNTraceIconButton}" />
                 </Grid>
                 <ContentControl

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/UtilityNetworkTraceTool/UtilityNetworkTraceTool.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/UtilityNetworkTraceTool/UtilityNetworkTraceTool.Theme.xaml
@@ -181,7 +181,7 @@
                                         <TextBlock
                                             VerticalAlignment="Center"
                                             Foreground="{Binding RelativeSource={RelativeSource AncestorType=Button}, Path=Foreground}"
-                                            Text="Zoom to" />
+                                            Text="{internal:LocalizedString Key=UtilityNetworkTraceToolZoomToResult}" />
                                     </StackPanel>
                                 </Button>
                                 <Button
@@ -191,7 +191,7 @@
                                     Style="{StaticResource UNTraceSecondaryButton}">
                                     <StackPanel VerticalAlignment="Center" Orientation="Horizontal">
                                         <Path Data="{StaticResource UNTraceIconDelete}" Style="{StaticResource UNTraceButtonEmbeddedIcon}" />
-                                        <TextBlock VerticalAlignment="Center" Text="Discard" />
+                                        <TextBlock VerticalAlignment="Center" Text="{internal:LocalizedString Key=UtilityNetworkTraceToolDiscardResult}" />
                                     </StackPanel>
                                 </Button>
                             </UniformGrid>
@@ -207,13 +207,13 @@
                                 <TextBlock
                                     Margin="4"
                                     HorizontalAlignment="Center"
-                                    Text="No results found."
+                                    Text="{internal:LocalizedString Key=UtilityNetworkTraceToolNoResults}"
                                     TextAlignment="Center"
                                     TextWrapping="Wrap" />
                             </StackPanel>
 
                             <Expander
-                                Header="Function results"
+                                Header="{internal:LocalizedString Key=UtilityNetworkTraceToolFunctionResults}"
                                 IsExpanded="True"
                                 Visibility="{Binding FunctionResults, Converter={StaticResource ListSizeVisibilityConverter}, ConverterParameter='any'}">
                                 <ListView
@@ -263,13 +263,13 @@
                             </Expander>
 
                             <Expander
-                                Header="Feature results"
+                                Header="{internal:LocalizedString Key=UtilityNetworkTraceToolFeatureResults}"
                                 IsExpanded="True"
                                 Visibility="{Binding ElementResultsGrouped.Count, Converter={StaticResource ListSizeVisibilityConverter}, ConverterParameter='any', FallbackValue=Collapsed}">
                                 <StackPanel>
                                     <CheckBox
                                         Margin="8"
-                                        Content="Select features on map"
+                                        Content="{internal:LocalizedString Key=UtilityNetworkTraceToolSelectFeatures}"
                                         IsChecked="{Binding AreFeaturesSelected, Mode=TwoWay}" />
                                     <ListView
                                         Margin="8,0,8,8"
@@ -296,13 +296,13 @@
                                 </StackPanel>
                             </Expander>
                             <Expander
-                                Header="Visualization options"
+                                Header="{internal:LocalizedString Key=UtilityNetworkTraceToolVisualizationOptions}"
                                 IsExpanded="False"
                                 Visibility="{Binding Graphics, Converter={StaticResource ListSizeVisibilityConverter}, ConverterParameter='any'}">
                                 <StackPanel Margin="8,0,8,0">
                                     <CheckBox
                                         Margin="0,8,0,0"
-                                        Content="Show graphics on map"
+                                        Content="{internal:LocalizedString Key=UtilityNetworkTraceToolShowGraphics}"
                                         IsChecked="{Binding AreGraphicsShown, Mode=TwoWay}" />
                                     <internal:ToolkitColorPalette Margin="0,8,0,0" SelectedColor="{Binding GraphicVisualizationColor, Mode=TwoWay}" />
                                     <Grid Margin="8">
@@ -313,7 +313,7 @@
                                         <TextBlock
                                             HorizontalAlignment="Right"
                                             FontWeight="SemiBold"
-                                            Text="Preview:" />
+                                            Text="{internal:LocalizedString Key=UtilityNetworkTraceToolPreview}" />
                                         <ListView
                                             Grid.Column="1"
                                             Focusable="False"
@@ -340,21 +340,21 @@
                                     </Grid>
                                 </StackPanel>
                             </Expander>
-                            <Expander Header="Trace configuration details">
+                            <Expander Header="{internal:LocalizedString Key=UtilityNetworkTraceToolTraceTypeDetails}">
                                 <StackPanel Margin="8">
-                                    <GroupBox Header="Description" Style="{StaticResource UNTraceLabelingGroupBox}">
+                                    <GroupBox Header="{internal:LocalizedString Key=UtilityNetworkTraceToolTraceTypeDescription}" Style="{StaticResource UNTraceLabelingGroupBox}">
                                         <TextBlock
                                             Margin="8,0,8,0"
                                             Text="{Binding Configuration.Description}"
                                             TextWrapping="Wrap" />
                                     </GroupBox>
-                                    <GroupBox Header="Creator" Style="{StaticResource UNTraceLabelingGroupBox}">
+                                    <GroupBox Header="{internal:LocalizedString Key=UtilityNetworkTraceToolTraceTypeCreator}" Style="{StaticResource UNTraceLabelingGroupBox}">
                                         <TextBlock
                                             Margin="8,0,8,0"
                                             Text="{Binding Configuration.Creator}"
                                             TextWrapping="Wrap" />
                                     </GroupBox>
-                                    <GroupBox Header="Tags" Style="{StaticResource UNTraceLabelingGroupBox}">
+                                    <GroupBox Header="{internal:LocalizedString Key=UtilityNetworkTraceToolTraceTypeTags}" Style="{StaticResource UNTraceLabelingGroupBox}">
                                         <ListView
                                             Margin="8,0,8,0"
                                             ItemsSource="{Binding Configuration.Tags}"
@@ -364,7 +364,7 @@
                             </Expander>
                             <Expander
                                 Foreground="{StaticResource UNTraceWarningNormal}"
-                                Header="Warnings"
+                                Header="{internal:LocalizedString Key=UtilityNetworkTraceToolWarnings}"
                                 IsExpanded="True"
                                 Visibility="{Binding Warnings.Count, Converter={StaticResource ListSizeVisibilityConverter}, ConverterParameter='any'}">
                                 <ListView
@@ -534,7 +534,7 @@
                         BorderThickness="{TemplateBinding BorderThickness}">
                         <Grid>
                             <TabControl x:Name="PART_TabsControl" Style="{StaticResource UNTraceTabControl}">
-                                <TabItem Header="New trace">
+                                <TabItem Header="{internal:LocalizedString Key=UtilityNetworkTraceToolNewTrace}">
                                     <Grid>
                                         <Grid.RowDefinitions>
                                             <RowDefinition Height="*" />
@@ -544,21 +544,21 @@
                                         <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
                                             <StackPanel Background="{StaticResource UNTraceBackground0}">
                                                 <GroupBox x:Name="PART_UtilityNetworkSelectorContainer"
-                                                    Header="Utility networks"
+                                                    Header="{internal:LocalizedString Key=UtilityNetworkTraceToolUtilityNetworks}"
                                                     Style="{StaticResource UNTraceGroupBox}">
                                                     <ComboBox x:Name="PART_UtilityNetworkSelector"
                                                         ItemTemplate="{TemplateBinding UtilityNetworkItemTemplate}"
                                                         Style="{StaticResource UNTraceComboBox}" />
                                                 </GroupBox>
                                                 <GroupBox x:Name="PART_TraceConfigurationsContainer"
-                                                    Header="Trace configurations"
+                                                    Header="{internal:LocalizedString Key=UtilityNetworkTraceToolTraceTypes}"
                                                     Style="{StaticResource UNTraceGroupBox}">
                                                     <ComboBox x:Name="PART_TraceConfigurationsSelector"
                                                         ItemTemplate="{TemplateBinding TraceTypeItemTemplate}"
                                                         Style="{StaticResource UNTraceComboBox}" />
                                                 </GroupBox>
                                                 <GroupBox x:Name="PART_StartingPointsSectionContainer"
-                                                    Header="Starting points"
+                                                    Header="{internal:LocalizedString Key=UtilityNetworkTraceToolStartingPoints}"
                                                     Style="{StaticResource UNTraceGroupBox}">
                                                     <StackPanel Orientation="Vertical">
                                                         <internal:StartingPointListView x:Name="PART_StartingPointsList"
@@ -602,7 +602,7 @@
                                                                             <GroupBox
                                                                                 BorderBrush="{StaticResource UNTraceBorder1}"
                                                                                 BorderThickness="0,1,0,0"
-                                                                                Header="Terminal"
+                                                                                Header="{internal:LocalizedString Key=UtilityNetworkTraceToolTerminal}"
                                                                                 Style="{StaticResource UNTraceGroupBox}"
                                                                                 Visibility="{Binding TerminalPickerVisible, Converter={StaticResource VisibilityConverter}}">
                                                                                 <ComboBox
@@ -614,7 +614,7 @@
                                                                             <GroupBox
                                                                                 BorderBrush="{StaticResource UNTraceBorder1}"
                                                                                 BorderThickness="0,1,0,0"
-                                                                                Header="Position along line"
+                                                                                Header="{internal:LocalizedString Key=UtilityNetworkTraceToolFractionAlongEdge}"
                                                                                 Style="{StaticResource UNTraceGroupBox}"
                                                                                 Visibility="{Binding FractionSliderVisible, Converter={StaticResource VisibilityConverter}}">
                                                                                 <Slider Style="{StaticResource UNTraceSlider}" Value="{Binding FractionAlongEdge, Mode=TwoWay}" />
@@ -622,7 +622,7 @@
                                                                             <GroupBox
                                                                                 BorderBrush="{StaticResource UNTraceBorder1}"
                                                                                 BorderThickness="0,1,0,0"
-                                                                                Header="Asset details"
+                                                                                Header="{internal:LocalizedString Key=UtilityNetworkTraceToolAssetDetails}"
                                                                                 Style="{StaticResource UNTraceGroupBox}">
                                                                                 <controls:PopupViewer PopupManager="{Binding PopupManager}">
                                                                                     <controls:PopupViewer.Template>
@@ -695,7 +695,7 @@
                                                         <TextBlock x:Name="PART_IsAddingStartingPointsIndicator"
                                                             Margin="2"
                                                             FontWeight="SemiBold"
-                                                            Text="Click on the map to identify starting points."
+                                                            Text="{internal:LocalizedString Key=UtilityNetworkTraceToolTapToIdentifyStartingPoints}"
                                                             TextAlignment="Center" />
                                                         <UniformGrid x:Name="PART_AddRemoveStartingPointButtonsContainer"
                                                             Margin="0,4,0,0"
@@ -705,7 +705,7 @@
                                                                 Style="{StaticResource UNTraceSecondaryButton}">
                                                                 <StackPanel Orientation="Horizontal">
                                                                     <Path Data="{StaticResource UNTraceIconReset}" Style="{StaticResource UNTraceButtonEmbeddedIcon}" />
-                                                                    <TextBlock Margin="0,0,4,0" Text="Remove all" />
+                                                                    <TextBlock Margin="0,0,4,0" Text="{internal:LocalizedString Key=UtilityNetworkTraceToolRemoveAllStartingPoints}" />
                                                                 </StackPanel>
                                                             </Button>
                                                             <Button x:Name="PART_AddStartingPointsButton"
@@ -714,29 +714,29 @@
                                                                 Style="{StaticResource UNTracePrimaryButton}">
                                                                 <StackPanel Orientation="Horizontal">
                                                                     <Path Data="{StaticResource UNTraceIconPlus}" Style="{StaticResource UNTraceButtonEmbeddedIcon}" />
-                                                                    <TextBlock Text="Add starting point" />
+                                                                    <TextBlock Text="{internal:LocalizedString Key=UtilityNetworkTraceToolAddStartingPoint}" />
                                                                 </StackPanel>
                                                             </Button>
                                                         </UniformGrid>
 
                                                         <Button x:Name="PART_CancelAddStartingPointsButton"
                                                             Margin="4"
-                                                            Content="Cancel"
+                                                            Content="{internal:LocalizedString Key=UtilityNetworkTraceToolCancel}"
                                                             Style="{StaticResource UNTracePrimaryButton}" />
                                                     </StackPanel>
                                                 </GroupBox>
-                                                <Expander x:Name="PART_AdvancedOptionsContainer" Header="Advanced options">
+                                                <Expander x:Name="PART_AdvancedOptionsContainer" Header="{internal:LocalizedString Key=UtilityNetworkTraceToolAdvancedOptions}">
                                                     <StackPanel Margin="8">
                                                         <CheckBox
                                                             Margin="0,0,0,8"
-                                                            Content="Zoom to result"
+                                                            Content="{internal:LocalizedString Key=UtilityNetworkTraceToolZoomToResult}"
                                                             IsChecked="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=AutoZoomToTraceResults, Mode=TwoWay}" />
-                                                        <GroupBox Header="Result name (optional)" Style="{StaticResource UNTraceLabelingGroupBox}">
+                                                        <GroupBox Header="{internal:LocalizedString Key=UtilityNetworkTraceToolResultName}" Style="{StaticResource UNTraceLabelingGroupBox}">
                                                             <TextBox x:Name="PART_ResultNameTextBox" Style="{StaticResource UNTraceTextBox}" />
                                                         </GroupBox>
                                                         <GroupBox
                                                             Margin="0,8,0,0"
-                                                            Header="Result visualization color"
+                                                            Header="{internal:LocalizedString Key=UtilityNetworkTraceToolResultVisualizationColor}"
                                                             Style="{StaticResource UNTraceLabelingGroupBox}">
                                                             <StackPanel>
                                                                 <internal:ToolkitColorPalette x:Name="PART_ResultColorPalette" />
@@ -748,7 +748,7 @@
                                                                     <TextBlock
                                                                         HorizontalAlignment="Right"
                                                                         FontWeight="SemiBold"
-                                                                        Text="Preview:" />
+                                                                        Text="{internal:LocalizedString Key=UtilityNetworkTraceToolPreview}" />
                                                                     <StackPanel Grid.Column="1" Orientation="Horizontal">
                                                                         <controls:SymbolDisplay Margin="4,0,0,0" Symbol="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ResultPointSymbol}" />
                                                                         <controls:SymbolDisplay Margin="4,0,0,0" Symbol="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ResultLineSymbol}" />
@@ -769,7 +769,7 @@
                                                         Margin="0,4,0,0"
                                                         HorizontalAlignment="Center"
                                                         FontWeight="SemiBold"
-                                                        Text="No named trace configurations found for the selected utility network."
+                                                        Text="{internal:LocalizedString Key=UtilityNetworkTraceToolNoTraceTypes}"
                                                         TextAlignment="Center"
                                                         TextWrapping="Wrap" />
                                                 </StackPanel>
@@ -785,7 +785,7 @@
                                                         <ColumnDefinition Width="*" />
                                                     </Grid.ColumnDefinitions>
                                                     <Path Style="{StaticResource UNTraceIcon32Warning}" />
-                                                    <TextBlock Style="{StaticResource UNTraceAlertText}" Text="The selected trace configuration requires additional starting points." />
+                                                    <TextBlock Style="{StaticResource UNTraceAlertText}" Text="{internal:LocalizedString Key=UtilityNetworkTraceToolNotEnoughStartingPoints}" />
                                                 </Grid>
                                             </Border>
                                             <Border x:Name="PART_DuplicateTraceWarningContainer"
@@ -797,7 +797,7 @@
                                                         <ColumnDefinition Width="*" />
                                                     </Grid.ColumnDefinitions>
                                                     <Path Style="{StaticResource UNTraceIcon32Warning}" />
-                                                    <TextBlock Style="{StaticResource UNTraceAlertText}" Text="The selected trace configuration has already been run with the selected starting points." />
+                                                    <TextBlock Style="{StaticResource UNTraceAlertText}" Text="{internal:LocalizedString Key=UtilityNetworkTraceToolDuplicateTrace}" />
                                                 </Grid>
                                             </Border>
                                             <Border x:Name="PART_ExtraStartingPointsWarningContainer"
@@ -810,14 +810,14 @@
                                                         <ColumnDefinition Width="*" />
                                                     </Grid.ColumnDefinitions>
                                                     <Path Data="{StaticResource UNTraceIconAlertInfo}" Style="{StaticResource UNTraceIcon32Info}" />
-                                                    <TextBlock Style="{StaticResource UNTraceAlertText}" Text="There are more starting points than required for the selected trace configuration." />
+                                                    <TextBlock Style="{StaticResource UNTraceAlertText}" Text="{internal:LocalizedString Key=UtilityNetworkTraceToolMoreThanRequiredStartingPoints}" />
                                                 </Grid>
                                             </Border>
                                         </Grid>
                                         <Button x:Name="PART_RunTraceButton"
                                             Grid.Row="2"
                                             Margin="4"
-                                            Content="Run trace"
+                                            Content="{internal:LocalizedString Key=UtilityNetworkTraceToolRunTrace}"
                                             Style="{StaticResource UNTracePrimaryButton}" />
                                         <Grid x:Name="PART_TraceInProgressIndicator"
                                             Grid.RowSpan="3"
@@ -828,11 +828,11 @@
                                                 Orientation="Vertical">
                                                 <TextBlock
                                                     HorizontalAlignment="Center"
-                                                    Text="Running trace..."
+                                                    Text="{internal:LocalizedString Key=UtilityNetworkTraceToolRuningTrace}"
                                                     TextAlignment="Center" />
                                                 <ProgressBar Style="{StaticResource UNTraceProgressBar}" />
                                                 <Button x:Name="PART_CancelTraceButton"
-                                                    Content="Cancel"
+                                                    Content="{internal:LocalizedString Key=UtilityNetworkTraceToolCancel}"
                                                     Style="{StaticResource UNTracePrimaryButton}" />
                                             </StackPanel>
                                         </Grid>
@@ -845,18 +845,18 @@
                                                 Orientation="Vertical">
                                                 <TextBlock
                                                     HorizontalAlignment="Center"
-                                                    Text="Identifying starting points..."
+                                                    Text="{internal:LocalizedString Key=UtilityNetworkTraceToolIdentifyingStartingPoints}"
                                                     TextAlignment="Center"
                                                     TextWrapping="Wrap" />
                                                 <ProgressBar Style="{StaticResource UNTraceProgressBar}" />
                                                 <Button x:Name="PART_CancelIdentifyButton"
-                                                    Content="Cancel"
+                                                    Content="{internal:LocalizedString Key=UtilityNetworkTraceToolCancel}"
                                                     Style="{StaticResource UNTracePrimaryButton}" />
                                             </StackPanel>
                                         </Grid>
                                     </Grid>
                                 </TabItem>
-                                <TabItem x:Name="PART_ResultsTabItem" Header="Results">
+                                <TabItem x:Name="PART_ResultsTabItem" Header="{internal:LocalizedString Key=UtilityNetworkTraceToolResults}">
                                     <Grid Background="{StaticResource UNTraceBackground0}">
                                         <Grid.RowDefinitions>
                                             <RowDefinition Height="*" />
@@ -874,7 +874,7 @@
                                         <Button x:Name="PART_DeleteAllResultsButton"
                                             Grid.Row="2"
                                             Margin="4"
-                                            Content="Clear results"
+                                            Content="{internal:LocalizedString Key=UtilityNetworkTraceToolClearResults}"
                                             Style="{StaticResource UNTracePrimaryButton}" />
                                     </Grid>
                                 </TabItem>
@@ -889,7 +889,7 @@
                                         Margin="4"
                                         HorizontalAlignment="Center"
                                         FontWeight="SemiBold"
-                                        Text="No utility networks found."
+                                        Text="{internal:LocalizedString Key=UtilityNetworkTraceToolNoUtilityNetworks}"
                                         TextAlignment="Center"
                                         TextWrapping="Wrap" />
                                 </StackPanel>
@@ -901,7 +901,7 @@
                                     Orientation="Vertical">
                                     <TextBlock
                                         HorizontalAlignment="Center"
-                                        Text="Loading..."
+                                        Text="{internal:LocalizedString Key=UtilityNetworkTraceToolLoading}"
                                         TextAlignment="Center" />
                                     <ProgressBar Style="{StaticResource UNTraceProgressBar}" />
                                 </StackPanel>

--- a/src/Toolkit/Toolkit.WinUI/UI/Controls/UtilityNetworkTraceTool/StartingPointListView.Theme.xaml
+++ b/src/Toolkit/Toolkit.WinUI/UI/Controls/UtilityNetworkTraceTool/StartingPointListView.Theme.xaml
@@ -24,12 +24,12 @@
 					<StackPanel Margin="4" Orientation="Horizontal">
 						<Button
                             Command="{TemplateBinding SelectPreviousItemCommand}"
-                            Content="Previous"
+                            Content="{internal:LocalizedString Key=UtilityNetworkTraceToolPrevious}"
                             Style="{StaticResource UNTraceIconButton}" />
 						<TextBlock Margin="8,0,8,0" Text="{TemplateBinding InspectorViewSelectionLabelText}" />
 						<Button
                             Command="{TemplateBinding SelectNextItemCommand}"
-                            Content="Next"
+                            Content="{internal:LocalizedString Key=UtilityNetworkTraceToolSelectNext}"
                             Style="{StaticResource UNTraceIconButton}" />
 					</StackPanel>
 					<Button
@@ -53,7 +53,7 @@
                         Margin="8,4,0,4"
                         VerticalAlignment="Center"
                         Command="{TemplateBinding CloseInspectorCommand}"
-                        Content="Close"
+                        Content="{internal:LocalizedString Key=UtilityNetworkTraceToolNext}"
                         Style="{StaticResource UNTraceIconButton}" />
 				</Grid>
 				<ContentControl

--- a/src/Toolkit/Toolkit.WinUI/UI/Controls/UtilityNetworkTraceTool/UtilityNetworkTraceTool.Theme.xaml
+++ b/src/Toolkit/Toolkit.WinUI/UI/Controls/UtilityNetworkTraceTool/UtilityNetworkTraceTool.Theme.xaml
@@ -159,7 +159,7 @@
                                 Margin="4,0,0,0"
                                 Command="{Binding ZoomToCommand}"
                                 CommandParameter="{Binding}"
-                                Content="Zoom to"
+                                Content="{internal:LocalizedString Key=UtilityNetworkTraceToolZoomToResult}"
                                 Style="{StaticResource UNTraceSecondaryButton}"
                                 Visibility="{Binding HasAnyResults, Converter={StaticResource VisibilityConverter}}" />
                             <Button
@@ -167,7 +167,7 @@
                                 Margin="4,0,4,0"
                                 Command="{Binding DeleteCommand}"
                                 CommandParameter="{Binding}"
-                                Content="Discard"
+                                Content="{internal:LocalizedString Key=UtilityNetworkTraceToolDiscardResult}"
                                 Style="{StaticResource UNTraceSecondaryButton}" />
                         </Grid>
                         <StackPanel Grid.Row="1" Orientation="Vertical">
@@ -182,12 +182,11 @@
                                     Margin="4"
                                     HorizontalAlignment="Center"
                                     Style="{StaticResource UNTraceBasicText}"
-                                    Text="No results found."
+                                    Text="{internal:LocalizedString Key=UtilityNetworkTraceToolNoResults}"
                                     TextAlignment="Center" />
                             </StackPanel>
-
                             <internal:Expander
-                                Header="Function results"
+                                Header="{internal:LocalizedString Key=UtilityNetworkTraceToolFunctionResults}"
                                 IsExpanded="True"
                                 Visibility="{Binding FunctionResults, Converter={StaticResource ListSizeVisibilityConverter}, ConverterParameter='any'}">
                                 <ListView
@@ -235,13 +234,13 @@
                             </internal:Expander>
 
                             <internal:Expander
-                                Header="Feature results"
+                                Header="{internal:LocalizedString Key=UtilityNetworkTraceToolFeatureResults}"
                                 IsExpanded="True"
                                 Visibility="{Binding ElementResultsGrouped.Count, Converter={StaticResource ListSizeVisibilityConverter}, ConverterParameter='any', FallbackValue=Collapsed}">
                                 <StackPanel>
                                     <CheckBox
                                         Margin="8"
-                                        Content="Select features on map"
+                                        Content="{internal:LocalizedString Key=UtilityNetworkTraceToolSelectFeatures}"
                                         IsChecked="{Binding AreFeaturesSelected, Mode=TwoWay}"
                                         Style="{StaticResource UNTraceCheckBox}" />
                                     <ListView
@@ -271,13 +270,13 @@
                                 </StackPanel>
                             </internal:Expander>
                             <internal:Expander
-                                Header="Visualization options"
+                                Header="{internal:LocalizedString Key=UtilityNetworkTraceToolVisualizationOptions}"
                                 IsExpanded="False"
                                 Visibility="{Binding Graphics, Converter={StaticResource ListSizeVisibilityConverter}, ConverterParameter='any'}">
                                 <StackPanel Margin="8,0,8,0">
                                     <CheckBox
                                         Margin="0,8,0,0"
-                                        Content="Show graphics on map"
+                                        Content="{internal:LocalizedString Key=UtilityNetworkTraceToolShowGraphics}"
                                         IsChecked="{Binding AreGraphicsShown, Mode=TwoWay}"
                                         Style="{StaticResource UNTraceCheckBox}" />
                                     <internal:ToolkitColorPalette Margin="0,8,0,0" SelectedColor="{Binding GraphicVisualizationColor, Mode=TwoWay}" />
@@ -289,7 +288,7 @@
                                         <TextBlock
                                             HorizontalAlignment="Right"
                                             Style="{StaticResource UNTraceBoldText}"
-                                            Text="Preview:" />
+                                            Text="{internal:LocalizedString Key=UtilityNetworkTraceToolPreview}" />
                                         <ListView
                                             Grid.Column="1"
                                             ItemsSource="{Binding Graphics}"
@@ -317,21 +316,21 @@
                                     </Grid>
                                 </StackPanel>
                             </internal:Expander>
-                            <internal:Expander Header="Trace configuration details">
+                            <internal:Expander Header="{internal:LocalizedString Key=UtilityNetworkTraceToolTraceTypeDetails}">
                                 <StackPanel Margin="8">
-                                    <internal:GroupBox Header="Description" Style="{StaticResource UNTraceLabelingGroupBox}">
+                                    <internal:GroupBox Header="{internal:LocalizedString Key=UtilityNetworkTraceToolTraceTypeDescription}" Style="{StaticResource UNTraceLabelingGroupBox}">
                                         <TextBlock
                                             Margin="8,0,8,0"
                                             Style="{StaticResource UNTraceBasicText}"
                                             Text="{Binding Configuration.Description}" />
                                     </internal:GroupBox>
-                                    <internal:GroupBox Header="Creator" Style="{StaticResource UNTraceLabelingGroupBox}">
+                                    <internal:GroupBox Header="{internal:LocalizedString Key=UtilityNetworkTraceToolTraceTypeCreator}" Style="{StaticResource UNTraceLabelingGroupBox}">
                                         <TextBlock
                                             Margin="8,0,8,0"
                                             Style="{StaticResource UNTraceBasicText}"
                                             Text="{Binding Configuration.Creator}" />
                                     </internal:GroupBox>
-                                    <internal:GroupBox Header="Tags" Style="{StaticResource UNTraceLabelingGroupBox}">
+                                    <internal:GroupBox Header="{internal:LocalizedString Key=UtilityNetworkTraceToolTraceTypeTags}" Style="{StaticResource UNTraceLabelingGroupBox}">
                                         <ListView
                                             Margin="8,0,8,0"
                                             ItemsSource="{Binding Configuration.Tags}"
@@ -341,7 +340,7 @@
                             </internal:Expander>
                             <internal:Expander
                                 Foreground="{StaticResource UNTraceWarningNormal}"
-                                Header="Warnings"
+                                Header="{internal:LocalizedString Key=UtilityNetworkTraceToolWarnings}"
                                 IsExpanded="True"
                                 Visibility="{Binding Warnings.Count, Converter={StaticResource ListSizeVisibilityConverter}, ConverterParameter='any'}">
                                 <ListView
@@ -424,7 +423,8 @@
                             Visibility="{Binding TerminalPickerVisible, Converter={StaticResource VisibilityConverter}}">
                             <ComboBox.ItemTemplate>
                                 <DataTemplate>
-                                    <TextBlock Style="{StaticResource UNTraceBasicText}" Text="{Binding Name}" />
+                                    <TextBlock Style="{StaticResource UNTraceBasicText}"
+                                               Text="{Binding Name}" />
                                 </DataTemplate>
                             </ComboBox.ItemTemplate>
                         </ComboBox>
@@ -488,7 +488,7 @@
                                 <PivotItem
                                     Margin="0"
                                     Background="{StaticResource UNTraceBackground0}"
-                                    Header="New trace">
+                                    Header="{internal:LocalizedString Key=UtilityNetworkTraceToolNewTrace}">
                                     <Grid>
                                         <Grid.RowDefinitions>
                                             <RowDefinition Height="*" />
@@ -499,13 +499,13 @@
                                             <StackPanel>
                                                 <internal:GroupBox
                                                     x:Name="PART_UtilityNetworkSelectorContainer"
-                                                    Header="Utility networks"
+                                                    Header="{internal:LocalizedString Key=UtilityNetworkTraceToolUtilityNetworks}"
                                                     Style="{StaticResource UNTraceGroupBox}">
                                                     <ComboBox x:Name="PART_UtilityNetworkSelector" Style="{StaticResource UNTraceComboBox}" />
                                                 </internal:GroupBox>
                                                 <internal:GroupBox
                                                     x:Name="PART_TraceConfigurationsContainer"
-                                                    Header="Trace configurations"
+                                                    Header="{internal:LocalizedString Key=UtilityNetworkTraceToolTraceTypes}"
                                                     Style="{StaticResource UNTraceGroupBox}">
                                                     <ComboBox
                                                         x:Name="PART_TraceConfigurationsSelector"
@@ -517,7 +517,7 @@
                                                 <internal:GroupBox
                                                     x:Name="PART_StartingPointsSectionContainer"
                                                     HorizontalAlignment="Stretch"
-                                                    Header="Starting points"
+                                                    Header="{internal:LocalizedString Key=UtilityNetworkTraceToolStartingPoints}"
                                                     Style="{StaticResource UNTraceGroupBox}">
                                                     <StackPanel Orientation="Vertical">
                                                         <Grid
@@ -533,21 +533,21 @@
                                                                 HorizontalAlignment="Stretch"
                                                                 Command="{Binding ElementName=PART_StartingPointsList, Path=ZoomToCommand, Mode=OneWay}"
                                                                 CommandParameter="{Binding ElementName=PART_StartingPointsList, Path=SelectedItem, Mode=OneWay}"
-                                                                Content="Zoom"
+                                                                Content="{internal:LocalizedString Key=UtilityNetworkTraceToolZoomStartingPoint}"
                                                                 Style="{StaticResource UNTraceSecondaryButton}" />
                                                             <Button
                                                                 Grid.Column="1"
                                                                 HorizontalAlignment="Stretch"
                                                                 Command="{Binding ElementName=PART_StartingPointsList, Path=OpenInspectorCommand, Mode=OneWay}"
                                                                 CommandParameter="{Binding ElementName=PART_StartingPointsList, Path=SelectedItem, Mode=OneWay}"
-                                                                Content="Inspect"
+                                                                Content="{internal:LocalizedString Key=UtilityNetworkTraceToolInspectStartingPoint}"
                                                                 Style="{StaticResource UNTraceSecondaryButton}" />
                                                             <Button
                                                                 Grid.Column="2"
                                                                 HorizontalAlignment="Stretch"
                                                                 Command="{Binding ElementName=PART_StartingPointsList, Path=DeleteSelectedCommand, Mode=OneWay}"
                                                                 CommandParameter="{Binding ElementName=PART_StartingPointsList, Path=SelectedItem, Mode=OneWay}"
-                                                                Content="Delete"
+                                                                Content="{internal:LocalizedString Key=UtilityNetworkTraceToolRemoveStartingPoint}"
                                                                 Style="{StaticResource UNTraceSecondaryButton}" />
                                                         </Grid>
                                                         <internal:StartingPointListView x:Name="PART_StartingPointsList" ItemTemplate="{TemplateBinding StartingPointItemTemplate}">
@@ -589,7 +589,7 @@
                                                                             <internal:GroupBox
                                                                                 BorderBrush="{StaticResource UNTraceBorder1}"
                                                                                 BorderThickness="0,1,0,0"
-                                                                                Header="Terminal"
+                                                                                Header="{internal:LocalizedString Key=UtilityNetworkTraceToolTerminal}"
                                                                                 Style="{StaticResource UNTraceGroupBox}"
                                                                                 Visibility="{Binding TerminalPickerVisible, Converter={StaticResource VisibilityConverter}}">
                                                                                 <ComboBox
@@ -601,7 +601,7 @@
                                                                             <internal:GroupBox
                                                                                 BorderBrush="{StaticResource UNTraceBorder1}"
                                                                                 BorderThickness="0,1,0,0"
-                                                                                Header="Position along line"
+                                                                                Header="{internal:LocalizedString Key=UtilityNetworkTraceToolFractionAlongEdge}"
                                                                                 Style="{StaticResource UNTraceGroupBox}"
                                                                                 Visibility="{Binding FractionSliderVisible, Converter={StaticResource VisibilityConverter}}">
                                                                                 <Slider Style="{StaticResource UNTraceSlider}" Value="{Binding FractionAlongEdge, Mode=TwoWay}" />
@@ -609,7 +609,7 @@
                                                                             <internal:GroupBox
                                                                                 BorderBrush="{StaticResource UNTraceBorder1}"
                                                                                 BorderThickness="0,1,0,0"
-                                                                                Header="Asset details"
+                                                                                Header="{internal:LocalizedString Key=UtilityNetworkTraceToolAssetDetails}"
                                                                                 Style="{StaticResource UNTraceGroupBox}">
                                                                                 <controls:PopupViewer PopupManager="{Binding PopupManager}">
                                                                                     <controls:PopupViewer.Template>
@@ -676,12 +676,11 @@
                                                                 </DataTemplate>
                                                             </internal:StartingPointListView.InspectorViewTemplate>
                                                         </internal:StartingPointListView>
-
                                                         <TextBlock
                                                             x:Name="PART_IsAddingStartingPointsIndicator"
                                                             Margin="2"
                                                             Style="{StaticResource UNTraceBoldText}"
-                                                            Text="Click on the map to identify starting points."
+                                                            Text="{internal:LocalizedString Key=UtilityNetworkTraceToolTapToIdentifyStartingPoints}"
                                                             TextAlignment="Center" />
                                                         <StackPanel
                                                             x:Name="PART_AddRemoveStartingPointButtonsContainer"
@@ -689,35 +688,35 @@
                                                             Spacing="4">
                                                             <Button
                                                                 x:Name="PART_ResetStartingPointsButton"
-                                                                Content="Remove all"
+                                                            	Content="{internal:LocalizedString Key=UtilityNetworkTraceToolRemoveAllStartingPoints}"
                                                                 Style="{StaticResource UNTraceSecondaryButton}" />
                                                             <Button
                                                                 x:Name="PART_AddStartingPointsButton"
-                                                                Content="Add starting point"
+                                                            	Content="{internal:LocalizedString Key=UtilityNetworkTraceToolAddStartingPoint}"
                                                                 Style="{StaticResource UNTracePrimaryButton}" />
                                                         </StackPanel>
-
                                                         <Button
                                                             x:Name="PART_CancelAddStartingPointsButton"
                                                             Margin="4"
                                                             HorizontalAlignment="Stretch"
-                                                            Content="Cancel"
+                                                            Content="{internal:LocalizedString Key=UtilityNetworkTraceToolCancel}"
                                                             Style="{StaticResource UNTracePrimaryButton}" />
                                                     </StackPanel>
                                                 </internal:GroupBox>
-                                                <internal:Expander x:Name="PART_AdvancedOptionsContainer" Header="Advanced options">
+                                                <internal:Expander x:Name="PART_AdvancedOptionsContainer" Header="{internal:LocalizedString Key=UtilityNetworkTraceToolAdvancedOptions}">
                                                     <StackPanel Margin="8">
                                                         <CheckBox
                                                             Margin="0,0,0,8"
-                                                            Content="Zoom to result"
+                                                            Content="{internal:LocalizedString Key=UtilityNetworkTraceToolZoomToResult}"
                                                             IsChecked="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=AutoZoomToTraceResults, Mode=TwoWay}"
                                                             Style="{StaticResource UNTraceCheckBox}" />
-                                                        <internal:GroupBox Header="Result name (optional)" Style="{StaticResource UNTraceLabelingGroupBox}">
-                                                            <TextBox x:Name="PART_ResultNameTextBox" Style="{StaticResource UNTraceTextBoxStyle}" />
+                                                        <internal:GroupBox Header="{internal:LocalizedString Key=UtilityNetworkTraceToolResultName}" Style="{StaticResource UNTraceLabelingGroupBox}">
+                                                            <TextBox x:Name="PART_ResultNameTextBox"
+                                                                     Style="{StaticResource UNTraceTextBoxStyle}" />
                                                         </internal:GroupBox>
                                                         <internal:GroupBox
                                                             Margin="0,8,0,0"
-                                                            Header="Result visualization color"
+                                                            Header="{internal:LocalizedString Key=UtilityNetworkTraceToolResultVisualizationColor}"
                                                             Style="{StaticResource UNTraceLabelingGroupBox}">
                                                             <StackPanel>
                                                                 <internal:ToolkitColorPalette x:Name="PART_ResultColorPalette" />
@@ -729,7 +728,7 @@
                                                                     <TextBlock
                                                                         HorizontalAlignment="Right"
                                                                         Style="{StaticResource UNTraceBoldText}"
-                                                                        Text="Preview:" />
+                                                                        Text="{internal:LocalizedString Key=UtilityNetworkTraceToolPreview}" />
                                                                     <StackPanel Grid.Column="1" Orientation="Horizontal">
                                                                         <controls:SymbolDisplay Margin="4,0,0,0" Symbol="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ResultPointSymbol}" />
                                                                         <controls:SymbolDisplay Margin="4,0,0,0" Symbol="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ResultLineSymbol}" />
@@ -754,7 +753,7 @@
                                                         Margin="0,4,0,0"
                                                         HorizontalAlignment="Center"
                                                         Style="{StaticResource UNTraceBoldText}"
-                                                        Text="No named trace configurations found for the selected utility network."
+                                                        Text="{internal:LocalizedString Key=UtilityNetworkTraceToolNoTraceTypes}"
                                                         TextAlignment="Center" />
                                                 </StackPanel>
                                             </StackPanel>
@@ -771,7 +770,7 @@
                                                         <ColumnDefinition Width="*" />
                                                     </Grid.ColumnDefinitions>
                                                     <Path Style="{StaticResource UNTraceIcon32Warning}" />
-                                                    <TextBlock Style="{StaticResource UNTraceAlertText}" Text="The selected trace configuration requires additional starting points." />
+                                                    <TextBlock Style="{StaticResource UNTraceAlertText}" Text="{internal:LocalizedString Key=UtilityNetworkTraceToolNotEnoughStartingPoints}" />
                                                 </Grid>
                                             </Border>
                                             <Border
@@ -785,7 +784,7 @@
                                                         <ColumnDefinition Width="*" />
                                                     </Grid.ColumnDefinitions>
                                                     <Path Style="{StaticResource UNTraceIcon32Warning}" />
-                                                    <TextBlock Style="{StaticResource UNTraceAlertText}" Text="The selected trace configuration has already been run with the selected starting points." />
+                                                    <TextBlock Style="{StaticResource UNTraceAlertText}" Text="{internal:LocalizedString Key=UtilityNetworkTraceToolDuplicateTrace}" />
                                                 </Grid>
                                             </Border>
                                             <Border
@@ -794,13 +793,13 @@
                                                 BorderBrush="{StaticResource UNTraceTintNormal}"
                                                 BorderThickness="1,3,1,1"
                                                 Style="{StaticResource UNTraceFloatingWarningBorderStyle}">
-                                                <TextBlock Style="{StaticResource UNTraceAlertText}" Text="There are more starting points than required for the selected trace configuration." />
+                                                <TextBlock Style="{StaticResource UNTraceAlertText}" Text="{internal:LocalizedString Key=UtilityNetworkTraceToolMoreThanRequiredStartingPoints}" />
                                             </Border>
                                         </Grid>
                                         <Button
                                             x:Name="PART_RunTraceButton"
                                             Grid.Row="2"
-                                            Content="Run trace"
+                                            Content="{internal:LocalizedString Key=UtilityNetworkTraceToolRunTrace}"
                                             Style="{StaticResource UNTracePrimaryButton}" />
                                         <Grid
                                             x:Name="PART_TraceInProgressIndicator"
@@ -814,12 +813,12 @@
                                                 <TextBlock
                                                     HorizontalAlignment="Center"
                                                     Style="{StaticResource UNTraceBasicText}"
-                                                    Text="Running trace..."
+                                                    Text="{internal:LocalizedString Key=UtilityNetworkTraceToolRuningTrace}"
                                                     TextAlignment="Center" />
                                                 <ProgressBar IsIndeterminate="True" />
                                                 <Button
                                                     x:Name="PART_CancelTraceButton"
-                                                    Content="Cancel"
+                                                    Content="{internal:LocalizedString Key=UtilityNetworkTraceToolCancel}"
                                                     Style="{StaticResource UNTracePrimaryButton}" />
                                             </StackPanel>
                                         </Grid>
@@ -835,12 +834,12 @@
                                                 <TextBlock
                                                     HorizontalAlignment="Center"
                                                     Style="{StaticResource UNTraceBasicText}"
-                                                    Text="Identifying starting points..."
+                                                    Text="{internal:LocalizedString Key=UtilityNetworkTraceToolIdentifyingStartingPoints}"
                                                     TextAlignment="Center" />
                                                 <ProgressBar IsIndeterminate="True" />
                                                 <Button
                                                     x:Name="PART_CancelIdentifyButton"
-                                                    Content="Cancel"
+                                                    Content="{internal:LocalizedString Key=UtilityNetworkTraceToolCancel}"
                                                     Style="{StaticResource UNTracePrimaryButton}" />
                                             </StackPanel>
                                         </Grid>
@@ -850,7 +849,7 @@
                                     x:Name="PART_ResultsTabItem"
                                     Margin="0"
                                     Background="{StaticResource UNTraceBackground0}"
-                                    Header="Results">
+                                    Header="{internal:LocalizedString Key=UtilityNetworkTraceToolResults}">
                                     <Grid>
                                         <Grid.RowDefinitions>
                                             <RowDefinition Height="*" />
@@ -878,7 +877,7 @@
                                             Grid.Row="2"
                                             Margin="4"
                                             HorizontalAlignment="Stretch"
-                                            Content="Clear results"
+                                            Content="{internal:LocalizedString Key=UtilityNetworkTraceToolClearResults}"
                                             Style="{StaticResource UNTracePrimaryButton}" />
                                     </Grid>
                                 </PivotItem>
@@ -897,7 +896,7 @@
                                         Margin="4"
                                         HorizontalAlignment="Center"
                                         Style="{StaticResource UNTraceBoldText}"
-                                        Text="No utility networks found."
+                                        Text="{internal:LocalizedString Key=UtilityNetworkTraceToolNoUtilityNetworks}"
                                         TextAlignment="Center" />
                                 </StackPanel>
                             </Grid>
@@ -910,7 +909,7 @@
                                     <TextBlock
                                         HorizontalAlignment="Center"
                                         Style="{StaticResource UNTraceBasicText}"
-                                        Text="Loading..."
+                                        Text="{internal:LocalizedString Key=UtilityNetworkTraceToolLoading}"
                                         TextAlignment="Center" />
                                     <ProgressBar IsIndeterminate="True" />
                                 </StackPanel>

--- a/src/Toolkit/Toolkit/LocalizedStrings/Resources.resx
+++ b/src/Toolkit/Toolkit/LocalizedStrings/Resources.resx
@@ -361,14 +361,6 @@
     <value>No results found.</value>
     <comment>The warning message when trace returned an empty result.</comment>
   </data>
-  <data name="UtilityNetworkTraceToolNoSelectedTraceType" xml:space="preserve">
-    <value>No trace type selected.</value>
-    <comment>The error message when attempting to trace without a selected trace type.</comment>
-  </data>
-  <data name="UtilityNetworkTraceToolNoSelectedUtilityNetwork" xml:space="preserve">
-    <value>No utility network selected.</value>
-    <comment>The error message when attempting to trace without a selected utility network.</comment>
-  </data>
   <data name="UtilityNetworkTraceToolNotEnoughStartingPoints" xml:space="preserve">
     <value>The selected trace type requires additional starting points.</value>
     <comment>The warning message when there are fewer starting points than the selected trace type requires.</comment>

--- a/src/Toolkit/Toolkit/LocalizedStrings/Resources.resx
+++ b/src/Toolkit/Toolkit/LocalizedStrings/Resources.resx
@@ -281,4 +281,200 @@
     <value>Search</value>
     <comment>The tooltip text to display for the search button.</comment>
   </data>
+  <data name="UtilityNetworkTraceToolAddStartingPoint" xml:space="preserve">
+    <value>Add starting point</value>
+    <comment>The text on button for adding starting points.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolAdvancedOptions" xml:space="preserve">
+    <value>Advanced options</value>
+    <comment>The text for expanding advanced options to specify trace result name, color, and zoom to result behavior.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolAssetDetails" xml:space="preserve">
+    <value>Asset details</value>
+    <comment>The text for listing the asset information of the starting point.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolCancel" xml:space="preserve">
+    <value>Cancel</value>
+    <comment>The text on button to cancel adding starting points or running the trace.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolClearResults" xml:space="preserve">
+    <value>Clear results</value>
+    <comment>The text on button for discarding all trace results.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolClose" xml:space="preserve">
+    <value>Close</value>
+    <comment>The text on button for closing the starting point's information.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolDiscardResult" xml:space="preserve">
+    <value>Discard</value>
+    <comment>The text on button that discards the selected trace result.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolDuplicateTrace" xml:space="preserve">
+    <value>The selected trace type has already been run with the same starting points.</value>
+    <comment>The warning message when prior trace ran with the same trace type and starting points.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolFeatureResults" xml:space="preserve">
+    <value>Feature results</value>
+    <comment>The text for expanding feature result collection.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolFractionAlongEdge" xml:space="preserve">
+    <value>Position along line</value>
+    <comment>The text for updating the point location along the line.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolFunctionResults" xml:space="preserve">
+    <value>Function results</value>
+    <comment>The text for expanding  function result collection.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolIdentifyingStartingPoints" xml:space="preserve">
+    <value>Identifying starting points...</value>
+    <comment>The status message when tapping on features to add as starting points.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolInspectStartingPoint" xml:space="preserve">
+    <value>Inspect</value>
+    <comment>The text on button for displaying the current starting point's information.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolLoading" xml:space="preserve">
+    <value>Loading...</value>
+    <comment>The status message when loading contents of this control.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolMoreThanRequiredStartingPoints" xml:space="preserve">
+    <value>There are more starting points than required for the selected trace type.</value>
+    <comment>The warning message when there are more starting points than the selected trace type requires.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolNewTrace" xml:space="preserve">
+    <value>New trace</value>
+    <comment>The text for configuring a new trace.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolNext" xml:space="preserve">
+    <value>Next</value>
+    <comment>The text on button for navigating to the next starting point's information.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolNoFeatureResults" xml:space="preserve">
+    <value>No feature results.</value>
+    <comment>The warning message when trace returned an empty feature result.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolNoFunctionResults" xml:space="preserve">
+    <value>No function results.</value>
+    <comment>The warning message when trace returned an empty function result.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolNoResults" xml:space="preserve">
+    <value>No results found.</value>
+    <comment>The warning message when trace returned an empty result.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolNoSelectedTraceType" xml:space="preserve">
+    <value>No trace type selected.</value>
+    <comment>The error message when attempting to trace without a selected trace type.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolNoSelectedUtilityNetwork" xml:space="preserve">
+    <value>No utility network selected.</value>
+    <comment>The error message when attempting to trace without a selected utility network.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolNotEnoughStartingPoints" xml:space="preserve">
+    <value>The selected trace type requires additional starting points.</value>
+    <comment>The warning message when there are fewer starting points than the selected trace type requires.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolNoTraceTypes" xml:space="preserve">
+    <value>No trace types found for the selected utility network.</value>
+    <comment>The error message when the selected utility network has no trace types.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolNoUtilityNetworks" xml:space="preserve">
+    <value>No utility networks found.</value>
+    <comment>The error message when the map has no utility networks.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolPreview" xml:space="preserve">
+    <value>Preview</value>
+    <comment>The text for previewing the graphic symbol when selected color is used.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolPrevious" xml:space="preserve">
+    <value>Previous</value>
+    <comment>The text on button for navigating to the previous starting point's information.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolRemoveAllStartingPoints" xml:space="preserve">
+    <value>Remove all</value>
+    <comment>The text on button for removing all starting points.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolRemoveStartingPoint" xml:space="preserve">
+    <value>Remove</value>
+    <comment>The text on button for removing the starting point.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolResultName" xml:space="preserve">
+    <value>Result name (optional)</value>
+    <comment>The text for specifying a new result name.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolResults" xml:space="preserve">
+    <value>Results</value>
+    <comment>The text for listing the trace results.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolResultVisualizationColor" xml:space="preserve">
+    <value>Result visualization color</value>
+    <comment>The text for selecting a new result symbol color.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolRuningTrace" xml:space="preserve">
+    <value>Running trace...</value>
+    <comment>The status message when there is a trace is in progress.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolRunTrace" xml:space="preserve">
+    <value>Run trace</value>
+    <comment>The text on button for running the trace.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolSelectFeatures" xml:space="preserve">
+    <value>Select features on map</value>
+    <comment>The text to enable selection of feature results.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolShowGraphics" xml:space="preserve">
+    <value>Show graphics on map</value>
+    <comment>The text to enable display of graphics with aggregated geometry results.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolStartingPoints" xml:space="preserve">
+    <value>Starting points</value>
+    <comment>The text for listing starting points.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolTapToIdentifyStartingPoints" xml:space="preserve">
+    <value>Tap on the map to identify starting points.</value>
+    <comment>The instruction text for identifying starting points on the map.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolTerminal" xml:space="preserve">
+    <value>Terminal</value>
+    <comment>The text for selecting a terminal.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolTraceTypeCreator" xml:space="preserve">
+    <value>Creator</value>
+    <comment>The text for displaying the creator of the selected trace type.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolTraceTypeDescription" xml:space="preserve">
+    <value>Description</value>
+    <comment>The text for displaying the description of the selected trace type.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolTraceTypeDetails" xml:space="preserve">
+    <value>Trace type details</value>
+    <comment>The text for expanding information about the selected trace type.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolTraceTypes" xml:space="preserve">
+    <value>Trace types</value>
+    <comment>The text for listing trace types.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolTraceTypeTags" xml:space="preserve">
+    <value>Tags</value>
+    <comment>The text for listing the tags for the selected trace type.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolUtilityNetworks" xml:space="preserve">
+    <value>Utility networks</value>
+    <comment>The text for listing utility networks.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolVisualizationOptions" xml:space="preserve">
+    <value>Visualization options</value>
+    <comment>The text for expanding symbol color palette.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolWarnings" xml:space="preserve">
+    <value>Warnings</value>
+    <comment>The text for expanding the list of trace result warnings.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolZoomStartingPoint" xml:space="preserve">
+    <value>Zoom</value>
+    <comment>The text on button that zooms around the starting point.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolZoomToResult" xml:space="preserve">
+    <value>Zoom to result</value>
+    <comment>The text on button that zooms to the selected trace result.</comment>
+  </data>
 </root>

--- a/src/Toolkit/Toolkit/UI/Controls/UtilityNetworkTraceTool/UtilityNetworkTraceToolController.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/UtilityNetworkTraceTool/UtilityNetworkTraceToolController.cs
@@ -578,12 +578,12 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
 
                 if (SelectedUtilityNetwork == null)
                 {
-                    throw new InvalidOperationException(Properties.Resources.GetString("UtilityNetworkTraceToolNoSelectedUtilityNetwork"));
+                    throw new InvalidOperationException("No utility network selected.");
                 }
 
                 if (SelectedTraceType == null)
                 {
-                    throw new InvalidOperationException(Properties.Resources.GetString("UtilityNetworkTraceToolNoSelectedTraceType"));
+                    throw new InvalidOperationException("No trace type selected.");
                 }
 
                 if (_traceCts != null)

--- a/src/Toolkit/Toolkit/UI/Controls/UtilityNetworkTraceTool/UtilityNetworkTraceToolController.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/UtilityNetworkTraceTool/UtilityNetworkTraceToolController.cs
@@ -326,7 +326,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
                     IsLoadingNetwork = true;
                     UtilityNetworks.Clear();
 
-                    var utilityNetworks = (sender is Map map ? map.UtilityNetworks : null) ?? throw new ArgumentException(Properties.Resources.GetString("UtilityNetworkTraceToolNoUtilityNetworks"));
+                    var utilityNetworks = (sender is Map map ? map.UtilityNetworks : Enumerable.Empty<UtilityNetwork>());
 
                     if (_lastObservedNetworkCollection != null)
                     {
@@ -357,10 +357,6 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
                     {
                         IsReadyToConfigure = true;
                     }
-                }
-                catch (Exception)
-                {
-                    IsReadyToConfigure = false;
                 }
                 finally
                 {

--- a/src/Toolkit/Toolkit/UI/Controls/UtilityNetworkTraceTool/UtilityNetworkTraceToolController.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/UtilityNetworkTraceTool/UtilityNetworkTraceToolController.cs
@@ -358,6 +358,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
                         IsReadyToConfigure = true;
                     }
                 }
+                catch { IsReadyToConfigure = false; }
                 finally
                 {
                     IsLoadingNetwork = false;

--- a/src/Toolkit/Toolkit/UI/Controls/UtilityNetworkTraceTool/UtilityNetworkTraceToolController.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/UtilityNetworkTraceTool/UtilityNetworkTraceToolController.cs
@@ -326,7 +326,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
                     IsLoadingNetwork = true;
                     UtilityNetworks.Clear();
 
-                    var utilityNetworks = (sender is Map map ? map.UtilityNetworks : null) ?? throw new ArgumentException("No UtilityNetworks found.");
+                    var utilityNetworks = (sender is Map map ? map.UtilityNetworks : null) ?? throw new ArgumentException(Properties.Resources.GetString("UtilityNetworkTraceToolNoUtilityNetworks"));
 
                     if (_lastObservedNetworkCollection != null)
                     {
@@ -581,17 +581,12 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
 
                 if (SelectedUtilityNetwork == null)
                 {
-                    throw new InvalidOperationException("No utility network selected.");
+                    throw new InvalidOperationException(Properties.Resources.GetString("UtilityNetworkTraceToolNoSelectedUtilityNetwork"));
                 }
 
                 if (SelectedTraceType == null)
                 {
-                    throw new InvalidOperationException("No trace type selected.");
-                }
-
-                if (traceParameters == null)
-                {
-                    throw new InvalidOperationException("No trace parameters created.");
+                    throw new InvalidOperationException(Properties.Resources.GetString("UtilityNetworkTraceToolNoSelectedTraceType"));
                 }
 
                 if (_traceCts != null)


### PR DESCRIPTION
Localize trace tool

- Updated strings in `Text="`, `Content="`, `Header="`, and error messages since all get displayed on the tool.
- There were some subtle string differences in WinUI, MAUI, WPF; for example, "Not enough starting points..", "Networks", "Delete result", "Click on the map.." that are now resolved.
- Text that use symbols 'X', '<', '>', (i.e. `&#xE10A;`) are not localized.
- Text to "Cancel" though different buttons are shared by add/identify starting points and running trace.
- Passenger bugs: 
    - Rename "(Named) trace configurations" => "Trace types". Older toolkit design and Javascript widget were all updated to use "Trace types"
    - Remove null check on `traceParameters` because null check for `SelectedTraceType` guarantees a new traceParameters is always created.
- To test, I ran Maui, WinUI, WPF, UWP `UtilityNetworkTraceTool` sample and visually checked appropriate labels, warnings and error messages are picked up from resx.