### PR TITLE
FeatureForm WPF: Tooltip shows even when empty

### DIFF
--- a/src/Toolkit/Toolkit.WPF/UI/Controls/FeatureForm/FeatureFormView.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/FeatureForm/FeatureFormView.Theme.xaml
@@ -5,22 +5,22 @@
   xmlns:controls="clr-namespace:Esri.ArcGISRuntime.Toolkit.UI.Controls"
   xmlns:forms="clr-namespace:Esri.ArcGISRuntime.Mapping.FeatureForms;assembly=Esri.ArcGISRuntime"
   xmlns:primitives="clr-namespace:Esri.ArcGISRuntime.Toolkit.Primitives">
- 
+
   <SolidColorBrush x:Key="FeatureFormAccentBrush" Color="#007AC2" />
   <Thickness x:Key="FeatureFormElementInputMargin">0,0,0,5</Thickness>
   <internal:VisibilityConverter x:Key="FeatureFormViewVisibilityConverter"/>
   <Style TargetType="TextBlock" x:Key="FeatureFormViewHeaderStyle">
-     <Setter Property="FontSize" Value="16" />
-     <Setter Property="FontWeight" Value="Bold" />
-     <Setter Property="TextWrapping" Value="Wrap" />
+    <Setter Property="FontSize" Value="16" />
+    <Setter Property="FontWeight" Value="Bold" />
+    <Setter Property="TextWrapping" Value="Wrap" />
   </Style>
   <Style TargetType="TextBlock" x:Key="FeatureFormViewTitleStyle">
-     <Setter Property="FontSize" Value="16" />
-     <Setter Property="TextWrapping" Value="Wrap" />
+    <Setter Property="FontSize" Value="16" />
+    <Setter Property="TextWrapping" Value="Wrap" />
   </Style>
   <Style TargetType="TextBlock" x:Key="FeatureFormViewCaptionStyle">
-     <Setter Property="FontSize" Value="12" />
-     <Setter Property="TextWrapping" Value="Wrap" />
+    <Setter Property="FontSize" Value="12" />
+    <Setter Property="TextWrapping" Value="Wrap" />
   </Style>
   <Style TargetType="{x:Type primitives:TimePicker}">
     <Setter Property="Template">
@@ -151,7 +151,7 @@
               <TextBlock Text="{Binding MaxLength, ElementName=TextInput}" />
             </StackPanel>
             <TextBox IsEnabled="{TemplateBinding IsEnabled}" BorderThickness="0" x:Name="TextInput" MaxLines="{TemplateBinding MaxLines}" MinLines="{TemplateBinding MinLines}" />
- 
+
             <Border x:Name="ErrorBorder" BorderThickness="1" BorderBrush="Red" Visibility="Collapsed" />
             <TextBlock Text="!" Background="Transparent" Width="10" Foreground="Red" Visibility="Collapsed" HorizontalAlignment="Right" VerticalAlignment="Center" x:Name="ErrorInfo" />
             <Button Grid.Column="1" Content="&#xec5a;" FontFamily="Segoe MDL2 Assets" Visibility="Collapsed" x:Name="BarcodeScannerButton" />
@@ -177,18 +177,18 @@
   <Style TargetType="{x:Type primitives:FieldFormElementView}" >
     <Setter Property="Margin" Value="{StaticResource FeatureFormElementInputMargin}" />
     <Setter Property="ComboBoxFormInputTemplate">
-        <Setter.Value>
-            <DataTemplate>
-                <primitives:ComboBoxFormInputView Element="{Binding}" IsEnabled="{Binding IsEditable}" />
-            </DataTemplate>
-        </Setter.Value>
+      <Setter.Value>
+        <DataTemplate>
+          <primitives:ComboBoxFormInputView Element="{Binding}" IsEnabled="{Binding IsEditable}" />
+        </DataTemplate>
+      </Setter.Value>
     </Setter>
     <Setter Property="RadioButtonsFormInputTemplate">
-        <Setter.Value>
-            <DataTemplate>
-                <primitives:RadioButtonsFormInputView Element="{Binding}" IsEnabled="{Binding IsEditable}" />
-            </DataTemplate>
-        </Setter.Value>
+      <Setter.Value>
+        <DataTemplate>
+          <primitives:RadioButtonsFormInputView Element="{Binding}" IsEnabled="{Binding IsEditable}" />
+        </DataTemplate>
+      </Setter.Value>
     </Setter>
     <Setter Property="SwitchFormInputTemplate">
       <Setter.Value>
@@ -230,7 +230,11 @@
         <ControlTemplate TargetType="{x:Type primitives:FieldFormElementView}">
           <StackPanel>
             <TextBlock Text="{Binding Label}" Style="{StaticResource FeatureFormViewTitleStyle}"/>
-            <ContentControl Margin="0,3" Foreground="Gray" Content="{Binding}" x:Name="FieldInput" ToolTip="{Binding Hint}" />
+            <ContentControl Margin="0,3" Foreground="Gray" Content="{Binding}" x:Name="FieldInput">
+              <ContentControl.ToolTip>
+                <ToolTip Content="{Binding Hint}" Visibility="{Binding Hint, Converter={StaticResource FeatureFormViewVisibilityConverter}}" />
+              </ContentControl.ToolTip>
+            </ContentControl>
             <TextBlock Text="{Binding Description}" Visibility="{Binding Description, Converter={StaticResource FeatureFormViewVisibilityConverter}}" Opacity=".7" Style="{StaticResource FeatureFormViewCaptionStyle}" />
             <TextBlock Foreground="Red" x:Name="ErrorLabel" Visibility="{Binding Text, ElementName=ErrorLabel, Converter={StaticResource FeatureFormViewVisibilityConverter}}" />
           </StackPanel>
@@ -268,21 +272,21 @@
   </Style>
   <Style x:Key="GroupFormElementExpanderStyle" TargetType="{x:Type Expander}">
     <Style.Triggers>
-        <DataTrigger Binding="{Binding Path=InitialState, Mode=OneTime}">
-            <DataTrigger.Value>
-                <forms:FormGroupState>Expanded</forms:FormGroupState>
-            </DataTrigger.Value>
-            <Setter Property="IsExpanded" Value="True" />
-        </DataTrigger>
-        <DataTrigger Binding="{Binding Path=InitialState, Mode=OneTime}">
-            <DataTrigger.Value>
-                <forms:FormGroupState>Collapsed</forms:FormGroupState>
-            </DataTrigger.Value>
-            <Setter Property="IsExpanded" Value="False" />
-        </DataTrigger>
-        <DataTrigger Binding="{Binding Path=Elements.Count, Mode=OneWay}" Value="0">
-            <Setter Property="Visibility" Value="Collapsed" />
-        </DataTrigger>
+      <DataTrigger Binding="{Binding Path=InitialState, Mode=OneTime}">
+        <DataTrigger.Value>
+          <forms:FormGroupState>Expanded</forms:FormGroupState>
+        </DataTrigger.Value>
+        <Setter Property="IsExpanded" Value="True" />
+      </DataTrigger>
+      <DataTrigger Binding="{Binding Path=InitialState, Mode=OneTime}">
+        <DataTrigger.Value>
+          <forms:FormGroupState>Collapsed</forms:FormGroupState>
+        </DataTrigger.Value>
+        <Setter Property="IsExpanded" Value="False" />
+      </DataTrigger>
+      <DataTrigger Binding="{Binding Path=Elements.Count, Mode=OneWay}" Value="0">
+        <Setter Property="Visibility" Value="Collapsed" />
+      </DataTrigger>
     </Style.Triggers>
     <Setter Property="BorderBrush" Value="Gray" />
     <Setter Property="BorderThickness" Value="0,0,0,1" />
@@ -328,7 +332,7 @@
       </Setter.Value>
     </Setter>
   </Style>
-  
+
   <Style TargetType="{x:Type controls:FeatureFormView}" >
     <Setter Property="Template">
       <Setter.Value>
@@ -359,10 +363,10 @@
               </Style>
             </Border.Resources>
             <Grid DataContext="{TemplateBinding FeatureForm}">
-            <Grid.RowDefinitions>
-              <RowDefinition Height="Auto"/>
-              <RowDefinition Height="*"/>
-            </Grid.RowDefinitions>
+              <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+              </Grid.RowDefinitions>
               <TextBlock Text="{Binding Title}" Style="{StaticResource FeatureFormViewHeaderStyle}"
                          Visibility="{Binding Title, Converter={StaticResource FeatureFormViewVisibilityConverter}}" />
               <ScrollViewer VerticalScrollBarVisibility="{TemplateBinding VerticalScrollBarVisibility}"  Grid.Row="1" x:Name="FeatureFormContentScrollViewer">
@@ -401,6 +405,6 @@
           </Border>
         </ControlTemplate>
       </Setter.Value>
-  </Setter>
+    </Setter>
   </Style>
 </ResourceDictionary>

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/FeatureForm/FeatureFormView.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/FeatureForm/FeatureFormView.Theme.xaml
@@ -10,17 +10,17 @@
   <Thickness x:Key="FeatureFormElementInputMargin">0,0,0,5</Thickness>
   <internal:VisibilityConverter x:Key="FeatureFormViewVisibilityConverter"/>
   <Style TargetType="TextBlock" x:Key="FeatureFormViewHeaderStyle">
-    <Setter Property="FontSize" Value="16" />
-    <Setter Property="FontWeight" Value="Bold" />
-    <Setter Property="TextWrapping" Value="Wrap" />
+     <Setter Property="FontSize" Value="16" />
+     <Setter Property="FontWeight" Value="Bold" />
+     <Setter Property="TextWrapping" Value="Wrap" />
   </Style>
   <Style TargetType="TextBlock" x:Key="FeatureFormViewTitleStyle">
-    <Setter Property="FontSize" Value="16" />
-    <Setter Property="TextWrapping" Value="Wrap" />
+     <Setter Property="FontSize" Value="16" />
+     <Setter Property="TextWrapping" Value="Wrap" />
   </Style>
   <Style TargetType="TextBlock" x:Key="FeatureFormViewCaptionStyle">
-    <Setter Property="FontSize" Value="12" />
-    <Setter Property="TextWrapping" Value="Wrap" />
+     <Setter Property="FontSize" Value="12" />
+     <Setter Property="TextWrapping" Value="Wrap" />
   </Style>
   <Style TargetType="{x:Type primitives:TimePicker}">
     <Setter Property="Template">
@@ -151,7 +151,7 @@
               <TextBlock Text="{Binding MaxLength, ElementName=TextInput}" />
             </StackPanel>
             <TextBox IsEnabled="{TemplateBinding IsEnabled}" BorderThickness="0" x:Name="TextInput" MaxLines="{TemplateBinding MaxLines}" MinLines="{TemplateBinding MinLines}" />
-
+ 
             <Border x:Name="ErrorBorder" BorderThickness="1" BorderBrush="Red" Visibility="Collapsed" />
             <TextBlock Text="!" Background="Transparent" Width="10" Foreground="Red" Visibility="Collapsed" HorizontalAlignment="Right" VerticalAlignment="Center" x:Name="ErrorInfo" />
             <Button Grid.Column="1" Content="&#xec5a;" FontFamily="Segoe MDL2 Assets" Visibility="Collapsed" x:Name="BarcodeScannerButton" />
@@ -177,18 +177,18 @@
   <Style TargetType="{x:Type primitives:FieldFormElementView}" >
     <Setter Property="Margin" Value="{StaticResource FeatureFormElementInputMargin}" />
     <Setter Property="ComboBoxFormInputTemplate">
-      <Setter.Value>
-        <DataTemplate>
-          <primitives:ComboBoxFormInputView Element="{Binding}" IsEnabled="{Binding IsEditable}" />
-        </DataTemplate>
-      </Setter.Value>
+        <Setter.Value>
+            <DataTemplate>
+                <primitives:ComboBoxFormInputView Element="{Binding}" IsEnabled="{Binding IsEditable}" />
+            </DataTemplate>
+        </Setter.Value>
     </Setter>
     <Setter Property="RadioButtonsFormInputTemplate">
-      <Setter.Value>
-        <DataTemplate>
-          <primitives:RadioButtonsFormInputView Element="{Binding}" IsEnabled="{Binding IsEditable}" />
-        </DataTemplate>
-      </Setter.Value>
+        <Setter.Value>
+            <DataTemplate>
+                <primitives:RadioButtonsFormInputView Element="{Binding}" IsEnabled="{Binding IsEditable}" />
+            </DataTemplate>
+        </Setter.Value>
     </Setter>
     <Setter Property="SwitchFormInputTemplate">
       <Setter.Value>
@@ -272,21 +272,21 @@
   </Style>
   <Style x:Key="GroupFormElementExpanderStyle" TargetType="{x:Type Expander}">
     <Style.Triggers>
-      <DataTrigger Binding="{Binding Path=InitialState, Mode=OneTime}">
-        <DataTrigger.Value>
-          <forms:FormGroupState>Expanded</forms:FormGroupState>
-        </DataTrigger.Value>
-        <Setter Property="IsExpanded" Value="True" />
-      </DataTrigger>
-      <DataTrigger Binding="{Binding Path=InitialState, Mode=OneTime}">
-        <DataTrigger.Value>
-          <forms:FormGroupState>Collapsed</forms:FormGroupState>
-        </DataTrigger.Value>
-        <Setter Property="IsExpanded" Value="False" />
-      </DataTrigger>
-      <DataTrigger Binding="{Binding Path=Elements.Count, Mode=OneWay}" Value="0">
-        <Setter Property="Visibility" Value="Collapsed" />
-      </DataTrigger>
+        <DataTrigger Binding="{Binding Path=InitialState, Mode=OneTime}">
+            <DataTrigger.Value>
+                <forms:FormGroupState>Expanded</forms:FormGroupState>
+            </DataTrigger.Value>
+            <Setter Property="IsExpanded" Value="True" />
+        </DataTrigger>
+        <DataTrigger Binding="{Binding Path=InitialState, Mode=OneTime}">
+            <DataTrigger.Value>
+                <forms:FormGroupState>Collapsed</forms:FormGroupState>
+            </DataTrigger.Value>
+            <Setter Property="IsExpanded" Value="False" />
+        </DataTrigger>
+        <DataTrigger Binding="{Binding Path=Elements.Count, Mode=OneWay}" Value="0">
+            <Setter Property="Visibility" Value="Collapsed" />
+        </DataTrigger>
     </Style.Triggers>
     <Setter Property="BorderBrush" Value="Gray" />
     <Setter Property="BorderThickness" Value="0,0,0,1" />
@@ -332,7 +332,7 @@
       </Setter.Value>
     </Setter>
   </Style>
-
+  
   <Style TargetType="{x:Type controls:FeatureFormView}" >
     <Setter Property="Template">
       <Setter.Value>
@@ -363,10 +363,10 @@
               </Style>
             </Border.Resources>
             <Grid DataContext="{TemplateBinding FeatureForm}">
-              <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="*"/>
-              </Grid.RowDefinitions>
+                <Grid.RowDefinitions>
+                  <RowDefinition Height="Auto"/>
+                  <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
               <TextBlock Text="{Binding Title}" Style="{StaticResource FeatureFormViewHeaderStyle}"
                          Visibility="{Binding Title, Converter={StaticResource FeatureFormViewVisibilityConverter}}" />
               <ScrollViewer VerticalScrollBarVisibility="{TemplateBinding VerticalScrollBarVisibility}"  Grid.Row="1" x:Name="FeatureFormContentScrollViewer">
@@ -405,6 +405,6 @@
           </Border>
         </ControlTemplate>
       </Setter.Value>
-    </Setter>
+  </Setter>
   </Style>
 </ResourceDictionary>

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/FeatureForm/FeatureFormView.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/FeatureForm/FeatureFormView.Theme.xaml
@@ -11,17 +11,17 @@
   <Thickness x:Key="FeatureFormElementInputMargin">0,0,0,5</Thickness>
   <internal:VisibilityConverter x:Key="FeatureFormViewVisibilityConverter"/>
   <Style TargetType="TextBlock" x:Key="FeatureFormViewHeaderStyle">
-    <Setter Property="FontSize" Value="16" />
-    <Setter Property="FontWeight" Value="Bold" />
-    <Setter Property="TextWrapping" Value="Wrap" />
+     <Setter Property="FontSize" Value="16" />
+     <Setter Property="FontWeight" Value="Bold" />
+     <Setter Property="TextWrapping" Value="Wrap" />
   </Style>
   <Style TargetType="TextBlock" x:Key="FeatureFormViewTitleStyle">
-    <Setter Property="FontSize" Value="16" />
-    <Setter Property="TextWrapping" Value="Wrap" />
+     <Setter Property="FontSize" Value="16" />
+     <Setter Property="TextWrapping" Value="Wrap" />
   </Style>
   <Style TargetType="TextBlock" x:Key="FeatureFormViewCaptionStyle">
-    <Setter Property="FontSize" Value="12" />
-    <Setter Property="TextWrapping" Value="Wrap" />
+     <Setter Property="FontSize" Value="12" />
+     <Setter Property="TextWrapping" Value="Wrap" />
   </Style>
   <Style TargetType="{x:Type primitives:TimePicker}">
     <Setter Property="Template">
@@ -152,7 +152,7 @@
               <TextBlock Text="{Binding MaxLength, ElementName=TextInput}" />
             </StackPanel>
             <TextBox IsEnabled="{TemplateBinding IsEnabled}" BorderThickness="0" x:Name="TextInput" MaxLines="{TemplateBinding MaxLines}" MinLines="{TemplateBinding MinLines}" />
-
+ 
             <Border x:Name="ErrorBorder" BorderThickness="1" BorderBrush="Red" Visibility="Collapsed" />
             <TextBlock Text="!" Background="Transparent" Width="10" Foreground="Red" Visibility="Collapsed" HorizontalAlignment="Right" VerticalAlignment="Center" x:Name="ErrorInfo" />
             <Button Grid.Column="1" Content="&#xec5a;" FontFamily="Segoe MDL2 Assets" Visibility="Collapsed" x:Name="BarcodeScannerButton" />
@@ -178,18 +178,18 @@
   <Style TargetType="{x:Type primitives:FieldFormElementView}" >
     <Setter Property="Margin" Value="{StaticResource FeatureFormElementInputMargin}" />
     <Setter Property="ComboBoxFormInputTemplate">
-      <Setter.Value>
-        <DataTemplate>
-          <primitives:ComboBoxFormInputView Element="{Binding}" IsEnabled="{Binding IsEditable}" />
-        </DataTemplate>
-      </Setter.Value>
+        <Setter.Value>
+            <DataTemplate>
+                <primitives:ComboBoxFormInputView Element="{Binding}" IsEnabled="{Binding IsEditable}" />
+            </DataTemplate>
+        </Setter.Value>
     </Setter>
     <Setter Property="RadioButtonsFormInputTemplate">
-      <Setter.Value>
-        <DataTemplate>
-          <primitives:RadioButtonsFormInputView Element="{Binding}" IsEnabled="{Binding IsEditable}" />
-        </DataTemplate>
-      </Setter.Value>
+        <Setter.Value>
+            <DataTemplate>
+                <primitives:RadioButtonsFormInputView Element="{Binding}" IsEnabled="{Binding IsEditable}" />
+            </DataTemplate>
+        </Setter.Value>
     </Setter>
     <Setter Property="SwitchFormInputTemplate">
       <Setter.Value>
@@ -256,7 +256,7 @@
       </Setter.Value>
     </Setter>
   </Style>
-
+ 
   <Style x:Key="GroupFormElementExpanderButtonStyle" TargetType="{x:Type ToggleButton}">
     <Setter Property="Template">
       <Setter.Value>
@@ -286,21 +286,21 @@
   </Style>
   <Style x:Key="GroupFormElementExpanderStyle" TargetType="{x:Type Expander}">
     <Style.Triggers>
-      <DataTrigger Binding="{Binding Path=InitialState, Mode=OneTime}">
-        <DataTrigger.Value>
-          <forms:FormGroupState>Expanded</forms:FormGroupState>
-        </DataTrigger.Value>
-        <Setter Property="IsExpanded" Value="True" />
-      </DataTrigger>
-      <DataTrigger Binding="{Binding Path=InitialState, Mode=OneTime}">
-        <DataTrigger.Value>
-          <forms:FormGroupState>Collapsed</forms:FormGroupState>
-        </DataTrigger.Value>
-        <Setter Property="IsExpanded" Value="False" />
-      </DataTrigger>
-      <DataTrigger Binding="{Binding Path=Elements.Count, Mode=OneWay}" Value="0">
-        <Setter Property="Visibility" Value="Collapsed" />
-      </DataTrigger>
+        <DataTrigger Binding="{Binding Path=InitialState, Mode=OneTime}">
+            <DataTrigger.Value>
+                <forms:FormGroupState>Expanded</forms:FormGroupState>
+            </DataTrigger.Value>
+            <Setter Property="IsExpanded" Value="True" />
+        </DataTrigger>
+        <DataTrigger Binding="{Binding Path=InitialState, Mode=OneTime}">
+            <DataTrigger.Value>
+                <forms:FormGroupState>Collapsed</forms:FormGroupState>
+            </DataTrigger.Value>
+            <Setter Property="IsExpanded" Value="False" />
+        </DataTrigger>
+        <DataTrigger Binding="{Binding Path=Elements.Count, Mode=OneWay}" Value="0">
+            <Setter Property="Visibility" Value="Collapsed" />
+        </DataTrigger>
     </Style.Triggers>
     <Setter Property="BorderBrush" Value="Gray" />
     <Setter Property="BorderThickness" Value="0,0,0,1" />
@@ -346,7 +346,7 @@
       </Setter.Value>
     </Setter>
   </Style>
-
+  
   <Style TargetType="{x:Type controls:FeatureFormView}" >
     <Setter Property="Template">
       <Setter.Value>
@@ -377,10 +377,10 @@
               </Style>
             </Border.Resources>
             <Grid DataContext="{TemplateBinding FeatureForm}">
-              <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="*"/>
-              </Grid.RowDefinitions>
+            <Grid.RowDefinitions>
+              <RowDefinition Height="Auto"/>
+              <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
               <TextBlock Text="{Binding Title}" Style="{StaticResource FeatureFormViewHeaderStyle}"
                          Visibility="{Binding Title, Converter={StaticResource FeatureFormViewVisibilityConverter}}" />
               <ScrollViewer VerticalScrollBarVisibility="{TemplateBinding VerticalScrollBarVisibility}"  Grid.Row="1" x:Name="FeatureFormContentScrollViewer">
@@ -419,6 +419,6 @@
           </Border>
         </ControlTemplate>
       </Setter.Value>
-    </Setter>
+      </Setter>
   </Style>
 </ResourceDictionary>

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/FeatureForm/FeatureFormView.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/FeatureForm/FeatureFormView.Theme.xaml
@@ -419,6 +419,6 @@
           </Border>
         </ControlTemplate>
       </Setter.Value>
-      </Setter>
+  </Setter>
   </Style>
 </ResourceDictionary>

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/FeatureForm/FeatureFormView.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/FeatureForm/FeatureFormView.Theme.xaml
@@ -363,10 +363,10 @@
               </Style>
             </Border.Resources>
             <Grid DataContext="{TemplateBinding FeatureForm}">
-                <Grid.RowDefinitions>
-                  <RowDefinition Height="Auto"/>
-                  <RowDefinition Height="*"/>
-                </Grid.RowDefinitions>
+            <Grid.RowDefinitions>
+              <RowDefinition Height="Auto"/>
+              <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
               <TextBlock Text="{Binding Title}" Style="{StaticResource FeatureFormViewHeaderStyle}"
                          Visibility="{Binding Title, Converter={StaticResource FeatureFormViewVisibilityConverter}}" />
               <ScrollViewer VerticalScrollBarVisibility="{TemplateBinding VerticalScrollBarVisibility}"  Grid.Row="1" x:Name="FeatureFormContentScrollViewer">

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/FeatureForm/FeatureFormView.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/FeatureForm/FeatureFormView.Theme.xaml
@@ -5,7 +5,7 @@
   xmlns:controls="clr-namespace:Esri.ArcGISRuntime.Toolkit.UI.Controls"
   xmlns:forms="clr-namespace:Esri.ArcGISRuntime.Mapping.FeatureForms;assembly=Esri.ArcGISRuntime"
   xmlns:primitives="clr-namespace:Esri.ArcGISRuntime.Toolkit.Primitives">
-
+ 
   <SolidColorBrush x:Key="FeatureFormAccentBrush" Color="#007AC2" />
   <Thickness x:Key="FeatureFormElementInputMargin">0,0,0,5</Thickness>
   <internal:VisibilityConverter x:Key="FeatureFormViewVisibilityConverter"/>

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/FeatureForm/FeatureFormView.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/FeatureForm/FeatureFormView.Theme.xaml
@@ -4,23 +4,24 @@
   xmlns:internal="clr-namespace:Esri.ArcGISRuntime.Toolkit.Internal"
   xmlns:controls="clr-namespace:Esri.ArcGISRuntime.Toolkit.UI.Controls"
   xmlns:forms="clr-namespace:Esri.ArcGISRuntime.Mapping.FeatureForms;assembly=Esri.ArcGISRuntime"
-  xmlns:primitives="clr-namespace:Esri.ArcGISRuntime.Toolkit.Primitives">
- 
+  xmlns:primitives="clr-namespace:Esri.ArcGISRuntime.Toolkit.Primitives"
+  xmlns:sys="clr-namespace:System;assembly=mscorlib">
+
   <SolidColorBrush x:Key="FeatureFormAccentBrush" Color="#007AC2" />
   <Thickness x:Key="FeatureFormElementInputMargin">0,0,0,5</Thickness>
   <internal:VisibilityConverter x:Key="FeatureFormViewVisibilityConverter"/>
   <Style TargetType="TextBlock" x:Key="FeatureFormViewHeaderStyle">
-     <Setter Property="FontSize" Value="16" />
-     <Setter Property="FontWeight" Value="Bold" />
-     <Setter Property="TextWrapping" Value="Wrap" />
+    <Setter Property="FontSize" Value="16" />
+    <Setter Property="FontWeight" Value="Bold" />
+    <Setter Property="TextWrapping" Value="Wrap" />
   </Style>
   <Style TargetType="TextBlock" x:Key="FeatureFormViewTitleStyle">
-     <Setter Property="FontSize" Value="16" />
-     <Setter Property="TextWrapping" Value="Wrap" />
+    <Setter Property="FontSize" Value="16" />
+    <Setter Property="TextWrapping" Value="Wrap" />
   </Style>
   <Style TargetType="TextBlock" x:Key="FeatureFormViewCaptionStyle">
-     <Setter Property="FontSize" Value="12" />
-     <Setter Property="TextWrapping" Value="Wrap" />
+    <Setter Property="FontSize" Value="12" />
+    <Setter Property="TextWrapping" Value="Wrap" />
   </Style>
   <Style TargetType="{x:Type primitives:TimePicker}">
     <Setter Property="Template">
@@ -151,7 +152,7 @@
               <TextBlock Text="{Binding MaxLength, ElementName=TextInput}" />
             </StackPanel>
             <TextBox IsEnabled="{TemplateBinding IsEnabled}" BorderThickness="0" x:Name="TextInput" MaxLines="{TemplateBinding MaxLines}" MinLines="{TemplateBinding MinLines}" />
- 
+
             <Border x:Name="ErrorBorder" BorderThickness="1" BorderBrush="Red" Visibility="Collapsed" />
             <TextBlock Text="!" Background="Transparent" Width="10" Foreground="Red" Visibility="Collapsed" HorizontalAlignment="Right" VerticalAlignment="Center" x:Name="ErrorInfo" />
             <Button Grid.Column="1" Content="&#xec5a;" FontFamily="Segoe MDL2 Assets" Visibility="Collapsed" x:Name="BarcodeScannerButton" />
@@ -177,18 +178,18 @@
   <Style TargetType="{x:Type primitives:FieldFormElementView}" >
     <Setter Property="Margin" Value="{StaticResource FeatureFormElementInputMargin}" />
     <Setter Property="ComboBoxFormInputTemplate">
-        <Setter.Value>
-            <DataTemplate>
-                <primitives:ComboBoxFormInputView Element="{Binding}" IsEnabled="{Binding IsEditable}" />
-            </DataTemplate>
-        </Setter.Value>
+      <Setter.Value>
+        <DataTemplate>
+          <primitives:ComboBoxFormInputView Element="{Binding}" IsEnabled="{Binding IsEditable}" />
+        </DataTemplate>
+      </Setter.Value>
     </Setter>
     <Setter Property="RadioButtonsFormInputTemplate">
-        <Setter.Value>
-            <DataTemplate>
-                <primitives:RadioButtonsFormInputView Element="{Binding}" IsEnabled="{Binding IsEditable}" />
-            </DataTemplate>
-        </Setter.Value>
+      <Setter.Value>
+        <DataTemplate>
+          <primitives:RadioButtonsFormInputView Element="{Binding}" IsEnabled="{Binding IsEditable}" />
+        </DataTemplate>
+      </Setter.Value>
     </Setter>
     <Setter Property="SwitchFormInputTemplate">
       <Setter.Value>
@@ -232,7 +233,20 @@
             <TextBlock Text="{Binding Label}" Style="{StaticResource FeatureFormViewTitleStyle}"/>
             <ContentControl Margin="0,3" Foreground="Gray" Content="{Binding}" x:Name="FieldInput">
               <ContentControl.ToolTip>
-                <ToolTip Content="{Binding Hint}" Visibility="{Binding Hint, Converter={StaticResource FeatureFormViewVisibilityConverter}}" />
+                <ToolTip Content="{Binding Hint}">
+                  <ToolTip.Style>
+                    <Style TargetType="{x:Type ToolTip}">
+                      <Style.Triggers>
+                        <Trigger Property="Content" Value="{x:Static sys:String.Empty}">
+                          <Setter Property="Visibility" Value="Collapsed"/>
+                        </Trigger>
+                        <Trigger Property="Content" Value="{x:Null}">
+                          <Setter Property="Visibility" Value="Collapsed"/>
+                        </Trigger>
+                      </Style.Triggers>
+                    </Style>
+                  </ToolTip.Style>
+                </ToolTip>
               </ContentControl.ToolTip>
             </ContentControl>
             <TextBlock Text="{Binding Description}" Visibility="{Binding Description, Converter={StaticResource FeatureFormViewVisibilityConverter}}" Opacity=".7" Style="{StaticResource FeatureFormViewCaptionStyle}" />
@@ -242,7 +256,7 @@
       </Setter.Value>
     </Setter>
   </Style>
- 
+
   <Style x:Key="GroupFormElementExpanderButtonStyle" TargetType="{x:Type ToggleButton}">
     <Setter Property="Template">
       <Setter.Value>
@@ -272,21 +286,21 @@
   </Style>
   <Style x:Key="GroupFormElementExpanderStyle" TargetType="{x:Type Expander}">
     <Style.Triggers>
-        <DataTrigger Binding="{Binding Path=InitialState, Mode=OneTime}">
-            <DataTrigger.Value>
-                <forms:FormGroupState>Expanded</forms:FormGroupState>
-            </DataTrigger.Value>
-            <Setter Property="IsExpanded" Value="True" />
-        </DataTrigger>
-        <DataTrigger Binding="{Binding Path=InitialState, Mode=OneTime}">
-            <DataTrigger.Value>
-                <forms:FormGroupState>Collapsed</forms:FormGroupState>
-            </DataTrigger.Value>
-            <Setter Property="IsExpanded" Value="False" />
-        </DataTrigger>
-        <DataTrigger Binding="{Binding Path=Elements.Count, Mode=OneWay}" Value="0">
-            <Setter Property="Visibility" Value="Collapsed" />
-        </DataTrigger>
+      <DataTrigger Binding="{Binding Path=InitialState, Mode=OneTime}">
+        <DataTrigger.Value>
+          <forms:FormGroupState>Expanded</forms:FormGroupState>
+        </DataTrigger.Value>
+        <Setter Property="IsExpanded" Value="True" />
+      </DataTrigger>
+      <DataTrigger Binding="{Binding Path=InitialState, Mode=OneTime}">
+        <DataTrigger.Value>
+          <forms:FormGroupState>Collapsed</forms:FormGroupState>
+        </DataTrigger.Value>
+        <Setter Property="IsExpanded" Value="False" />
+      </DataTrigger>
+      <DataTrigger Binding="{Binding Path=Elements.Count, Mode=OneWay}" Value="0">
+        <Setter Property="Visibility" Value="Collapsed" />
+      </DataTrigger>
     </Style.Triggers>
     <Setter Property="BorderBrush" Value="Gray" />
     <Setter Property="BorderThickness" Value="0,0,0,1" />
@@ -332,7 +346,7 @@
       </Setter.Value>
     </Setter>
   </Style>
-  
+
   <Style TargetType="{x:Type controls:FeatureFormView}" >
     <Setter Property="Template">
       <Setter.Value>
@@ -363,10 +377,10 @@
               </Style>
             </Border.Resources>
             <Grid DataContext="{TemplateBinding FeatureForm}">
-            <Grid.RowDefinitions>
-              <RowDefinition Height="Auto"/>
-              <RowDefinition Height="*"/>
-            </Grid.RowDefinitions>
+              <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+              </Grid.RowDefinitions>
               <TextBlock Text="{Binding Title}" Style="{StaticResource FeatureFormViewHeaderStyle}"
                          Visibility="{Binding Title, Converter={StaticResource FeatureFormViewVisibilityConverter}}" />
               <ScrollViewer VerticalScrollBarVisibility="{TemplateBinding VerticalScrollBarVisibility}"  Grid.Row="1" x:Name="FeatureFormContentScrollViewer">
@@ -405,6 +419,6 @@
           </Border>
         </ControlTemplate>
       </Setter.Value>
-  </Setter>
+    </Setter>
   </Style>
 </ResourceDictionary>


### PR DESCRIPTION
## Issue
Feature forms elements have tooltips, but the string might be empty. When this happens hovering on elements shows an ugly empty tooltip. We should not add tooltips when empty.

## Implemented Solution:

Breaking ToolTip into Child Element and setting its visibility with `Esri.ArcGISRuntime.Toolkit.Internal.VisibilityConverter` Converter.