### PR TITLE
BugFix: Fixes BasemapGallery View Style in MAUI Windows

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -46,8 +46,8 @@
     <NetMauiWindowsTargetFramework Condition="'$(NetMauiWindowsTargetFramework)'==''">$(NETMauiTarget)-windows10.0.$(WindowsSDKTargetBuild).0</NetMauiWindowsTargetFramework>
     <NetAndroidTargetFramework Condition="'$(NetAndroidTargetFramework)'==''">$(NETMauiTarget)-android34.0</NetAndroidTargetFramework>
     <NetCatalystTargetFramework Condition="'$(NetCatalystTargetFramework)'==''">$(NETMauiTarget)-maccatalyst17.0</NetCatalystTargetFramework>
-    <NetiOSTargetFramework Condition="'$(NetiOSTargetFramework)'==''">$(NETMauiTarget)-ios17.0</NetiOSTargetFramework>  
-    <MauiVersion Condition="'$(MauiVersion)'==''">8.0.3</MauiVersion>
+    <NetiOSTargetFramework Condition="'$(NetiOSTargetFramework)'==''">$(NETMauiTarget)-ios17.0</NetiOSTargetFramework>
+    <MauiVersion Condition="'$(MauiVersion)'==''">8.0.10</MauiVersion>
   </PropertyGroup>
   <PropertyGroup>
     <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -46,8 +46,8 @@
     <NetMauiWindowsTargetFramework Condition="'$(NetMauiWindowsTargetFramework)'==''">$(NETMauiTarget)-windows10.0.$(WindowsSDKTargetBuild).0</NetMauiWindowsTargetFramework>
     <NetAndroidTargetFramework Condition="'$(NetAndroidTargetFramework)'==''">$(NETMauiTarget)-android34.0</NetAndroidTargetFramework>
     <NetCatalystTargetFramework Condition="'$(NetCatalystTargetFramework)'==''">$(NETMauiTarget)-maccatalyst17.0</NetCatalystTargetFramework>
-    <NetiOSTargetFramework Condition="'$(NetiOSTargetFramework)'==''">$(NETMauiTarget)-ios17.0</NetiOSTargetFramework>
-    <MauiVersion Condition="'$(MauiVersion)'==''">8.0.10</MauiVersion>
+    <NetiOSTargetFramework Condition="'$(NetiOSTargetFramework)'==''">$(NETMauiTarget)-ios17.0</NetiOSTargetFramework>  
+    <MauiVersion Condition="'$(MauiVersion)'==''">8.0.3</MauiVersion>
   </PropertyGroup>
   <PropertyGroup>
     <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>

--- a/src/Toolkit/Toolkit.Maui/BasemapGallery/BasemapGallery.Appearance.cs
+++ b/src/Toolkit/Toolkit.Maui/BasemapGallery/BasemapGallery.Appearance.cs
@@ -293,13 +293,13 @@ public partial class BasemapGallery : TemplatedView
             if (styleAfterUpdate == BasemapGalleryViewStyle.List)
             {
                 ListView.ItemTemplate = ListItemTemplate;
-                ReassignItemsLayout(1, 0, 0);
+                UpdateItemsLayout(1, 0, 0);
                 ListView.Margin = new Thickness(0);
             }
             else
             {
                 ListView.ItemTemplate = DefaultGridDataTemplate;
-                ReassignItemsLayout(gridSpanAfterUpdate, 4, 4);
+                UpdateItemsLayout(gridSpanAfterUpdate, 4, 4);
                 ListView.Margin = new Thickness(4, 4, 0, 0);
             }
 
@@ -308,7 +308,7 @@ public partial class BasemapGallery : TemplatedView
         }
     }
 
-    private void ReassignItemsLayout(int span, double verticalSpacing, double horizontalSpacing)
+    private void UpdateItemsLayout(int span, double verticalSpacing, double horizontalSpacing)
     {
         if (ListView is not null)
         {

--- a/src/Toolkit/Toolkit.Maui/BasemapGallery/BasemapGallery.Appearance.cs
+++ b/src/Toolkit/Toolkit.Maui/BasemapGallery/BasemapGallery.Appearance.cs
@@ -310,11 +310,26 @@ public partial class BasemapGallery : TemplatedView
 
     private void UpdateItemsLayout(int span, double verticalSpacing, double horizontalSpacing)
     {
-        if (ListView?.ItemsLayout is GridItemsLayout layout)
+        if (ListView is not null)
         {
-            layout.Span = span;
-            layout.VerticalItemSpacing = verticalSpacing;
-            layout.HorizontalItemSpacing = horizontalSpacing;
+#if __IOS__
+            // This is a workaround for a bug in the current version of the iOS renderer for CollectionView
+            // where CollectionView throws `NullReferneceException` on changing span of GridItemsLayout.
+            // It won't be needed once we move MAUI version up to 8.0.10+.
+            // Will have to consider if toolkit can require a newer version (currently it's fixed to API).
+            ListView.ItemsLayout = new GridItemsLayout(span, ItemsLayoutOrientation.Vertical)
+            {
+                VerticalItemSpacing = verticalSpacing,
+                HorizontalItemSpacing = horizontalSpacing,
+            }; 
+#else
+            if (ListView.ItemsLayout is GridItemsLayout layout)
+            {
+                layout.Span = span;
+                layout.VerticalItemSpacing = verticalSpacing;
+                layout.HorizontalItemSpacing = horizontalSpacing;
+            }
+#endif
         }
     }
 

--- a/src/Toolkit/Toolkit.Maui/BasemapGallery/BasemapGallery.Appearance.cs
+++ b/src/Toolkit/Toolkit.Maui/BasemapGallery/BasemapGallery.Appearance.cs
@@ -293,28 +293,41 @@ public partial class BasemapGallery : TemplatedView
             if (styleAfterUpdate == BasemapGalleryViewStyle.List)
             {
                 ListView.ItemTemplate = ListItemTemplate;
-                if (ListView.ItemsLayout is GridItemsLayout layout)
-                {
-                    layout.Span = 1;
-                    layout.VerticalItemSpacing = 0;
-                    layout.HorizontalItemSpacing = 0;
-                };
+                ReassignItemsLayout(1, 0, 0);
                 ListView.Margin = new Thickness(0);
             }
             else
             {
                 ListView.ItemTemplate = DefaultGridDataTemplate;
-                if (ListView.ItemsLayout is GridItemsLayout layout)
-                {
-                    layout.Span = gridSpanAfterUpdate;
-                    layout.VerticalItemSpacing = 4;
-                    layout.HorizontalItemSpacing = 4;
-                }
+                ReassignItemsLayout(gridSpanAfterUpdate, 4, 4);
                 ListView.Margin = new Thickness(4, 4, 0, 0);
             }
 
             _currentSelectedSpan = gridSpanAfterUpdate;
             _currentlyAppliedViewStyle = styleAfterUpdate;
+        }
+    }
+
+    private void ReassignItemsLayout(int span, double verticalSpacing, double horizontalSpacing)
+    {
+        if (ListView is not null)
+        {
+#if __IOS__
+            // This is a workaround for a bug in the current version of the iOS renderer for CollectionView
+            // where CollectionView throws `NullReferneceException` on changing span of GridItemsLayout.
+            ListView.ItemsLayout = new GridItemsLayout(span, ItemsLayoutOrientation.Vertical)
+            {
+                VerticalItemSpacing = verticalSpacing,
+                HorizontalItemSpacing = horizontalSpacing,
+            }; 
+#else
+            if (ListView.ItemsLayout is GridItemsLayout layout)
+            {
+                layout.Span = span;
+                layout.VerticalItemSpacing = verticalSpacing;
+                layout.HorizontalItemSpacing = horizontalSpacing;
+            }
+#endif
         }
     }
 

--- a/src/Toolkit/Toolkit.Maui/BasemapGallery/BasemapGallery.Appearance.cs
+++ b/src/Toolkit/Toolkit.Maui/BasemapGallery/BasemapGallery.Appearance.cs
@@ -45,7 +45,7 @@ public partial class BasemapGallery : TemplatedView
             Border border = new Border { Padding = 4, StrokeThickness = 1, StrokeShape = new Rectangle() };
             Grid outerScrimContainer = new Grid();
             outerScrimContainer.RowDefinitions.Add(new RowDefinition { Height = new GridLength(86) });
-            outerScrimContainer.RowDefinitions.Add(new RowDefinition { Height = new GridLength(40)});
+            outerScrimContainer.RowDefinitions.Add(new RowDefinition { Height = new GridLength(40) });
             outerScrimContainer.RowSpacing = 4;
 
             Image thumbnail = new Image { WidthRequest = 64, HeightRequest = 64, Aspect = Aspect.AspectFill, BackgroundColor = Colors.Transparent, HorizontalOptions = LayoutOptions.Center };
@@ -62,7 +62,7 @@ public partial class BasemapGallery : TemplatedView
             scrimGrid.SetAppThemeColor(BackgroundColorProperty, Colors.White, Colors.Black);
             outerScrimContainer.Children.Add(scrimGrid);
             Grid.SetRowSpan(scrimGrid, 2);
-            
+
 
             thumbnail.SetBinding(Image.SourceProperty, nameof(BasemapGalleryItem.ThumbnailData), converter: ImageSourceConverter);
             nameLabel.SetBinding(Label.TextProperty, nameof(BasemapGalleryItem.Name));
@@ -195,6 +195,7 @@ public partial class BasemapGallery : TemplatedView
         if (ListView != null)
         {
             ListView.BindingContext = _controller;
+            ListView.ItemsLayout = new GridItemsLayout(ItemsLayoutOrientation.Vertical);
         }
     }
 
@@ -282,12 +283,6 @@ public partial class BasemapGallery : TemplatedView
                 break;
         }
 
-        // This check may be removable once UWP collectionview supports dynamic item sizing: https://gist.github.com/hartez/7d0edd4182dbc7de65cebc6c67f72e14
-        if (DeviceInfo.Platform == DevicePlatform.WinUI)
-        {
-            styleAfterUpdate = BasemapGalleryViewStyle.List;
-        }
-
         if (styleAfterUpdate == BasemapGalleryViewStyle.Grid)
         {
             gridSpanAfterUpdate = System.Math.Max((int)(currentWidth / 128), 1);
@@ -298,13 +293,23 @@ public partial class BasemapGallery : TemplatedView
             if (styleAfterUpdate == BasemapGalleryViewStyle.List)
             {
                 ListView.ItemTemplate = ListItemTemplate;
-                ListView.ItemsLayout = new LinearItemsLayout(ItemsLayoutOrientation.Vertical) { ItemSpacing = 0 };
+                if (ListView.ItemsLayout is GridItemsLayout layout)
+                {
+                    layout.Span = 1;
+                    layout.VerticalItemSpacing = 0;
+                    layout.HorizontalItemSpacing = 0;
+                };
                 ListView.Margin = new Thickness(0);
             }
             else
             {
-                ListView.ItemTemplate = GridItemTemplate;
-                ListView.ItemsLayout = new GridItemsLayout(gridSpanAfterUpdate, ItemsLayoutOrientation.Vertical) { HorizontalItemSpacing = 4, VerticalItemSpacing = 4 };
+                ListView.ItemTemplate = DefaultGridDataTemplate;
+                if (ListView.ItemsLayout is GridItemsLayout layout)
+                {
+                    layout.Span = gridSpanAfterUpdate;
+                    layout.VerticalItemSpacing = 4;
+                    layout.HorizontalItemSpacing = 4;
+                }
                 ListView.Margin = new Thickness(4, 4, 0, 0);
             }
 

--- a/src/Toolkit/Toolkit.Maui/BasemapGallery/BasemapGallery.Appearance.cs
+++ b/src/Toolkit/Toolkit.Maui/BasemapGallery/BasemapGallery.Appearance.cs
@@ -310,24 +310,11 @@ public partial class BasemapGallery : TemplatedView
 
     private void UpdateItemsLayout(int span, double verticalSpacing, double horizontalSpacing)
     {
-        if (ListView is not null)
+        if (ListView?.ItemsLayout is GridItemsLayout layout)
         {
-#if __IOS__
-            // This is a workaround for a bug in the current version of the iOS renderer for CollectionView
-            // where CollectionView throws `NullReferneceException` on changing span of GridItemsLayout.
-            ListView.ItemsLayout = new GridItemsLayout(span, ItemsLayoutOrientation.Vertical)
-            {
-                VerticalItemSpacing = verticalSpacing,
-                HorizontalItemSpacing = horizontalSpacing,
-            }; 
-#else
-            if (ListView.ItemsLayout is GridItemsLayout layout)
-            {
-                layout.Span = span;
-                layout.VerticalItemSpacing = verticalSpacing;
-                layout.HorizontalItemSpacing = horizontalSpacing;
-            }
-#endif
+            layout.Span = span;
+            layout.VerticalItemSpacing = verticalSpacing;
+            layout.HorizontalItemSpacing = horizontalSpacing;
         }
     }
 


### PR DESCRIPTION
### Description

- Observed bug in MAUI Windows:
![8fd81320-d729-4d25-8da5-758af858da61](https://github.com/user-attachments/assets/fabbc1c2-7bbb-49a6-a483-c9a927e9cef8)



- I used GridItemsLayout to represent both List View and Grid View just by manipulating `Span` property.
- There is a bug logged in MAUI :  dotnet/maui#24345
- This workaround works fine with Windows and Android platforms. But iOS platform throws `NullReferenceExcpetion` when Span is changed.

- Fix result:

https://github.com/user-attachments/assets/a36f66bc-6917-4587-be09-69b468892579

