### PR TITLE
BugFix: BasemapGallery loading demo data in production release

### DIFF
--- a/src/Toolkit/Toolkit.Maui/BasemapGallery/BasemapGallery.Appearance.cs
+++ b/src/Toolkit/Toolkit.Maui/BasemapGallery/BasemapGallery.Appearance.cs
@@ -173,7 +173,7 @@ public partial class BasemapGallery : TemplatedView
                                                     </Style>
                                                 </Grid.Resources>
                                         <CollectionView x:Name=""PART_InnerListView"" HorizontalOptions=""Fill"" VerticalOptions=""Fill"" SelectionMode=""Single"" BackgroundColor=""{{AppThemeBinding Light=#fff,Dark=#353535}}"" />
-                                        <Grid x:Name=""PART_LoadingScrim"">
+                                        <Grid x:Name=""PART_LoadingScrim"" IsVisible=""False"">
                                             <Grid BackgroundColor=""{{AppThemeBinding Light=White, Dark=Black}}"" Opacity=""0.3"" />
                                             <ActivityIndicator IsRunning=""True"" HorizontalOptions=""Center"" VerticalOptions=""Center"" />
                                         </Grid>

--- a/src/Toolkit/Toolkit.Maui/BasemapGallery/BasemapGallery.cs
+++ b/src/Toolkit/Toolkit.Maui/BasemapGallery/BasemapGallery.cs
@@ -46,21 +46,10 @@ public partial class BasemapGallery
 
     private void BasemapGallery_Loaded(object? sender, EventArgs e)
     {
-        LoadBasemaps();
-    }
-
-    private void LoadBasemaps()
-    {
-        _controller.IsLoading = true;
-        if (AvailableBasemaps == null)
+        if (AvailableBasemaps is null)
         {
             _ = _controller.LoadFromDefaultPortal();
         }
-        else
-        {
-            _controller.AvailableBasemaps = AvailableBasemaps;
-        }
-        _controller.IsLoading = false;
     }
 
     private void HandleControllerPropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/src/Toolkit/Toolkit.Maui/BasemapGallery/BasemapGallery.cs
+++ b/src/Toolkit/Toolkit.Maui/BasemapGallery/BasemapGallery.cs
@@ -41,7 +41,26 @@ public partial class BasemapGallery
         ListItemTemplate = DefaultListDataTemplate;
         GridItemTemplate = DefaultGridDataTemplate;
         ControlTemplate = DefaultControlTemplate;
-        _ = _controller.LoadFromDefaultPortal();
+        Loaded += BasemapGallery_Loaded;
+    }
+
+    private void BasemapGallery_Loaded(object? sender, EventArgs e)
+    {
+        LoadBasemaps();
+    }
+
+    private void LoadBasemaps()
+    {
+        _controller.IsLoading = true;
+        if (AvailableBasemaps == null)
+        {
+            _ = _controller.LoadFromDefaultPortal();
+        }
+        else
+        {
+            _controller.AvailableBasemaps = AvailableBasemaps;
+        }
+        _controller.IsLoading = false;
     }
 
     private void HandleControllerPropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/src/Toolkit/Toolkit.Maui/BasemapGallery/BasemapGallery.cs
+++ b/src/Toolkit/Toolkit.Maui/BasemapGallery/BasemapGallery.cs
@@ -49,6 +49,9 @@ public partial class BasemapGallery
 
     private async void BasemapGallery_Loaded(object? sender, EventArgs e)
     {
+        // Unsubscribe from the Loaded event to ensure this only runs once.
+        Loaded -= BasemapGallery_Loaded;
+
         if (AvailableBasemaps is null)
         {
             _loadCancellationTokenSource = new CancellationTokenSource();

--- a/src/Toolkit/Toolkit.Maui/BasemapGallery/BasemapGallery.cs
+++ b/src/Toolkit/Toolkit.Maui/BasemapGallery/BasemapGallery.cs
@@ -26,13 +26,10 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui;
 /// If connected to a GeoView, changing the basemap selection will change the connected Map or Scene's basemap.
 /// Only basemaps whose spatial reference matches the map or scene's spatial reference can be selected for display.
 /// </remarks>
-#pragma warning disable CA1001 // Types that own disposable fields should be disposable
 public partial class BasemapGallery
-#pragma warning restore CA1001 // Types that own disposable fields should be disposable
 {
     private CollectionView? _listView;
     private readonly BasemapGalleryController _controller;
-    private CancellationTokenSource? _loadCancellationTokenSource;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="BasemapGallery"/> class.
@@ -54,13 +51,7 @@ public partial class BasemapGallery
 
         if (AvailableBasemaps is null)
         {
-            _loadCancellationTokenSource = new CancellationTokenSource();
-            try
-            {
-                await _controller.LoadFromDefaultPortal(_loadCancellationTokenSource.Token);
-            }
-            catch (OperationCanceledException)
-            { }
+            await _controller.LoadFromDefaultPortal();
         }
     }
 
@@ -205,11 +196,7 @@ public partial class BasemapGallery
     public IList<BasemapGalleryItem>? AvailableBasemaps
     {
         get => GetValue(AvailableBasemapsProperty) as IList<BasemapGalleryItem>;
-        set
-        {
-            SetValue(AvailableBasemapsProperty, value);
-            _loadCancellationTokenSource?.Cancel();
-        }
+        set => SetValue(AvailableBasemapsProperty, value);
     }
 
     /// <summary>

--- a/src/Toolkit/Toolkit.UI.Controls/BasemapGallery/BasemapGallery.Windows.cs
+++ b/src/Toolkit/Toolkit.UI.Controls/BasemapGallery/BasemapGallery.Windows.cs
@@ -31,12 +31,9 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
     /// If connected to a GeoView, changing the basemap selection will change the connected Map or Scene's basemap.
     /// Only basemaps whose spatial reference matches the map or scene's spatial reference can be selected for display.
     /// </remarks>
-#pragma warning disable CA1001 // Types that own disposable fields should be disposable
     public partial class BasemapGallery : Control
-#pragma warning restore CA1001 // Types that own disposable fields should be disposable
     {
         private readonly BasemapGalleryController _controller;
-        private CancellationTokenSource? _loadCancellationTokenSource;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BasemapGallery"/> class.
@@ -58,13 +55,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             
             if (AvailableBasemaps is null)
             {
-                _loadCancellationTokenSource = new CancellationTokenSource();
-                try
-                {
-                    await _controller.LoadFromDefaultPortal(_loadCancellationTokenSource.Token);
-                }
-                catch (OperationCanceledException)
-                { }
+                await _controller.LoadFromDefaultPortal();
             }
         }
 

--- a/src/Toolkit/Toolkit.UI.Controls/BasemapGallery/BasemapGallery.Windows.cs
+++ b/src/Toolkit/Toolkit.UI.Controls/BasemapGallery/BasemapGallery.Windows.cs
@@ -31,9 +31,12 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
     /// If connected to a GeoView, changing the basemap selection will change the connected Map or Scene's basemap.
     /// Only basemaps whose spatial reference matches the map or scene's spatial reference can be selected for display.
     /// </remarks>
+#pragma warning disable CA1001 // Types that own disposable fields should be disposable
     public partial class BasemapGallery : Control
+#pragma warning restore CA1001 // Types that own disposable fields should be disposable
     {
         private readonly BasemapGalleryController _controller;
+        private CancellationTokenSource? _loadCancellationTokenSource;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BasemapGallery"/> class.
@@ -48,11 +51,17 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             Loaded += BasemapGallery_Loaded;
         }
 
-        private void BasemapGallery_Loaded(object? sender, RoutedEventArgs e)
+        private async void BasemapGallery_Loaded(object? sender, RoutedEventArgs e)
         {
             if (AvailableBasemaps is null)
             {
-                _ = _controller.LoadFromDefaultPortal();
+                _loadCancellationTokenSource = new CancellationTokenSource();
+                try
+                {
+                    await _controller.LoadFromDefaultPortal(_loadCancellationTokenSource.Token);
+                }
+                catch (OperationCanceledException)
+                { }
             }
         }
 

--- a/src/Toolkit/Toolkit.UI.Controls/BasemapGallery/BasemapGallery.Windows.cs
+++ b/src/Toolkit/Toolkit.UI.Controls/BasemapGallery/BasemapGallery.Windows.cs
@@ -50,21 +50,10 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
 
         private void BasemapGallery_Loaded(object? sender, RoutedEventArgs e)
         {
-            LoadBasemaps();
-        }
-
-        private void LoadBasemaps()
-        {
-            _controller.IsLoading = true;
-            if (AvailableBasemaps == null)
+            if (AvailableBasemaps is null)
             {
                 _ = _controller.LoadFromDefaultPortal();
             }
-            else
-            {
-                _controller.AvailableBasemaps = AvailableBasemaps;
-            }
-            _controller.IsLoading = false;
         }
 
         private void HandleControllerPropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/src/Toolkit/Toolkit.UI.Controls/BasemapGallery/BasemapGallery.Windows.cs
+++ b/src/Toolkit/Toolkit.UI.Controls/BasemapGallery/BasemapGallery.Windows.cs
@@ -45,7 +45,26 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             SizeChanged += BasemapGallerySizeChanged;
             AvailableBasemaps = new ObservableCollection<BasemapGalleryItem>();
             _controller.PropertyChanged += HandleControllerPropertyChanged;
-            _ = _controller.LoadFromDefaultPortal();
+            Loaded += BasemapGallery_Loaded;
+        }
+
+        private void BasemapGallery_Loaded(object? sender, RoutedEventArgs e)
+        {
+            LoadBasemaps();
+        }
+
+        private void LoadBasemaps()
+        {
+            _controller.IsLoading = true;
+            if (AvailableBasemaps == null)
+            {
+                _ = _controller.LoadFromDefaultPortal();
+            }
+            else
+            {
+                _controller.AvailableBasemaps = AvailableBasemaps;
+            }
+            _controller.IsLoading = false;
         }
 
         private void HandleControllerPropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/src/Toolkit/Toolkit.UI.Controls/BasemapGallery/BasemapGallery.Windows.cs
+++ b/src/Toolkit/Toolkit.UI.Controls/BasemapGallery/BasemapGallery.Windows.cs
@@ -53,6 +53,9 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
 
         private async void BasemapGallery_Loaded(object? sender, RoutedEventArgs e)
         {
+            // Unsubscribe from the Loaded event to ensure this only runs once.
+            Loaded -= BasemapGallery_Loaded;
+            
             if (AvailableBasemaps is null)
             {
                 _loadCancellationTokenSource = new CancellationTokenSource();

--- a/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryController.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryController.cs
@@ -224,12 +224,12 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
             }
         }
 
-        public async Task LoadFromDefaultPortal()
+        public async Task LoadFromDefaultPortal(CancellationToken cancellationToken = default)
         {
             IsLoading = true;
             try
             {
-                AvailableBasemaps = await PopulateFromDefaultList();
+                AvailableBasemaps = await PopulateFromDefaultList(cancellationToken);
             }
             finally
             {
@@ -305,11 +305,11 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
             return listOfBasemaps;
         }
 
-        private static async Task<IList<BasemapGalleryItem>> PopulateFromDefaultList()
+        private static async Task<IList<BasemapGalleryItem>> PopulateFromDefaultList(CancellationToken cancellationToken = default)
         {
-            ArcGISPortal defaultPortal = await ArcGISPortal.CreateAsync();
+            ArcGISPortal defaultPortal = await ArcGISPortal.CreateAsync(cancellationToken);
 
-            var results = await defaultPortal.GetDeveloperBasemapsAsync();
+            var results = await defaultPortal.GetDeveloperBasemapsAsync(cancellationToken);
 
             var listOfBasemaps = new List<BasemapGalleryItem>();
 

--- a/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryItem.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryItem.cs
@@ -248,8 +248,36 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
 
             return other == Basemap || (other.Item?.ItemId != null && other.Item?.ItemId == Basemap?.Item?.ItemId)
                                     || (other.Uri != null && other.Uri == Basemap?.Uri)
-                                    || (Basemap?.BaseLayers.Count == other.BaseLayers.Count
-                                        && Basemap.BaseLayers.All(layer => other?.BaseLayers.FirstOrDefault(l => l.Name == layer.Name) is not null));
+                                    || AreBasemapsEqualByLayers(Basemap, other);
+        }
+
+        private static bool AreBasemapsEqualByLayers(Basemap? basemap1, Basemap? basemap2)
+        {
+            if (basemap1 == null || basemap2 == null) return false;
+
+            return LayersEqual(basemap1.BaseLayers, basemap2.BaseLayers)
+                && LayersEqual(basemap1.ReferenceLayers, basemap2.ReferenceLayers);
+        }
+
+        private static bool LayersEqual(LayerCollection layers1, LayerCollection layers2)
+        {
+            return layers1.Count == layers2.Count
+                && layers1.Zip(layers2, (layer1, layer2) => new { Layer1 = layer1, Layer2 = layer2 })
+                    .All(pair => LayerEquals(pair.Layer1, pair.Layer2));
+        }
+
+        private static bool LayerEquals(Layer layer1, Layer layer2)
+        {
+            // This method can be extended to handle more specific layer comparisons if needed
+            if (layer1.GetType() != layer2.GetType()) return false;
+
+            return layer1 switch
+            {
+                ArcGISSceneLayer sceneLayer => sceneLayer.Source == ((ArcGISSceneLayer)layer2).Source,
+                ArcGISTiledLayer tiledLayer => tiledLayer.Source == ((ArcGISTiledLayer)layer2).Source,
+                ArcGISVectorTiledLayer vectorTiledLayer => vectorTiledLayer.Source == ((ArcGISVectorTiledLayer)layer2).Source,
+                _ => false,
+            };
         }
 
         /// <inheritdoc />

--- a/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryItem.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryItem.cs
@@ -246,10 +246,10 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
                 return false;
             }
 
-            return other == Basemap || (Basemap.BaseLayers.Count == other.BaseLayers.Count
-                                        && Basemap.BaseLayers.All(layer => other?.BaseLayers.FirstOrDefault(l => l.Name == layer.Name) is not null))
-                                    || (other.Item?.ItemId != null && other.Item?.ItemId == Basemap?.Item?.ItemId)
-                                    || (other.Uri != null && other.Uri == Basemap?.Uri);
+            return other == Basemap || (other.Item?.ItemId != null && other.Item?.ItemId == Basemap?.Item?.ItemId)
+                                    || (other.Uri != null && other.Uri == Basemap?.Uri)
+                                    || (Basemap?.BaseLayers.Count == other.BaseLayers.Count
+                                        && Basemap.BaseLayers.All(layer => other?.BaseLayers.FirstOrDefault(l => l.Name == layer.Name) is not null));
         }
 
         /// <inheritdoc />

--- a/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryItem.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryItem.cs
@@ -262,8 +262,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
         private static bool LayersEqual(LayerCollection layers1, LayerCollection layers2)
         {
             return layers1.Count == layers2.Count
-                && layers1.Zip(layers2, (layer1, layer2) => new { Layer1 = layer1, Layer2 = layer2 })
-                    .All(pair => LayerEquals(pair.Layer1, pair.Layer2));
+                && layers1.Zip(layers2, LayerEquals).All(equal => equal);
         }
 
         private static bool LayerEquals(Layer layer1, Layer layer2)

--- a/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryItem.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryItem.cs
@@ -246,7 +246,8 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
                 return false;
             }
 
-            return other == Basemap || other.Name == Basemap?.Name
+            return other == Basemap || (Basemap.BaseLayers.Count == other.BaseLayers.Count
+                                        && Basemap.BaseLayers.All(layer => other?.BaseLayers.FirstOrDefault(l => l.Name == layer.Name) is not null))
                                     || (other.Item?.ItemId != null && other.Item?.ItemId == Basemap?.Item?.ItemId)
                                     || (other.Uri != null && other.Uri == Basemap?.Uri);
         }

--- a/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryItem.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryItem.cs
@@ -273,9 +273,25 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
 
             return layer1 switch
             {
+                AnnotationLayer annotationLayer => annotationLayer.Source == ((AnnotationLayer)layer2).Source,
+                ArcGISMapImageLayer arcGISMapImageLayer => arcGISMapImageLayer.Source == ((ArcGISMapImageLayer)layer2).Source,
                 ArcGISSceneLayer sceneLayer => sceneLayer.Source == ((ArcGISSceneLayer)layer2).Source,
                 ArcGISTiledLayer tiledLayer => tiledLayer.Source == ((ArcGISTiledLayer)layer2).Source,
                 ArcGISVectorTiledLayer vectorTiledLayer => vectorTiledLayer.Source == ((ArcGISVectorTiledLayer)layer2).Source,
+                BingMapsLayer imageServiceLayer => imageServiceLayer.Portal?.Uri == ((BingMapsLayer)layer2).Portal?.Uri,
+                DimensionLayer dimensionLayer => dimensionLayer.Source == ((DimensionLayer)layer2).Source,
+                FeatureCollectionLayer featureCollectionLayer => featureCollectionLayer.FeatureCollection == ((FeatureCollectionLayer)layer2).FeatureCollection,
+                GroupLayer groupLayer => groupLayer.Layers.Count == ((GroupLayer)layer2).Layers.Count && LayersEqual(groupLayer.Layers, ((GroupLayer)layer2).Layers),
+                IntegratedMeshLayer integratedMeshLayer => integratedMeshLayer.Source == ((IntegratedMeshLayer)layer2).Source,
+                KmlLayer kmlLayer => kmlLayer.Dataset?.Source == ((KmlLayer)layer2).Dataset?.Source,
+                Ogc3DTilesLayer ogc3DTilesLayer => ogc3DTilesLayer.Source == ((Ogc3DTilesLayer)layer2).Source,
+                OpenStreetMapLayer openStreetMapLayer => true, // OpenStreetMap layers are considered equal if types match
+                PointCloudLayer pointCloudLayer => pointCloudLayer.Source == ((PointCloudLayer)layer2).Source,
+                WebTiledLayer webTiledLayer => webTiledLayer.TemplateUri == ((WebTiledLayer)layer2).TemplateUri,
+                ServiceImageTiledLayer serviceImageTiledLayer => serviceImageTiledLayer.TileInfo == ((ServiceImageTiledLayer)layer2).TileInfo && serviceImageTiledLayer.FullExtent == ((ServiceImageTiledLayer)layer2).FullExtent,
+                SubtypeFeatureLayer subtypeFeatureLayer => subtypeFeatureLayer.FeatureTable == ((SubtypeFeatureLayer)layer2).FeatureTable,
+                WmsLayer wmsLayer => wmsLayer.Source == ((WmsLayer)layer2).Source,
+                WmtsLayer wmtsLayer => wmtsLayer.Source == ((WmtsLayer)layer2).Source,
                 _ => false,
             };
         }


### PR DESCRIPTION
## Related Issue #566 
### Description

This pull request includes several updates to the `BasemapGallery` and `BasemapGalleryItem` classes. Here are the key changes:
1.	Update to `BasemapGallery.Appearance.cs`: The visibility of the `PART_LoadingScrim` Grid has been set to False. This change will hide the loading scrim by default, providing a cleaner user interface while the basemaps are loading.
2.	Refactoring of `LoadBasemaps` method: The `LoadBasemaps` method previously present in both `BasemapGallery.cs` and `BasemapGallery.Windows.cs` has been removed. Its functionality has been integrated into the `BasemapGallery_Loaded` method. This change streamlines the loading process and reduces code duplication.
3.	Enhancement to `BasemapGalleryItem.cs`: The Equals method in this class has been updated. In addition to the existing checks, it now also verifies the equality of the `BaseLayers` count and checks for the existence of all layers in `Basemap` in the `other` object. This enhancement ensures a more thorough comparison of `BasemapGalleryItem` instances.

These updates aim to improve the efficiency of the basemap loading process and the accuracy of basemap item comparisons. Please review the changes and let me know if you have any questions or feedback.
