### PR TITLE
Breaking change: Changed from ListView to CollectionView in BookmarksView which resolves ItemTemplate issue in iOS

### DIFF
--- a/src/Samples/Toolkit.SampleApp.Maui/Samples/BookmarksViewSample.xaml
+++ b/src/Samples/Toolkit.SampleApp.Maui/Samples/BookmarksViewSample.xaml
@@ -10,12 +10,10 @@
              x:Class="Toolkit.SampleApp.Maui.Samples.BookmarksViewSample">
     <ContentPage.Resources>
         <DataTemplate x:Key="ItemTemplateOne">
-            <TextCell Text="{Binding Name}" TextColor="Red" />
+            <Label Text="{Binding Name}" TextColor="Red" />
         </DataTemplate>
         <DataTemplate x:Key="ItemTemplateTwo">
-            <ViewCell>
-                <Label BackgroundColor="Red" TextColor="White" Text="{Binding Name}" />
-            </ViewCell>
+            <Label BackgroundColor="Red" TextColor="White" Text="{Binding Name}" />
         </DataTemplate>
     </ContentPage.Resources>
     <ContentPage.Content>

--- a/src/Toolkit/Toolkit.Maui/BookmarksView/BookmarksView.cs
+++ b/src/Toolkit/Toolkit.Maui/BookmarksView/BookmarksView.cs
@@ -26,6 +26,7 @@ public class BookmarksView : TemplatedView
 {
     private readonly BookmarksViewDataSource _dataSource = new();
     private const string _presentingViewName = "PresentingView";
+    CollectionView? _presentingView;
 
     private static readonly DataTemplate DefaultDataTemplate;
     private static readonly ControlTemplate DefaultControlTemplate;
@@ -64,12 +65,16 @@ public class BookmarksView : TemplatedView
     {
         base.OnApplyTemplate();
 
-        var collectionView = (CollectionView)GetTemplateChild(_presentingViewName);
-        if (collectionView is CollectionView view)
+        if (_presentingView is not null)
         {
-            view.SelectionChanged -= Internal_bookmarkSelected;
-            view.SelectionChanged += Internal_bookmarkSelected;
-            view.ItemsSource = _dataSource;
+            _presentingView.SelectionChanged -= Internal_bookmarkSelected;
+        }
+
+        if (GetTemplateChild(_presentingViewName) is CollectionView view)
+        {
+            _presentingView = view;
+            _presentingView.SelectionChanged += Internal_bookmarkSelected;
+            _presentingView.ItemsSource = _dataSource;
         }
     }
 

--- a/src/Toolkit/Toolkit.Maui/BookmarksView/BookmarksView.cs
+++ b/src/Toolkit/Toolkit.Maui/BookmarksView/BookmarksView.cs
@@ -156,6 +156,9 @@ public class BookmarksView : TemplatedView
     /// </summary>
     private static void ItemTemplateChanged(BindableObject sender, object? oldValue, object? newValue)
     {
+        // MAUI Bug: Custom Control ItemTemplate fails to change at runtime in MAUI iOS
+        // GitHub Issue: #24492 (https://github.com/dotnet/maui/issues/24492)
+
         BookmarksView bookmarkView = (BookmarksView)sender;
 
         if (bookmarkView._presentingView != null)

--- a/src/Toolkit/Toolkit.Maui/BookmarksView/BookmarksView.cs
+++ b/src/Toolkit/Toolkit.Maui/BookmarksView/BookmarksView.cs
@@ -26,7 +26,7 @@ public class BookmarksView : TemplatedView
 {
     private readonly BookmarksViewDataSource _dataSource = new();
     private const string _presentingViewName = "PresentingView";
-    CollectionView? _presentingView;
+    private CollectionView? _presentingView;
 
     private static readonly DataTemplate DefaultDataTemplate;
     private static readonly ControlTemplate DefaultControlTemplate;
@@ -69,10 +69,9 @@ public class BookmarksView : TemplatedView
         {
             _presentingView.SelectionChanged -= Internal_bookmarkSelected;
         }
-
-        if (GetTemplateChild(_presentingViewName) is CollectionView view)
+        _presentingView = GetTemplateChild(_presentingViewName) as CollectionView;
+        if (_presentingView is not null)
         {
-            _presentingView = view;
             _presentingView.SelectionChanged += Internal_bookmarkSelected;
             _presentingView.ItemsSource = _dataSource;
         }

--- a/src/Toolkit/Toolkit.Maui/BookmarksView/BookmarksView.cs
+++ b/src/Toolkit/Toolkit.Maui/BookmarksView/BookmarksView.cs
@@ -69,7 +69,7 @@ public class BookmarksView : TemplatedView
     protected override void OnApplyTemplate()
     {
         base.OnApplyTemplate();
-        UpdateListView();
+        UpdatePresentingView();
     }
 
     /// <summary>
@@ -147,7 +147,7 @@ public class BookmarksView : TemplatedView
     private static void ItemTemplateChanged(BindableObject sender, object? oldValue, object? newValue)
     {
         BookmarksView bookmarkView = (BookmarksView)sender;
-        bookmarkView.UpdateListView();
+        bookmarkView.UpdatePresentingView();
     }
 
     /// <summary>
@@ -182,7 +182,7 @@ public class BookmarksView : TemplatedView
         }
     }
 
-    private void UpdateListView()
+    private void UpdatePresentingView()
     {
         var collection = (CollectionView)GetTemplateChild(_presentingViewName);
         if (collection != null)
@@ -199,7 +199,7 @@ public class BookmarksView : TemplatedView
     {
         if (e.Action is NotifyCollectionChangedAction.Add)
         {
-            UpdateListView();
+            UpdatePresentingView();
         }
     }
 

--- a/src/Toolkit/Toolkit.Maui/BookmarksView/BookmarksView.cs
+++ b/src/Toolkit/Toolkit.Maui/BookmarksView/BookmarksView.cs
@@ -26,6 +26,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui;
 public class BookmarksView : TemplatedView
 {
     private BookmarksViewDataSource _dataSource = new BookmarksViewDataSource();
+    private const string _presentingViewName = "PresentingView";
 
     private static readonly DataTemplate DefaultDataTemplate;
     private static readonly ControlTemplate DefaultControlTemplate;
@@ -41,10 +42,10 @@ public class BookmarksView : TemplatedView
         });
 
         string template =
-            @"<ControlTemplate xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
+            $@"<ControlTemplate xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
                                xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
                                xmlns:esriTK=""clr-namespace:Esri.ArcGISRuntime.Toolkit.Maui"">
-                <CollectionView x:Name=""PresentingView"" SelectionMode=""Single"" />
+                <CollectionView x:Name=""{_presentingViewName}"" SelectionMode=""Single"" />
              </ControlTemplate>";
         DefaultControlTemplate = Microsoft.Maui.Controls.Xaml.Extensions.LoadFromXaml(new ControlTemplate(), template);
     }
@@ -183,7 +184,7 @@ public class BookmarksView : TemplatedView
 
     private void UpdateListView()
     {
-        var collection = (CollectionView)GetTemplateChild("PresentingView");
+        var collection = (CollectionView)GetTemplateChild(_presentingViewName);
         if (collection != null)
         {
             collection.SelectionChanged -= Internal_bookmarkSelected;

--- a/src/Toolkit/Toolkit/UI/Controls/BookmarksView/BookmarksViewDataSource.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/BookmarksView/BookmarksViewDataSource.cs
@@ -40,7 +40,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         private GeoView? _geoView;
         private WeakEventListener<BookmarksViewDataSource, INotifyCollectionChanged, object?, NotifyCollectionChangedEventArgs>? _geoViewBookmarksListener;
         private WeakEventListener<BookmarksViewDataSource, ILoadable, object?, EventArgs>? _geoViewLoadListener;
-        private new WeakEventListener<BookmarksViewDataSource, INotifyCollectionChanged, object?, NotifyCollectionChangedEventArgs>? _overrideListListener;
+        private WeakEventListener<BookmarksViewDataSource, INotifyCollectionChanged, object?, NotifyCollectionChangedEventArgs>? _overrideListListener;
         private IList<Bookmark>? _overrideList;
 
         private IList<Bookmark> ActiveBookmarkList


### PR DESCRIPTION
The bug is related to Bookmarks updating template does not apply on all rows for iOS.

MAUI Bug Reported [dotnet/maui#24492](https://github.com/dotnet/maui/issues/24492)


EDIT:
Found that changing to `CollectionView` actually solves this issue and I was able to test it on Windows, iOS and Android platforms.
There is going to be a breaking change for `ItemTemplates` Cells used for `CollectionView`.