### PR TITLE
BugFix: BasemapGallery fails to load default Basemaps in WPF

### DIFF
--- a/src/Toolkit/Toolkit.UI.Controls/BasemapGallery/BasemapGallery.Windows.cs
+++ b/src/Toolkit/Toolkit.UI.Controls/BasemapGallery/BasemapGallery.Windows.cs
@@ -34,6 +34,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
     public partial class BasemapGallery : Control
     {
         private readonly BasemapGalleryController _controller;
+        private bool isAvailableBasemapCollectionInitialized;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BasemapGallery"/> class.
@@ -43,6 +44,8 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             _controller = new BasemapGalleryController();
             DefaultStyleKey = typeof(BasemapGallery);
             SizeChanged += BasemapGallerySizeChanged;
+            AvailableBasemaps = new ObservableCollection<BasemapGalleryItem>();
+            isAvailableBasemapCollectionInitialized = true;
             _controller.PropertyChanged += HandleControllerPropertyChanged;
             Loaded += BasemapGallery_Loaded;
         }
@@ -52,7 +55,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             // Unsubscribe from the Loaded event to ensure this only runs once.
             Loaded -= BasemapGallery_Loaded;
 
-            if (AvailableBasemaps is null)
+            if ((AvailableBasemaps is null || !AvailableBasemaps.Any()) && isAvailableBasemapCollectionInitialized)
             {
                 await _controller.LoadFromDefaultPortal();
             }
@@ -140,6 +143,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         {
             if (d is BasemapGallery gallery)
             {
+                gallery.isAvailableBasemapCollectionInitialized = false;
                 if (e.NewValue != gallery._controller.AvailableBasemaps)
                 {
                     gallery._controller.AvailableBasemaps = e.NewValue as IList<BasemapGalleryItem>;

--- a/src/Toolkit/Toolkit.UI.Controls/BasemapGallery/BasemapGallery.Windows.cs
+++ b/src/Toolkit/Toolkit.UI.Controls/BasemapGallery/BasemapGallery.Windows.cs
@@ -43,7 +43,6 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             _controller = new BasemapGalleryController();
             DefaultStyleKey = typeof(BasemapGallery);
             SizeChanged += BasemapGallerySizeChanged;
-            AvailableBasemaps = new ObservableCollection<BasemapGalleryItem>();
             _controller.PropertyChanged += HandleControllerPropertyChanged;
             Loaded += BasemapGallery_Loaded;
         }
@@ -52,7 +51,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         {
             // Unsubscribe from the Loaded event to ensure this only runs once.
             Loaded -= BasemapGallery_Loaded;
-            
+
             if (AvailableBasemaps is null)
             {
                 await _controller.LoadFromDefaultPortal();


### PR DESCRIPTION
### Description:
The BasemapGallery used to be fully empty when default Basemaps are loaded.
It also preserved loading custom Basemaps into the BasemapGallery.

#### BasemapGallery with Default Basemaps:

![image](https://github.com/user-attachments/assets/d0696663-b4e6-44c6-bbcd-ccba310753f1)


#### BasemapGallery with Custom Basemaps:

![image](https://github.com/user-attachments/assets/b356fa6d-d973-4e01-9760-83b32514a1a6)
