### PR TITLE
Improve the loading speed of the basemap gallery

### DIFF
--- a/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryController.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryController.cs
@@ -324,20 +324,10 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
                 listOfBasemaps.Add(new BasemapGalleryItem(basemap));
             }
 
-#if !WINDOWS_XAML && !NETCOREAPP
-            await Task.WhenAll(listOfBasemaps.Select(gi => gi.LoadAsync()));
-#else
             foreach (var item in listOfBasemaps)
             {
-                try
-                {
-                    await item.LoadAsync();
-                }
-                catch (Exception)
-                {
-                }
+                _ = item.LoadAsync();
             }
-#endif
             return new ObservableCollection<BasemapGalleryItem>(listOfBasemaps);
         }
 

--- a/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryItem.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryItem.cs
@@ -392,7 +392,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
         {
             get
             {
-                return _nameOverride ?? Basemap.Name;
+                return _nameOverride ?? (string.IsNullOrEmpty(Basemap.Name) ? Basemap.Item?.Name ?? string.Empty : Basemap.Name);
             }
 
             set


### PR DESCRIPTION
Addresses https://github.com/Esri/arcgis-maps-sdk-dotnet-toolkit/issues/600

Don't wait for basemaps to load before displaying the picker: This allows placeholders to show sooner, and all basemaps to load in parallel.

Comparison: Top: Before, Bottom: after



https://github.com/user-attachments/assets/d62e62ef-78c4-42d0-89a8-ced3d7df8bd2


