### PR TITLE
Adds support for the barcode input field

### DIFF
--- a/src/Toolkit/Toolkit.Maui/Internal/CalciteImageButton.cs
+++ b/src/Toolkit/Toolkit.Maui/Internal/CalciteImageButton.cs
@@ -1,0 +1,43 @@
+﻿// /*******************************************************************************
+//  * Copyright 2012-2018 Esri
+//  *
+//  *  Licensed under the Apache License, Version 2.0 (the "License");
+//  *  you may not use this file except in compliance with the License.
+//  *  You may obtain a copy of the License at
+//  *
+//  *  http://www.apache.org/licenses/LICENSE-2.0
+//  *
+//  *   Unless required by applicable law or agreed to in writing, software
+//  *   distributed under the License is distributed on an "AS IS" BASIS,
+//  *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  *   See the License for the specific language governing permissions and
+//  *   limitations under the License.
+//  ******************************************************************************/
+
+namespace Esri.ArcGISRuntime.Toolkit.Maui.Internal
+{
+    internal sealed class CalciteImageButton : ImageButton
+    {
+        private readonly string _glyph;
+        public CalciteImageButton(string glyph)
+        {
+            _glyph = glyph;
+            Source = new FontImageSource() { Glyph = _glyph, FontFamily = "calcite-ui-icons-24", Color = Color };
+            this.SetAppThemeColor(ColorProperty, Colors.Black, Colors.White);
+        }
+
+        public Color Color
+        {
+            get { return (Color)GetValue(ColorProperty); }
+            set { SetValue(ColorProperty, value); }
+        }
+
+        public static readonly BindableProperty ColorProperty = BindableProperty.Create(nameof(Color), typeof(Color), typeof(CalciteImageButton), Colors.Black,
+            propertyChanged: (s, oldValue, newValue) => ((CalciteImageButton)s).SetColor());
+
+        private void SetColor()
+        {
+            ((FontImageSource)Source).Color = Color;
+        }
+    }
+}

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/FeatureForm/FeatureFormView.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/FeatureForm/FeatureFormView.Theme.xaml
@@ -119,6 +119,8 @@
     <Setter Property="KeyboardNavigation.IsTabStop" Value="False" />
   </Style>
   <Style TargetType="{x:Type primitives:TextFormInputView}">
+    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="BorderBrush" Value="Black" />
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type primitives:TextFormInputView}">
@@ -156,14 +158,29 @@
               <TextBlock Text="/" />
               <TextBlock Text="{Binding MaxLength, ElementName=TextInput}" />
             </StackPanel>
-            <TextBox x:Name="TextInput" MaxLines="{TemplateBinding MaxLines}" MinLines="{TemplateBinding MinLines}" /> 
+            <Border BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <TextBox x:Name="TextInput" MaxLines="{TemplateBinding MaxLines}" MinLines="{TemplateBinding MinLines}" BorderThickness="0" />
+                    <TextBlock Text="!" Background="Transparent" Width="10" Foreground="Red" Visibility="Collapsed" HorizontalAlignment="Right" VerticalAlignment="Center" x:Name="ErrorInfo" Grid.Column="1" />
+                    <Button Content="&#xED14;" FontFamily="Segoe MDL2 Assets" Background="Transparent" Grid.Column="2"
+                       Padding="8" Margin="-8,-8,-5,-7" BorderThickness="0" Visibility="Collapsed" HorizontalAlignment="Right" VerticalAlignment="Center" x:Name="BarcodeButton" />
+                </Grid>
+            </Border>
             <TextBlock x:Name="ReadOnlyText" Visibility="Collapsed" />
             <Border x:Name="ErrorBorder" BorderThickness="1" BorderBrush="Red" Visibility="Collapsed" />
-            <TextBlock Text="!" Background="Transparent" Width="10" Foreground="Red" Visibility="Collapsed" HorizontalAlignment="Right" VerticalAlignment="Center" x:Name="ErrorInfo" />
           </Grid>
           <ControlTemplate.Triggers>
+            <Trigger Property="ShowBarcodeScanner" Value="true">
+              <Setter TargetName="BarcodeButton" Property="Visibility" Value="Visible"/>
+            </Trigger>
             <Trigger Property="IsEnabled" Value="false">
               <Setter TargetName="TextInput" Property="Visibility" Value="Collapsed"/> 
+              <Setter TargetName="BarcodeButton" Property="Visibility" Value="Collapsed"/> 
               <Setter TargetName="ReadOnlyText" Property="Visibility" Value="Visible"/>
             </Trigger>
             <Trigger Property="IsEnabled" Value="true">
@@ -176,6 +193,7 @@
             <Trigger Property="ShowCharacterCount" Value="true">
               <Setter TargetName="CharacterCountPanel" Property="Visibility" Value="Visible"/>
             </Trigger>
+
           </ControlTemplate.Triggers>
         </ControlTemplate>
       </Setter.Value>
@@ -213,6 +231,13 @@
       </Setter.Value>
     </Setter>
     <Setter Property="TextBoxFormInputTemplate">
+      <Setter.Value>
+        <DataTemplate>
+          <primitives:TextFormInputView Element="{Binding}" IsEnabled="{Binding IsEditable}" />
+        </DataTemplate>
+      </Setter.Value>
+    </Setter>
+    <Setter Property="BarcodeScannerFormInputTemplate">
       <Setter.Value>
         <DataTemplate>
           <primitives:TextFormInputView Element="{Binding}" IsEnabled="{Binding IsEditable}" />

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FeatureFormView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FeatureFormView.cs
@@ -272,6 +272,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
                 uint min = 0;
                 if (element.Input is TextAreaFormInput area) { max = area.MaxLength; min = area.MinLength; }
                 else if (element.Input is TextBoxFormInput tb) { max = tb.MaxLength; min = tb.MinLength; }
+                else if (element.Input is BarcodeScannerFormInput bar) { max = bar.MaxLength; min = bar.MinLength; }
                 if (max > 0 && min > 0)
                     return string.Format(Properties.Resources.GetString("FeatureFormOutsideLengthRange")!, min, max);
                 if (max > 0)
@@ -357,6 +358,28 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             }
             return false;
         }
+
+        /// <summary>
+        /// Raised when the Barcode Icon in a barcode element is clicked.
+        /// </summary>
+        /// <remarks>
+        /// <para>Set the <see cref="BarcodeButtonClickedEventArgs.Handled"/> property to <c>true</c> to prevent
+        /// any default code and perform your own logic.</para>
+        /// </remarks>
+        public event EventHandler<BarcodeButtonClickedEventArgs>? BarcodeButtonClicked;
+
+        internal bool OnBarcodeButtonClicked(FieldFormElement element)
+        {
+            var handler = BarcodeButtonClicked;
+            if (handler is not null)
+            {
+                var args = new BarcodeButtonClickedEventArgs(element);
+                
+                handler.Invoke(this, args);
+                return args.Handled;
+            }
+            return false;
+        }
     }
 
     /// <summary>
@@ -378,6 +401,27 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         /// Gets the attachment that was clicked.
         /// </summary>
         public FormAttachment Attachment { get; }
+    }
+
+    /// <summary>
+    /// Event argument for the <see cref="FeatureFormView.BarcodeButtonClicked"/> event.
+    /// </summary>
+    public class BarcodeButtonClickedEventArgs : EventArgs
+    {
+        internal BarcodeButtonClickedEventArgs(FieldFormElement element)
+        {
+            FormElement = element;
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the event handler has handled the event and the default action should be prevented.
+        /// </summary>
+        public bool Handled { get; set; }
+
+        /// <summary>
+        /// Gets the element that was clicked.
+        /// </summary>
+        public FieldFormElement FormElement { get; }
     }
 }
 #endif

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FieldFormElementView.Maui.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FieldFormElementView.Maui.cs
@@ -32,6 +32,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
         private static readonly DataTemplate DefaultRadioButtonsFormInputTemplate;
         private static readonly DataTemplate DefaultTextAreaFormInputTemplate;
         private static readonly DataTemplate DefaultTextBoxFormInputTemplate;
+        private static readonly DataTemplate DefaultBarcodeScannerFormInputTemplate;
 
 
         static FieldFormElementView()
@@ -43,6 +44,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
             DefaultRadioButtonsFormInputTemplate = new DataTemplate(BuildDefaultRadioButtonsFormInputTemplate);
             DefaultTextAreaFormInputTemplate = new DataTemplate(BuildDefaultTextAreaFormInputTemplate);
             DefaultTextBoxFormInputTemplate = new DataTemplate(BuildDefaultTextBoxFormInputTemplate);
+            DefaultBarcodeScannerFormInputTemplate = new DataTemplate(BuildDefaultBarcodeScannerFormInputTemplate);
         }
 
         private static object BuildDefaultComboBoxFormInputTemplate()
@@ -81,6 +83,13 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
         }
 
         private static object BuildDefaultTextBoxFormInputTemplate()
+        {
+            var input = new TextFormInputView();
+            input.SetBinding(TextFormInputView.ElementProperty, Binding.SelfPath);
+            return input;
+        }
+
+        private static object BuildDefaultBarcodeScannerFormInputTemplate()
         {
             var input = new TextFormInputView();
             input.SetBinding(TextFormInputView.ElementProperty, Binding.SelfPath);

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FieldFormElementView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FieldFormElementView.cs
@@ -299,8 +299,8 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
         /// </summary>
         public DataTemplate? BarcodeScannerFormInputTemplate
         {
-            get { return (DataTemplate)GetValue(TextBoxFormInputTemplateProperty); }
-            set { SetValue(TextBoxFormInputTemplateProperty, value); }
+            get { return (DataTemplate)GetValue(BarcodeScannerFormInputTemplateProperty); }
+            set { SetValue(BarcodeScannerFormInputTemplateProperty, value); }
         }
 
         /// <summary>

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FieldFormElementView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FieldFormElementView.cs
@@ -54,6 +54,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
             RadioButtonsFormInputTemplate = DefaultRadioButtonsFormInputTemplate;
             TextAreaFormInputTemplate = DefaultTextAreaFormInputTemplate;
             TextBoxFormInputTemplate = DefaultTextBoxFormInputTemplate;
+            BarcodeScannerFormInputTemplate = BarcodeScannerFormInputTemplate;
 #else
             DefaultStyleKey = typeof(FieldFormElementView);
 #endif
@@ -148,7 +149,8 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                 Element.Input is DateTimePickerFormInput ||
                 Element.Input is RadioButtonsFormInput ||
                 Element.Input is TextAreaFormInput ||
-                Element.Input is TextBoxFormInput);
+                Element.Input is TextBoxFormInput ||
+                Element.Input is BarcodeScannerFormInput);
 #if MAUI
             this.IsVisible = isVisible;
 #else
@@ -290,6 +292,25 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
             BindableProperty.Create(nameof(TextBoxFormInputTemplate), typeof(DataTemplate), typeof(FieldFormElementView), null);
 #else
             DependencyProperty.Register(nameof(TextBoxFormInputTemplate), typeof(DataTemplate), typeof(FieldFormElementView), new PropertyMetadata(null));
+#endif
+
+        /// <summary>
+        /// Gets or sets the template for the <see cref="BarcodeScannerFormInputTemplate"/> element.
+        /// </summary>
+        public DataTemplate? BarcodeScannerFormInputTemplate
+        {
+            get { return (DataTemplate)GetValue(TextBoxFormInputTemplateProperty); }
+            set { SetValue(TextBoxFormInputTemplateProperty, value); }
+        }
+
+        /// <summary>
+        /// Identifies the <see cref="BarcodeScannerFormInputTemplate"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty BarcodeScannerFormInputTemplateProperty =
+#if MAUI
+            BindableProperty.Create(nameof(BarcodeScannerFormInputTemplate), typeof(DataTemplate), typeof(FieldFormElementView), null);
+#else
+            DependencyProperty.Register(nameof(BarcodeScannerFormInputTemplate), typeof(DataTemplate), typeof(FieldFormElementView), new PropertyMetadata(null));
 #endif
     }
 }

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FieldFormElementView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FieldFormElementView.cs
@@ -54,7 +54,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
             RadioButtonsFormInputTemplate = DefaultRadioButtonsFormInputTemplate;
             TextAreaFormInputTemplate = DefaultTextAreaFormInputTemplate;
             TextBoxFormInputTemplate = DefaultTextBoxFormInputTemplate;
-            BarcodeScannerFormInputTemplate = BarcodeScannerFormInputTemplate;
+            BarcodeScannerFormInputTemplate = DefaultBarcodeScannerFormInputTemplate;
 #else
             DefaultStyleKey = typeof(FieldFormElementView);
 #endif

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FieldTemplateSelector.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FieldTemplateSelector.cs
@@ -47,6 +47,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                     RadioButtonsFormInput => _parent.RadioButtonsFormInputTemplate,
                     TextAreaFormInput => _parent.TextAreaFormInputTemplate,
                     TextBoxFormInput => _parent.TextBoxFormInputTemplate,
+                    BarcodeScannerFormInput => _parent.BarcodeScannerFormInputTemplate,
                     _ => base.SelectTemplate(item, container)
                 };
             }

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FieldTemplateSelector.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FieldTemplateSelector.cs
@@ -48,10 +48,18 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                     TextAreaFormInput => _parent.TextAreaFormInputTemplate,
                     TextBoxFormInput => _parent.TextBoxFormInputTemplate,
                     BarcodeScannerFormInput => _parent.BarcodeScannerFormInputTemplate,
+#if MAUI
+                    _ => null
+#else
                     _ => base.SelectTemplate(item, container)
+#endif
                 };
             }
+#if MAUI
+            return null;
+#else
             return base.SelectTemplate(item, container);
+#endif
         }
     }
 }

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/TextFormInputView.Maui.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/TextFormInputView.Maui.cs
@@ -30,11 +30,13 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
         [DynamicDependency(nameof(Esri.ArcGISRuntime.Mapping.FeatureForms.FieldFormElement.Value), "Esri.ArcGISRuntime.Mapping.FeatureForms.FieldFormElement", "Esri.ArcGISRuntime")]
         [DynamicDependency(nameof(Esri.ArcGISRuntime.Mapping.FeatureForms.TextAreaFormInput.MaxLength), "Esri.ArcGISRuntime.Mapping.FeatureForms.TextAreaFormInput", "Esri.ArcGISRuntime")]
         [DynamicDependency(nameof(Esri.ArcGISRuntime.Mapping.FeatureForms.TextBoxFormInput.MaxLength), "Esri.ArcGISRuntime.Mapping.FeatureForms.TextBoxFormInput", "Esri.ArcGISRuntime")]
+        [DynamicDependency(nameof(Esri.ArcGISRuntime.Mapping.FeatureForms.BarcodeScannerFormInput.MaxLength), "Esri.ArcGISRuntime.Mapping.FeatureForms.BarcodeScannerFormInput", "Esri.ArcGISRuntime")]
         private static object BuildDefaultTemplate()
         {
             
             Grid root = new Grid();
             root.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Star));
+            root.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
             root.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
             HorizontalStackLayout horizontalStackLayout = new HorizontalStackLayout();
             horizontalStackLayout.Margin = new Thickness(0, -17, 0, 0);
@@ -47,6 +49,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
             maxCountLabel.SetBinding(Label.TextProperty, new Binding("Element.Input.MaxLength", source: RelativeBindingSource.TemplatedParent));
             horizontalStackLayout.Children.Add(maxCountLabel);
             Grid.SetColumn(horizontalStackLayout, 1);
+            Grid.SetColumnSpan(horizontalStackLayout, 2);
             root.Add(horizontalStackLayout);
             Entry textInput = new Entry();
             Grid.SetColumnSpan(textInput, 2);
@@ -63,6 +66,10 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
             Border errorBorder = new Border() { StrokeThickness = 1, Stroke = new SolidColorBrush(Colors.Red), IsVisible = false };
             Grid.SetColumnSpan(errorBorder, 2);
             root.Add(errorBorder);
+            ImageButton barcodeButton = new ImageButton() { IsVisible = false, BorderWidth = 0, Source = new FontImageSource() { FontFamily = "calcite-ui-icons-24", Glyph = "\uE22F", Color = Colors.Black } };
+            Grid.SetColumn(barcodeButton, 2);
+            barcodeButton.SetBinding(View.IsVisibleProperty, new Binding(nameof(TextFormInputView.ShowBarcodeScanner), source: RelativeBindingSource.TemplatedParent));
+            root.Add(barcodeButton);
 
             INameScope nameScope = new NameScope();
             NameScope.SetNameScope(root, nameScope);
@@ -70,6 +77,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
             nameScope.RegisterName("TextInput", textInput);
             nameScope.RegisterName("TextAreaInput", textArea);
             nameScope.RegisterName("ReadOnlyText", readonlyText);
+            nameScope.RegisterName("BarcodeButton", barcodeButton);
             return root;
         }
 
@@ -100,8 +108,22 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
                 _textAreaInput.TextChanged += TextInput_TextChanged;
             }
             _readonlyLabel = GetTemplateChild("ReadOnlyText") as Label;
+            if (GetTemplateChild("BarcodeButton") is ImageButton imageButton)
+            {
+                imageButton.Clicked += BarcodeButton_Clicked;
+            }
+            else if (GetTemplateChild("BarcodeButton") is Button button)
+            {
+                button.Clicked += BarcodeButton_Clicked;
+            }
             ConfigureTextBox();
             UpdateValidationState();
+        }
+
+        private void BarcodeButton_Clicked(object? sender, EventArgs e)
+        {
+            if (Element != null)
+                FeatureFormView.GetFeatureFormViewParent(this)?.OnBarcodeButtonClicked(Element);
         }
     }
 }

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/TextFormInputView.Maui.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/TextFormInputView.Maui.cs
@@ -3,6 +3,7 @@ using Microsoft.Maui.Controls.Internals;
 using Esri.ArcGISRuntime.Mapping.FeatureForms;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 
 namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
 {
@@ -66,7 +67,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
             Border errorBorder = new Border() { StrokeThickness = 1, Stroke = new SolidColorBrush(Colors.Red), IsVisible = false };
             Grid.SetColumnSpan(errorBorder, 2);
             root.Add(errorBorder);
-            ImageButton barcodeButton = new ImageButton() { IsVisible = false, BorderWidth = 0, Source = new FontImageSource() { FontFamily = "calcite-ui-icons-24", Glyph = "\uE22F", Color = Colors.Black } };
+            Internal.CalciteImageButton barcodeButton = new Internal.CalciteImageButton("\uE22F") { IsVisible = false, BorderWidth = 0 };
             Grid.SetColumn(barcodeButton, 2);
             barcodeButton.SetBinding(View.IsVisibleProperty, new Binding(nameof(TextFormInputView.ShowBarcodeScanner), source: RelativeBindingSource.TemplatedParent));
             root.Add(barcodeButton);

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/TextFormInputView.Windows.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/TextFormInputView.Windows.cs
@@ -9,6 +9,7 @@ using System.Globalization;
 using System.Text;
 using System.Windows.Controls.Primitives;
 using System.Windows.Input;
+using Esri.ArcGISRuntime.Toolkit.UI.Controls;
 
 namespace Esri.ArcGISRuntime.Toolkit.Primitives
 {
@@ -16,6 +17,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
     {
         private TextBox? _textInput;
         private TextBlock? _readonlyLabel;
+        private ButtonBase? _barcodeButton;
 
 
         /// <inheritdoc />
@@ -34,8 +36,23 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                 _textInput.TextChanged += TextInput_TextChanged;
             }
             _readonlyLabel = GetTemplateChild("ReadOnlyText") as TextBlock;
+            if (_barcodeButton != null)
+            {
+                _barcodeButton.Click -= BarcodeButton_Click;
+            }
+            _barcodeButton = GetTemplateChild("BarcodeButton") as ButtonBase;
+            if (_barcodeButton != null)
+            {
+                _barcodeButton.Click += BarcodeButton_Click;
+            }
             ConfigureTextBox();
             UpdateValidationState();
+        }
+
+        private void BarcodeButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (Element != null)
+                FeatureFormView.GetFeatureFormViewParent(this)?.OnBarcodeButtonClicked(Element);
         }
     }
 }

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/TextFormInputView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/TextFormInputView.cs
@@ -47,27 +47,27 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                 {
 #if MAUI
                     if (_textLineInput != null) _textLineInput.IsVisible = false;
-                    if (_textAreaInput != null)
-                    {
-                        _textAreaInput.IsVisible = Element.IsEditable;
-                    }
+                    if (_textAreaInput != null) _textAreaInput.IsVisible = Element.IsEditable;
 #else
                     _textInput.AcceptsReturn = true;
 #endif
                     _textInput.MaxLength = (int)area.MaxLength;
                 }
-                else if (Element?.Input is TextBoxFormInput box)
+                else if (Element?.Input is TextBoxFormInput || Element?.Input is BarcodeScannerFormInput)
                 {
 #if MAUI
                     if (_textAreaInput != null) _textAreaInput.IsVisible = false;
-                    if (_textLineInput != null)
-                    {
-                        _textLineInput.IsVisible = Element.IsEditable;
-                    }
+                    if (_textLineInput != null) _textLineInput.IsVisible = Element.IsEditable;
 #else
                     _textInput.AcceptsReturn = false;
 #endif
-                    _textInput.MaxLength = (int)box.MaxLength;
+                    int maxLength = 0;
+                    if (Element?.Input is TextBoxFormInput box)
+                        maxLength = (int)box.MaxLength;
+                    else if (Element?.Input is BarcodeScannerFormInput bar)
+                        maxLength = (int)bar.MaxLength;
+
+                    _textInput.MaxLength = maxLength == 0 ? int.MaxValue : maxLength;
                 }
                 _textInput.Text = Element?.Value?.ToString();
 #if MAUI
@@ -90,14 +90,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                 _readonlyLabel.Text = Element?.FormattedValue;
             }
 
-            if (Element?.Input is BarcodeScannerFormInput barcode)
-            {
-                ShowBarcodeScanner = Element.IsEditable;
-                if (_textInput != null)
-                    _textInput.MaxLength = (int)barcode.MaxLength;
-            }
-            else
-                ShowBarcodeScanner = false;
+            ShowBarcodeScanner = Element?.Input is BarcodeScannerFormInput && Element.IsEditable;
 
 #if !MAUI
             if (_textInput != null)

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/TextFormInputView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/TextFormInputView.cs
@@ -89,8 +89,18 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
 #endif
                 _readonlyLabel.Text = Element?.FormattedValue;
             }
+
+            if (Element?.Input is BarcodeScannerFormInput barcode)
+            {
+                ShowBarcodeScanner = Element.IsEditable;
+                if (_textInput != null)
+                    _textInput.MaxLength = (int)barcode.MaxLength;
+            }
+            else
+                ShowBarcodeScanner = false;
+
 #if !MAUI
-            if(_textInput != null)
+            if (_textInput != null)
                 _textInput.Visibility = Element?.IsEditable == false ? Visibility.Collapsed : Visibility.Visible;
 #endif
         }
@@ -187,7 +197,8 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
         /// </summary>
         public bool ShowCharacterCount
         {
-            get {
+            get
+            {
 #if MAUI
                 return _showCharacterCount;
 #else
@@ -197,7 +208,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
             private set
             {
 #if MAUI
-                if(_showCharacterCount != value)
+                if (_showCharacterCount != value)
                 {
                     _showCharacterCount = value;
                     OnPropertyChanged(nameof(ShowCharacterCount));
@@ -213,6 +224,40 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
 #else
         private static readonly DependencyPropertyKey ShowCharacterCountPropertyKey =
             DependencyProperty.RegisterReadOnly(nameof(ShowCharacterCount), typeof(bool), typeof(TextFormInputView), new PropertyMetadata(false));
+#endif
+
+        /// <summary>
+        /// Gets a value indicating whether the bar code scanner button is visible.
+        /// </summary>
+        public bool ShowBarcodeScanner
+        {
+            get
+            {
+#if MAUI
+                return _ShowBarcodeScanner;
+#else
+                return (bool)GetValue(ShowBarcodeScannerPropertyKey.DependencyProperty);
+#endif
+            }
+            private set
+            {
+#if MAUI
+                if (_ShowBarcodeScanner != value)
+                {
+                    _ShowBarcodeScanner = value;
+                    OnPropertyChanged(nameof(ShowBarcodeScanner));
+                }
+#else
+                SetValue(ShowBarcodeScannerPropertyKey, value);
+#endif
+            }
+        }
+
+#if MAUI
+        private bool _ShowBarcodeScanner = false;
+#else
+        private static readonly DependencyPropertyKey ShowBarcodeScannerPropertyKey =
+            DependencyProperty.RegisterReadOnly(nameof(ShowBarcodeScanner), typeof(bool), typeof(TextFormInputView), new PropertyMetadata(false));
 #endif
 
         /// <summary>


### PR DESCRIPTION
Allows rendering the new BarcodeScannerInputField. This is just the text field, but with a QR code icon button users can click.
At this point of implementation, no default action happens clicking this, but users can react to the BarcodeButtonClicked event on the FeatureForm and use for instance ZXing to launch a barcode scanner.
```cs
    private async void FeatureFormView_BarcodeButtonClicked(object sender, BarcodeButtonClickedEventArgs e)
    {
        try {
            e.FormElement.UpdateValue(await GetBarcodeScan());
        } catch {}
    }
```