### PR TITLE
Added popupviewer attachment click event

### DIFF
--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/PopupViewer/PopupViewerSample.xaml
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/PopupViewer/PopupViewerSample.xaml
@@ -14,7 +14,7 @@
 
         <Grid Background="#AA333333" Visibility="Collapsed" x:Name="PopupBackground" MouseDown="PopupBackground_MouseDown">
             <Border  BorderBrush="Black" BorderThickness="1" Background="White" HorizontalAlignment="Center" VerticalAlignment="Center" >
-                    <esri:PopupViewer x:Name="popupViewer" Margin="5" Width="400" MaxHeight="400" />
+                    <esri:PopupViewer x:Name="popupViewer" Margin="5" Width="400" MaxHeight="400" PopupAttachmentClicked="popupViewer_PopupAttachmentClicked" />
             </Border>
         </Grid>
     </Grid>

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/PopupViewer/PopupViewerSample.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/PopupViewer/PopupViewerSample.xaml.cs
@@ -127,28 +127,31 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.PopupViewer
 
         private async void popupViewer_PopupAttachmentClicked(object sender, UI.Controls.PopupAttachmentClickedEventArgs e)
         {
-            try
+            if (!e.Attachment.IsLocal) // Attachment hasn't been downloaded
             {
-                // Make first click just load the attachment (or cancel a loading operation). Otherwise fallback to default behavior
-                if (e.Attachment.LoadStatus == LoadStatus.NotLoaded)
+                try
                 {
-                    e.Handled = true;
-                    await e.Attachment.LoadAsync();
+                    // Make first click just load the attachment (or cancel a loading operation). Otherwise fallback to default behavior
+                    if (e.Attachment.LoadStatus == LoadStatus.NotLoaded)
+                    {
+                        e.Handled = true;
+                        await e.Attachment.LoadAsync();
+                    }
+                    else if (e.Attachment.LoadStatus == LoadStatus.FailedToLoad)
+                    {
+                        e.Handled = true;
+                        await e.Attachment.RetryLoadAsync();
+                    }
+                    else if (e.Attachment.LoadStatus == LoadStatus.Loading)
+                    {
+                        e.Handled = true;
+                        e.Attachment.CancelLoad();
+                    }
                 }
-                else if (e.Attachment.LoadStatus == LoadStatus.FailedToLoad)
+                catch (Exception ex)
                 {
-                    e.Handled = true;
-                    await e.Attachment.RetryLoadAsync();
+                    MessageBox.Show("Failed to download attachment", ex.Message);
                 }
-                else if (e.Attachment.LoadStatus == LoadStatus.Loading)
-                {
-                    e.Handled = true;
-                    e.Attachment.CancelLoad();
-                }
-            }
-            catch (Exception ex)
-            {
-                MessageBox.Show("Failed to download attachment", ex.Message);
             }
         }
     }

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/PopupViewer/PopupViewerSample.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/PopupViewer/PopupViewerSample.xaml.cs
@@ -125,23 +125,30 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.PopupViewer
             popupViewer.Popup = null;
         }
 
-        private void popupViewer_PopupAttachmentClicked(object sender, UI.Controls.PopupAttachmentClickedEventArgs e)
+        private async void popupViewer_PopupAttachmentClicked(object sender, UI.Controls.PopupAttachmentClickedEventArgs e)
         {
-            // Make first click just load the attachment (or cancel a loading operation). Otherwise fallback to default behavior
-            if (e.Attachment.LoadStatus == LoadStatus.NotLoaded)
+            try
             {
-                e.Handled = true;
-                _ = e.Attachment.LoadAsync();
+                // Make first click just load the attachment (or cancel a loading operation). Otherwise fallback to default behavior
+                if (e.Attachment.LoadStatus == LoadStatus.NotLoaded)
+                {
+                    e.Handled = true;
+                    await e.Attachment.LoadAsync();
+                }
+                else if (e.Attachment.LoadStatus == LoadStatus.FailedToLoad)
+                {
+                    e.Handled = true;
+                    await e.Attachment.RetryLoadAsync();
+                }
+                else if (e.Attachment.LoadStatus == LoadStatus.Loading)
+                {
+                    e.Handled = true;
+                    e.Attachment.CancelLoad();
+                }
             }
-            else if (e.Attachment.LoadStatus == LoadStatus.FailedToLoad)
+            catch (Exception ex)
             {
-                e.Handled = true;
-                _ = e.Attachment.RetryLoadAsync();
-            }
-            else if (e.Attachment.LoadStatus == LoadStatus.Loading)
-            {
-                e.Handled = true;
-                e.Attachment.CancelLoad();
+                MessageBox.Show("Failed to download attachment", ex.Message);
             }
         }
     }

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/PopupViewer/PopupViewerSample.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/PopupViewer/PopupViewerSample.xaml.cs
@@ -124,5 +124,25 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.PopupViewer
             PopupBackground.Visibility = Visibility.Collapsed;
             popupViewer.Popup = null;
         }
+
+        private void popupViewer_PopupAttachmentClicked(object sender, UI.Controls.PopupAttachmentClickedEventArgs e)
+        {
+            // Make first click just load the attachment (or cancel a loading operation). Otherwise fallback to default behavior
+            if (e.Attachment.LoadStatus == LoadStatus.NotLoaded)
+            {
+                e.Handled = true;
+                _ = e.Attachment.LoadAsync();
+            }
+            else if (e.Attachment.LoadStatus == LoadStatus.FailedToLoad)
+            {
+                e.Handled = true;
+                _ = e.Attachment.RetryLoadAsync();
+            }
+            else if (e.Attachment.LoadStatus == LoadStatus.Loading)
+            {
+                e.Handled = true;
+                e.Attachment.CancelLoad();
+            }
+        }
     }
 }

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/PopupViewer/PopupViewer.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/PopupViewer/PopupViewer.Theme.xaml
@@ -58,7 +58,7 @@
                 <ControlTemplate TargetType="{x:Type primitives:AttachmentsPopupElementView}">
                     <StackPanel>
                         <StackPanel.Resources>
-                            <Style TargetType="TextBlock" x:Key="DownloadIcon">
+                            <Style TargetType="TextBlock" x:Key="DownloadIcon" xmlns:es="clr-namespace:Esri.ArcGISRuntime;assembly=Esri.ArcGISRuntime">
                                 <Setter Property="FontFamily" Value="Segoe MDL2 Assets" />
                                 <Setter Property="FontSize" Value="18" />
                                 <Setter Property="VerticalAlignment" Value="Center" />
@@ -71,7 +71,7 @@
                                     </Setter.Value>
                                 </Setter>
                                 <Style.Triggers>
-                                    <DataTrigger Binding="{Binding LoadStatus}" Value="{x:Static es:LoadStatus.Loading}" xmlns:es="clr-namespace:Esri.ArcGISRuntime;assembly=Esri.ArcGISRuntime">
+                                    <DataTrigger Binding="{Binding LoadStatus}" Value="{x:Static es:LoadStatus.Loading}">
                                         <Setter Property="Text" Value="&#xE72C;"/>
                                         <Setter Property="ToolTip" Value="Downloading"/>
                                         <DataTrigger.EnterActions>
@@ -87,13 +87,13 @@
                                             <StopStoryboard BeginStoryboardName="SpinnerStoryboard" />
                                         </DataTrigger.ExitActions>
                                     </DataTrigger>
-                                    <DataTrigger Binding="{Binding LoadStatus}" Value="{x:Static es:LoadStatus.NotLoaded}" xmlns:es="clr-namespace:Esri.ArcGISRuntime;assembly=Esri.ArcGISRuntime">
+                                    <DataTrigger Binding="{Binding LoadStatus}" Value="{x:Static es:LoadStatus.NotLoaded}">
                                         <Setter Property="Text" Value="&#xE896;"/>
                                     </DataTrigger>
-                                    <DataTrigger Binding="{Binding LoadStatus}" Value="{x:Static es:LoadStatus.FailedToLoad}" xmlns:es="clr-namespace:Esri.ArcGISRuntime;assembly=Esri.ArcGISRuntime">
+                                    <DataTrigger Binding="{Binding LoadStatus}" Value="{x:Static es:LoadStatus.FailedToLoad}">
                                         <Setter Property="Text" Value="&#xEA6A;"/>
                                     </DataTrigger>
-                                    <DataTrigger Binding="{Binding IsLocal}" Value="true" xmlns:es="clr-namespace:Esri.ArcGISRuntime;assembly=Esri.ArcGISRuntime">
+                                    <DataTrigger Binding="{Binding IsLocal}" Value="true">
                                         <Setter Property="Text" Value="&#xF13E;"/>
                                     </DataTrigger>
                                 </Style.Triggers>

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/PopupViewer/PopupViewer.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/PopupViewer/PopupViewer.Theme.xaml
@@ -63,14 +63,32 @@
                                 <Setter Property="FontSize" Value="18" />
                                 <Setter Property="VerticalAlignment" Value="Center" />
                                 <Setter Property="Margin" Value="0,0,5,0" />
-                                <Setter Property="Text" Value="&#xEBD3;" />
+                                <Setter Property="Text" Value="&#xE896;" />
+                                <Setter Property="RenderTransformOrigin" Value=".5,.5" />
+                                <Setter Property="RenderTransform">
+                                    <Setter.Value>
+                                        <RotateTransform />
+                                    </Setter.Value>
+                                </Setter>
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding LoadStatus}" Value="{x:Static es:LoadStatus.Loading}" xmlns:es="clr-namespace:Esri.ArcGISRuntime;assembly=Esri.ArcGISRuntime">
-                                        <Setter Property="Text" Value="&#xE826;"/>
+                                        <Setter Property="Text" Value="&#xE72C;"/>
                                         <Setter Property="ToolTip" Value="Downloading"/>
+                                        <DataTrigger.EnterActions>
+                                        <BeginStoryboard Name="SpinnerStoryboard">
+                                            <Storyboard RepeatBehavior="Forever" >
+                                                <DoubleAnimation 
+                                                    Storyboard.TargetProperty="RenderTransform.Angle" 
+                                                    Duration="0:0:1" From="0" To="360" />
+                                            </Storyboard>
+                                        </BeginStoryboard>
+                                        </DataTrigger.EnterActions>
+                                        <DataTrigger.ExitActions>
+                                            <StopStoryboard BeginStoryboardName="SpinnerStoryboard" />
+                                        </DataTrigger.ExitActions>
                                     </DataTrigger>
                                     <DataTrigger Binding="{Binding LoadStatus}" Value="{x:Static es:LoadStatus.Loaded}" xmlns:es="clr-namespace:Esri.ArcGISRuntime;assembly=Esri.ArcGISRuntime">
-                                        <Setter Property="Text" Value="&#xF28B;"/>
+                                        <Setter Property="Text" Value="&#xF13E;"/>
                                     </DataTrigger>
                                 </Style.Triggers>
                             </Style>

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/PopupViewer/PopupViewer.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/PopupViewer/PopupViewer.Theme.xaml
@@ -63,7 +63,7 @@
                                 <Setter Property="FontSize" Value="18" />
                                 <Setter Property="VerticalAlignment" Value="Center" />
                                 <Setter Property="Margin" Value="0,0,5,0" />
-                                <Setter Property="Text" Value="&#xE896;" />
+                                <Setter Property="Text" Value="&#xF13E;" />
                                 <Setter Property="RenderTransformOrigin" Value=".5,.5" />
                                 <Setter Property="RenderTransform">
                                     <Setter.Value>
@@ -87,7 +87,13 @@
                                             <StopStoryboard BeginStoryboardName="SpinnerStoryboard" />
                                         </DataTrigger.ExitActions>
                                     </DataTrigger>
-                                    <DataTrigger Binding="{Binding LoadStatus}" Value="{x:Static es:LoadStatus.Loaded}" xmlns:es="clr-namespace:Esri.ArcGISRuntime;assembly=Esri.ArcGISRuntime">
+                                    <DataTrigger Binding="{Binding LoadStatus}" Value="{x:Static es:LoadStatus.NotLoaded}" xmlns:es="clr-namespace:Esri.ArcGISRuntime;assembly=Esri.ArcGISRuntime">
+                                        <Setter Property="Text" Value="&#xE896;"/>
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding LoadStatus}" Value="{x:Static es:LoadStatus.FailedToLoad}" xmlns:es="clr-namespace:Esri.ArcGISRuntime;assembly=Esri.ArcGISRuntime">
+                                        <Setter Property="Text" Value="&#xEA6A;"/>
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding IsLocal}" Value="true" xmlns:es="clr-namespace:Esri.ArcGISRuntime;assembly=Esri.ArcGISRuntime">
                                         <Setter Property="Text" Value="&#xF13E;"/>
                                     </DataTrigger>
                                 </Style.Triggers>

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/PopupViewer/PopupViewer.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/PopupViewer/PopupViewer.Theme.xaml
@@ -57,12 +57,33 @@
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type primitives:AttachmentsPopupElementView}">
                     <StackPanel>
+                        <StackPanel.Resources>
+                            <Style TargetType="TextBlock" x:Key="DownloadIcon">
+                                <Setter Property="FontFamily" Value="Segoe MDL2 Assets" />
+                                <Setter Property="FontSize" Value="18" />
+                                <Setter Property="VerticalAlignment" Value="Center" />
+                                <Setter Property="Margin" Value="0,0,5,0" />
+                                <Setter Property="Text" Value="&#xEBD3;" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding LoadStatus}" Value="{x:Static es:LoadStatus.Loading}" xmlns:es="clr-namespace:Esri.ArcGISRuntime;assembly=Esri.ArcGISRuntime">
+                                        <Setter Property="Text" Value="&#xE826;"/>
+                                        <Setter Property="ToolTip" Value="Downloading"/>
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding LoadStatus}" Value="{x:Static es:LoadStatus.Loaded}" xmlns:es="clr-namespace:Esri.ArcGISRuntime;assembly=Esri.ArcGISRuntime">
+                                        <Setter Property="Text" Value="&#xF28B;"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </StackPanel.Resources>
                         <TextBlock Text="{Binding Title, Mode=OneWay}" Style="{StaticResource PopupViewerTitleStyle}" Visibility="{Binding Title, Converter={StaticResource PopupViewerVisibilityConverter}}" />
                         <TextBlock Text="{Binding Description, Mode=OneWay}" Style="{StaticResource PopupViewerCaptionStyle}" Visibility="{Binding Description, Converter={StaticResource PopupViewerVisibilityConverter}}" />
                         <ListView x:Name="AttachmentList" BorderThickness="0" SelectionMode="Single">
                             <ListView.ItemTemplate>
                                 <DataTemplate>
-                                    <TextBlock Text="{Binding Name}" Margin="5" Cursor="Hand"/>
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock Style="{StaticResource DownloadIcon}"/>
+                                        <TextBlock Text="{Binding Name}" Margin="5" Cursor="Hand"/>                                        
+                                    </StackPanel>
                                 </DataTemplate>
                             </ListView.ItemTemplate>
                         </ListView>

--- a/src/Toolkit/Toolkit/UI/Controls/PopupViewer/AttachmentsPopupElementView.Maui.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/PopupViewer/AttachmentsPopupElementView.Maui.cs
@@ -152,40 +152,6 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
             return parent as PopupViewer;
         }
 
-        /// <summary>
-        /// Occurs when an attachment is clicked.
-        /// </summary>
-        /// <remarks>
-        /// <para>Override this to prevent the default open action.</para></remarks>
-        /// <param name="attachment">Attachment clicked.</param>
-        public virtual async void OnAttachmentClicked(PopupAttachment attachment)
-        {
-            if (attachment.LoadStatus == LoadStatus.NotLoaded)
-            {
-                _ = attachment.LoadAsync();
-                return;
-            }
-            if (attachment.LoadStatus == LoadStatus.Loaded && attachment.Attachment != null)
-            {
-                var viewer = GetPopupViewerParent();
-                if(viewer is not null)
-                {
-                    bool handled = viewer.OnPopupAttachmentClicked(attachment);
-                    if (handled)
-                        return;
-                }
-
-                try
-                {
-                    await Microsoft.Maui.ApplicationModel.Launcher.Default.OpenAsync(
-                        new Microsoft.Maui.ApplicationModel.OpenFileRequest(attachment.Name, new ReadOnlyFile(attachment.Filename!, attachment.ContentType)));
-                }
-                catch
-                {
-                }
-            }
-        }
-
         private class AttachmentViewModel : System.ComponentModel.INotifyPropertyChanged
         {
             public AttachmentViewModel(PopupAttachment attachment)

--- a/src/Toolkit/Toolkit/UI/Controls/PopupViewer/AttachmentsPopupElementView.Windows.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/PopupViewer/AttachmentsPopupElementView.Windows.cs
@@ -33,7 +33,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
         private UI.Controls.PopupViewer? GetPopupViewerParent()
         {
             var parent = VisualTreeHelper.GetParent(this);
-            while(parent is not null && parent is not UI.Controls.PopupViewer popup)
+            while (parent is not null && parent is not UI.Controls.PopupViewer popup)
             {
                 parent = VisualTreeHelper.GetParent(parent);
             }

--- a/src/Toolkit/Toolkit/UI/Controls/PopupViewer/AttachmentsPopupElementView.Windows.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/PopupViewer/AttachmentsPopupElementView.Windows.cs
@@ -30,25 +30,15 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
     {
         private const string AttachmentListName = "AttachmentList";
 
-        /// <summary>
-        /// Occurs when an attachment is clicked.
-        /// </summary>
-        /// <remarks>Override this to prevent the default "save to file dialog" action.</remarks>
-        /// <param name="attachment">Attachment clicked.</param>
-        public virtual async void OnAttachmentClicked(PopupAttachment attachment)
+        private UI.Controls.PopupViewer? GetPopupViewerParent()
         {
-            SaveFileDialog saveFileDialog = new SaveFileDialog();
-            saveFileDialog.FileName = attachment.Name;
-            if (saveFileDialog.ShowDialog() == true)
+            
+            var parent = VisualTreeHelper.GetParent(this);
+            while(parent is not null && parent is not UI.Controls.PopupViewer popup)
             {
-                try
-                {
-                    using var stream = await attachment.Attachment!.GetDataAsync();
-                    using var outfile = saveFileDialog.OpenFile();
-                    await stream.CopyToAsync(outfile);
-                }
-                catch { }
+                parent = VisualTreeHelper.GetParent(parent);
             }
+            return parent as UI.Controls.PopupViewer;
         }
     }
 }

--- a/src/Toolkit/Toolkit/UI/Controls/PopupViewer/AttachmentsPopupElementView.Windows.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/PopupViewer/AttachmentsPopupElementView.Windows.cs
@@ -32,7 +32,6 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
 
         private UI.Controls.PopupViewer? GetPopupViewerParent()
         {
-            
             var parent = VisualTreeHelper.GetParent(this);
             while(parent is not null && parent is not UI.Controls.PopupViewer popup)
             {

--- a/src/Toolkit/Toolkit/UI/Controls/PopupViewer/AttachmentsPopupElementView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/PopupViewer/AttachmentsPopupElementView.cs
@@ -168,7 +168,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                         using var outfile = saveFileDialog.OpenFile();
                         await stream.CopyToAsync(outfile);
                     }
-                    catch(System.Exception ex)
+                    catch (System.Exception ex)
                     {
                         System.Diagnostics.Trace.WriteLine($"Failed to save file to disk: " + ex.Message);
                     }

--- a/src/Toolkit/Toolkit/UI/Controls/PopupViewer/PopupViewer.Maui.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/PopupViewer/PopupViewer.Maui.cs
@@ -107,59 +107,6 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui
         internal static Style GetPopupViewerTitleStyle() => GetStyle(PopupViewerTitleStyleName, DefaultPopupViewerTitleStyle);
 
         internal static Style GetPopupViewerCaptionStyle() => GetStyle(PopupViewerCaptionStyleName, DefaultPopupViewerCaptionStyle);
-
-        /// <summary>
-        /// Raised when a loaded popup attachment is clicked
-        /// </summary>
-        /// <remarks>
-        /// <para>By default, when an attachment is clicked, the default application for the file type (if any) is launched. To override this,
-        /// listen to this event, set the <see cref="PopupAttachmentClickedEventArgs.Handled"/> property to <c>true</c> and perform
-        /// your own logic. </para>
-        /// <example>
-        /// Example: Use the .NET MAUI share API for the attachment:
-        /// <code language="csharp">
-        /// private async void PopupAttachmentClicked(object sender, PopupAttachmentClickedEventArgs e)
-        /// {
-        ///     e.Handled = true; // Prevent default launch action
-        ///     await Share.Default.RequestAsync(new ShareFileRequest(new ReadOnlyFile(e.Attachment.Filename!, e.Attachment.ContentType)));
-        /// }
-        /// </code>
-        /// </example>
-        /// </remarks>
-        public event EventHandler<PopupAttachmentClickedEventArgs>? PopupAttachmentClicked;
-
-        internal bool OnPopupAttachmentClicked(PopupAttachment attachment)
-        {
-            var handler = PopupAttachmentClicked;
-            if (handler is not null)
-            {
-                var args = new PopupAttachmentClickedEventArgs(attachment);
-                PopupAttachmentClicked?.Invoke(this, args);
-                return args.Handled;
-            }
-            return false;
-        }
-    }
-
-    /// <summary>
-    /// Event argument for the <see cref="PopupViewer.PopupAttachmentClicked"/> event.
-    /// </summary>
-    public class PopupAttachmentClickedEventArgs : EventArgs
-    {
-        internal PopupAttachmentClickedEventArgs(PopupAttachment attachment)
-        {
-            Attachment = attachment;
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether the event handler has handled the event and the default action should be prevented.
-        /// </summary>
-        public bool Handled { get; set; }
-
-        /// <summary>
-        /// Gets the attachment that was clicked.
-        /// </summary>
-        public PopupAttachment Attachment { get; }
     }
 }
 #endif

--- a/src/Toolkit/Toolkit/UI/Controls/PopupViewer/PopupViewer.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/PopupViewer/PopupViewer.cs
@@ -217,6 +217,59 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
                 ScrollBarVisibility.Auto
 #endif
                 );
+
+        /// <summary>
+        /// Raised when a popup attachment is clicked
+        /// </summary>
+        /// <remarks>
+        /// <para>By default, when an attachment is clicked, the default application for the file type (if any) is launched. To override this,
+        /// listen to this event, set the <see cref="PopupAttachmentClickedEventArgs.Handled"/> property to <c>true</c> and perform
+        /// your own logic. </para>
+        /// <example>
+        /// Example: Use the .NET MAUI share API for the attachment:
+        /// <code language="csharp">
+        /// private async void PopupAttachmentClicked(object sender, PopupAttachmentClickedEventArgs e)
+        /// {
+        ///     e.Handled = true; // Prevent default launch action
+        ///     await Share.Default.RequestAsync(new ShareFileRequest(new ReadOnlyFile(e.Attachment.Filename!, e.Attachment.ContentType)));
+        /// }
+        /// </code>
+        /// </example>
+        /// </remarks>
+        public event EventHandler<PopupAttachmentClickedEventArgs>? PopupAttachmentClicked;
+
+        internal bool OnPopupAttachmentClicked(PopupAttachment attachment)
+        {
+            var handler = PopupAttachmentClicked;
+            if (handler is not null)
+            {
+                var args = new PopupAttachmentClickedEventArgs(attachment);
+                PopupAttachmentClicked?.Invoke(this, args);
+                return args.Handled;
+            }
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Event argument for the <see cref="PopupViewer.PopupAttachmentClicked"/> event.
+    /// </summary>
+    public class PopupAttachmentClickedEventArgs : EventArgs
+    {
+        internal PopupAttachmentClickedEventArgs(PopupAttachment attachment)
+        {
+            Attachment = attachment;
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the event handler has handled the event and the default action should be prevented.
+        /// </summary>
+        public bool Handled { get; set; }
+
+        /// <summary>
+        /// Gets the attachment that was clicked.
+        /// </summary>
+        public PopupAttachment Attachment { get; }
     }
 }
 #endif


### PR DESCRIPTION
This event was already available in MAUI and now exposed to WPF.

Also added ability to override and just trigger download, and make sure icons reflect current load status in sample app.

Fixes https://github.com/Esri/arcgis-maps-sdk-dotnet-toolkit/issues/555