### PR TITLE
FeatureForms: Adds a temporary combox value when no coded value matches

### DIFF
--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/ComboboxFormInputView.Maui.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/ComboboxFormInputView.Maui.cs
@@ -48,6 +48,13 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
 
         private void Picker_SelectedIndexChanged(object? sender, EventArgs e)
         {
+            if(_selector?.SelectedItem is not ComboBoxPlaceHolderValue && _selector?.ItemsSource is IList<object> list && list.LastOrDefault() is ComboBoxPlaceHolderValue)
+            {
+                // Remove placeholder if it isn't selected any longer
+                list.RemoveAt(list.Count - 1);
+            }
+            if (_selector?.SelectedItem is ComboBoxPlaceHolderValue)
+                return;
             var value = (_selector?.SelectedItem as CodedValue)?.Code;
             Element?.UpdateValue(value);
         }

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/ComboboxFormInputView.Windows.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/ComboboxFormInputView.Windows.cs
@@ -30,6 +30,13 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
 
         private void Selector_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
+            if(_selector?.SelectedItem is not ComboBoxPlaceHolderValue && _selector?.ItemsSource is IList<object> list && list.LastOrDefault() is ComboBoxPlaceHolderValue)
+            {
+                // Remove placeholder if it isn't selected any longer
+                list.RemoveAt(list.Count - 1);
+            }
+            if (_selector?.SelectedItem is ComboBoxPlaceHolderValue)
+                return;
             var value = (_selector?.SelectedItem as CodedValue)?.Code;
             Element?.UpdateValue(value);
         }

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/ComboboxFormInputView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/ComboboxFormInputView.cs
@@ -2,6 +2,7 @@
 using Esri.ArcGISRuntime.Data;
 using Esri.ArcGISRuntime.Mapping.FeatureForms;
 using Esri.ArcGISRuntime.Toolkit.Internal;
+using System.Collections.ObjectModel;
 using System.ComponentModel;
 
 #if MAUI

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/ComboboxFormInputView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/ComboboxFormInputView.cs
@@ -135,7 +135,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
 
         private class ComboBoxPlaceHolderValue : ComboBoxNullValue
         {
-		}
+        }
     }
 }
 #endif

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/ComboboxFormInputView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/ComboboxFormInputView.cs
@@ -114,7 +114,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                         _selector.SelectedIndex = 0;
                     else if (selection is null && Element?.Value is not null) // Attribute value not available in the domain
                     {
-                        var missingValue = new ComboBoxPlaceHolderValue() { Name = Element?.Value?.ToString() };
+                        var missingValue = new ComboBoxPlaceHolderValue() { Name = Element.Value.ToString() };
                         var items = (IList<object>)_selector.ItemsSource;
                         items.Add(missingValue);
                         _selector.SelectedItem = missingValue;

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/ComboboxFormInputView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/ComboboxFormInputView.cs
@@ -85,12 +85,13 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
 #if !MAUI
                     _selector.DisplayMemberPath = nameof(CodedValue.Name);
 #endif
-                    List<object> items = new List<object>();
+                    var items = new ObservableCollection<object>();
                     if (input.NoValueOption == FormInputNoValueOption.Show)
                     {
                         items.Add(new ComboBoxNullValue() { Name = input.NoValueLabel });
                     }
-                    items.AddRange(input.CodedValues);
+                    foreach (var value in input.CodedValues)
+                        items.Add(value);
                     _selector.ItemsSource = items;
                     UpdateSelection();
                 }
@@ -111,6 +112,13 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                     var selection = input.CodedValues.Where(a => object.Equals(a.Code, Element?.Value)).FirstOrDefault();
                     if (selection is null && input.NoValueOption == FormInputNoValueOption.Show)
                         _selector.SelectedIndex = 0;
+                    else if (selection is null && Element?.Value is not null) // Attribute value not available in the domain
+                    {
+                        var missingValue = new ComboBoxPlaceHolderValue() { Name = Element?.Value?.ToString() };
+                        var items = (IList<object>)_selector.ItemsSource;
+                        items.Add(missingValue);
+                        _selector.SelectedItem = missingValue;
+                    }
                     else
                         _selector.SelectedItem = selection;
                 }
@@ -123,6 +131,10 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
             public string? Name { get; set; }
             public override string ToString() => Name!;
         }
+
+        private class ComboBoxPlaceHolderValue : ComboBoxNullValue
+        {
+		}
     }
 }
 #endif


### PR DESCRIPTION
This change allows the comboboxes to show values that are outside the coded value domains. A warning will still be shown, and once selecting a valid value in the dropdown, the temporary placeholder entry in the dropdown will be removed. This matches the behavior of ArcGIS Online webviewer