### PR TITLE
Handle prop changed events to validation errors

### DIFF
--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FeatureFormView.Windows.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FeatureFormView.Windows.cs
@@ -29,6 +29,23 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         private const string ItemsViewName = "ItemsView";
         private const string FeatureFormContentScrollViewerName = "FeatureFormContentScrollViewer";
 
+        private static readonly DependencyPropertyKey IsValidPropertyKey
+          = DependencyProperty.RegisterReadOnly(nameof(IsValid), typeof(bool), typeof(FeatureFormView), new FrameworkPropertyMetadata(false));
+
+        /// <summary>
+        /// Identifies the <see cref="IsValid"/> Dependency property.
+        /// </summary>
+        public static readonly DependencyProperty IsValidProperty = IsValidPropertyKey.DependencyProperty;
+
+        /// <summary>
+        /// Gets a value indicating whether this form has any validation errors.
+        /// </summary>
+        /// <seealso cref="FeatureForm.ValidationErrors"/>
+        public bool IsValid
+        {
+            get { return (bool)GetValue(IsValidProperty); }
+            private set { SetValue(IsValidPropertyKey, value); }
+        }
     }
 }
 #endif

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FieldFormElementView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FieldFormElementView.cs
@@ -118,23 +118,6 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
             try
             {
                 await FeatureForm.EvaluateExpressionsAsync();
-                var errors = Element.ValidationErrors;
-
-                string? errMessage = null;
-                if (errors != null && errors.Any())
-                {
-                    errMessage = string.Join("\n", errors.Select(e => FeatureFormView.ValidationErrorToLocalizedString(Element, e)!));
-                }
-                else if (Element?.IsRequired == true && (Element.Value is null || Element?.Value is string str && string.IsNullOrEmpty(str)))
-                {
-                    errMessage = "Required";
-                }
-
-                if (GetTemplateChild("ErrorLabel") is TextBlock tb)
-                {
-                    tb.Text = errMessage;
-                }
-
             }
             catch (System.Exception)
             {
@@ -156,6 +139,32 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                 else
                     OnValuePropertyChanged();
 #endif
+            }
+            else if (e.PropertyName == nameof(FieldFormElement.ValidationErrors))
+            {
+                UpdateErrorMessages();
+            }
+        }
+
+        private void UpdateErrorMessages()
+        {
+            string? errMessage = null;
+            if (Element is not null)
+            {
+                var errors = Element.ValidationErrors;
+
+                if (errors != null && errors.Any())
+                {
+                    errMessage = string.Join("\n", errors.Select(e => FeatureFormView.ValidationErrorToLocalizedString(Element, e)!));
+                }
+                else if (Element?.IsRequired == true && (Element.Value is null || Element?.Value is string str && string.IsNullOrEmpty(str)))
+                {
+                    errMessage = Properties.Resources.GetString("FeatureFormFieldIsRequired");
+                }
+            }
+            if (GetTemplateChild("ErrorLabel") is TextBlock tb)
+            {
+                tb.Text = errMessage;
             }
         }
     }


### PR DESCRIPTION
Removed all the validation checking and rely on callbacks instead to update validation state.
Introduces readonly IsValid property you can use to bind to your Apply button.