### PR TITLE
J nery/build warnings

### DIFF
--- a/src/Toolkit/Toolkit.Maui/UtilityNetworkTraceTool/UtilityNetworkTraceTool.Appearance.cs
+++ b/src/Toolkit/Toolkit.Maui/UtilityNetworkTraceTool/UtilityNetworkTraceTool.Appearance.cs
@@ -19,7 +19,9 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Esri.ArcGISRuntime.Toolkit.Maui;
 
+#pragma warning disable CA1001
 public partial class UtilityNetworkTraceTool
+#pragma warning restore CA1001
 {
 #pragma warning disable SA1310, SX1309, SA1306
     // Navigation

--- a/src/Toolkit/Toolkit.Maui/UtilityNetworkTraceTool/UtilityNetworkTraceTool.cs
+++ b/src/Toolkit/Toolkit.Maui/UtilityNetworkTraceTool/UtilityNetworkTraceTool.cs
@@ -339,10 +339,8 @@ public partial class UtilityNetworkTraceTool : TemplatedView
 
     private void PART_NetworksCollectionView_SelectionChanged(object? sender, EventArgs e)
     {
-        if (PART_ListViewNetworks?.SelectedItem is UtilityNetwork newSelection)
-        {
-            _controller.SelectedUtilityNetwork = newSelection;
-        }
+        _controller.SelectedUtilityNetwork = PART_ListViewNetworks?.SelectedItem as UtilityNetwork;
+        UtilityNetworkChanged?.Invoke(this, new UtilityNetworkChangedEventArgs(_controller.SelectedUtilityNetwork));
     }
 
     private void UtilityNetworks_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)

--- a/src/Toolkit/Toolkit.Maui/UtilityNetworkTraceTool/UtilityNetworkTraceTool.cs
+++ b/src/Toolkit/Toolkit.Maui/UtilityNetworkTraceTool/UtilityNetworkTraceTool.cs
@@ -397,11 +397,14 @@ public partial class UtilityNetworkTraceTool : TemplatedView
                     _resultOverlays.Add(item.ResultOverlay);
                     GeoView.GraphicsOverlays.Insert(0, item.ResultOverlay);
                 }
-
-                UtilityNetworkTraceCompleted?.Invoke(this, new UtilityNetworkTraceCompletedEventArgs(item.Parameters, item.RawResults));
-                if (item?.Error != null)
+                                
+                if (item.Error != null)
                 {
                     UtilityNetworkTraceCompleted?.Invoke(this, new UtilityNetworkTraceCompletedEventArgs(item.Parameters, item.Error));
+                }
+                else
+                {
+                    UtilityNetworkTraceCompleted?.Invoke(this, new UtilityNetworkTraceCompletedEventArgs(item.Parameters, item.RawResults));
                 }
             }
         }

--- a/src/Toolkit/Toolkit.UI.Controls/UtilityNetworkTraceTool/UtilityNetworkTraceTool.Appearance.cs
+++ b/src/Toolkit/Toolkit.UI.Controls/UtilityNetworkTraceTool/UtilityNetworkTraceTool.Appearance.cs
@@ -64,7 +64,9 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
 #else
     [TemplatePart(Name = "PART_TabsControl", Type = typeof(Pivot))]
 #endif
+#pragma warning disable CA1001
     public partial class UtilityNetworkTraceTool
+#pragma warning restore CA1001
     {
         private UIElement? _loadingScrim;
         private UIElement? _ineligibleScrim;

--- a/src/Toolkit/Toolkit.UI.Controls/UtilityNetworkTraceTool/UtilityNetworkTraceTool.Windows.cs
+++ b/src/Toolkit/Toolkit.UI.Controls/UtilityNetworkTraceTool/UtilityNetworkTraceTool.Windows.cs
@@ -155,10 +155,13 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
                         GeoView.GraphicsOverlays.Insert(0, item.ResultOverlay);
                     }
 
-                    UtilityNetworkTraceCompleted?.Invoke(this, new UtilityNetworkTraceCompletedEventArgs(item.Parameters, item.RawResults));
-                    if (item?.Error != null)
+                    if (item.Error != null)
                     {
                         UtilityNetworkTraceCompleted?.Invoke(this, new UtilityNetworkTraceCompletedEventArgs(item.Parameters, item.Error));
+                    }
+                    else
+                    {
+                        UtilityNetworkTraceCompleted?.Invoke(this, new UtilityNetworkTraceCompletedEventArgs(item.Parameters, item.RawResults));
                     }
                 }
             }


### PR DESCRIPTION
To handle the following warnings
>\Toolkit.UI.Controls\UtilityNetworkTraceTool\UtilityNetworkTraceTool.Appearance.cs(67,26,67,49): warning CA1001: Type 'UtilityNetworkTraceTool' owns disposable field(s) '_controller', '_identifyLayersCts' but is not disposable
\Toolkit.UI.Controls\UtilityNetworkTraceTool\UtilityNetworkTraceTool.Appearance.cs(67,26,67,49): warning CA1001: Type 'UtilityNetworkTraceTool' owns disposable field(s) '_controller', '_identifyLayersCts' but is not disposable
\Toolkit.Maui\UtilityNetworkTraceTool\UtilityNetworkTraceTool.cs(751,64,751,85): warning CS0067: The event 'UtilityNetworkTraceTool.UtilityNetworkChanged' is never used
\Toolkit.Maui\UtilityNetworkTraceTool\UtilityNetworkTraceTool.Appearance.cs(22,22,22,45): warning CA1001: Type 'UtilityNetworkTraceTool' owns disposable field(s) '_controller', '_identifyLayersCts' but is not disposable
\Toolkit.Maui\UtilityNetworkTraceTool\UtilityNetworkTraceTool.cs(751,64,751,85): warning CS0067: The event 'UtilityNetworkTraceTool.UtilityNetworkChanged' is never used
\Toolkit.Maui\UtilityNetworkTraceTool\UtilityNetworkTraceTool.Appearance.cs(22,22,22,45): warning CA1001: Type 'UtilityNetworkTraceTool' owns disposable field(s) '_controller', '_identifyLayersCts' but is not disposable
\Toolkit.Maui\UtilityNetworkTraceTool\UtilityNetworkTraceTool.cs(751,64,751,85): warning CS0067: The event 'UtilityNetworkTraceTool.UtilityNetworkChanged' is never used
\Toolkit.Maui\UtilityNetworkTraceTool\UtilityNetworkTraceTool.Appearance.cs(22,22,22,45): warning CA1001: Type 'UtilityNetworkTraceTool' owns disposable field(s) '_controller', '_identifyLayersCts' but is not disposable
\Toolkit.Maui\UtilityNetworkTraceTool\UtilityNetworkTraceTool.cs(751,64,751,85): warning CS0067: The event 'UtilityNetworkTraceTool.UtilityNetworkChanged' is never used
\Toolkit.Maui\UtilityNetworkTraceTool\UtilityNetworkTraceTool.Appearance.cs(22,22,22,45): warning CA1001: Type 'UtilityNetworkTraceTool' owns disposable field(s) '_controller', '_identifyLayersCts' but is not disposable
\Toolkit.Maui\UtilityNetworkTraceTool\UtilityNetworkTraceTool.cs(751,64,751,85): warning CS0067: The event 'UtilityNetworkTraceTool.UtilityNetworkChanged' is never used
\Toolkit.Maui\UtilityNetworkTraceTool\UtilityNetworkTraceTool.Appearance.cs(22,22,22,45): warning CA1001: Type 'UtilityNetworkTraceTool' owns disposable field(s) '_controller', '_identifyLayersCts' but is not disposable

.NET MAUI and WinUI do not like disposable objects being part of a class that is not disposable. `UtilityNetworkTraceTool` could dispose these objects when unloaded, but followed the same pattern that was done on `SearchView`

`UtilityNetworkChanged` was not raised on .NET Maui and while fixing this, found `UtilityNetworkTraceCompleted` could be raised twice.