### PR TITLE
Fixes layout issues with search view in MAUI

### DIFF
--- a/src/Samples/Toolkit.SampleApp.Maui/Samples/SearchViewSample.xaml
+++ b/src/Samples/Toolkit.SampleApp.Maui/Samples/SearchViewSample.xaml
@@ -12,7 +12,7 @@
         <Grid RowSpacing="0">
             <Grid.RowDefinitions>
                 <RowDefinition Height="32" />
-                <RowDefinition Height="{OnPlatform WinUI=400, Default=Auto}" />
+                <RowDefinition Height="Auto" />
                 <RowDefinition Height="*" />
             </Grid.RowDefinitions>
             <esri:MapView x:Name="MyMapView" Grid.Row="1" Grid.RowSpan="2" />

--- a/src/Toolkit/Toolkit.Maui/SearchView/SearchView.Appearance.cs
+++ b/src/Toolkit/Toolkit.Maui/SearchView/SearchView.Appearance.cs
@@ -193,10 +193,12 @@ xmlns:esriTK=""clr-namespace:Esri.ArcGISRuntime.Toolkit.Maui"">
     <Entry x:Name=""{nameof(PART_Entry)}"" Grid.Column=""1"" Grid.Row=""0"" TextColor=""{{AppThemeBinding Light={FOREGROUND_LIGHT}, Dark={FOREGROUND_DARK}}}"" />
     <ImageButton x:Name=""{nameof(PART_CancelButton)}"" Grid.Column=""1"" HorizontalOptions=""End"" WidthRequest=""32"" HeightRequest=""32"" Padding=""4"" BackgroundColor=""Transparent"" />
     <ImageButton x:Name=""{nameof(PART_SearchButton)}"" Grid.Column=""2"" WidthRequest=""32"" HeightRequest=""32"" Padding=""4"" BackgroundColor=""Transparent"" />
-    <CollectionView x:Name=""{nameof(PART_SuggestionsView)}"" SelectionMode=""Single"" Grid.Column=""0"" Grid.ColumnSpan=""3"" Grid.Row=""1"" Grid.RowSpan=""2""  HeightRequest=""175"" />
-    <CollectionView x:Name=""{nameof(PART_ResultView)}"" SelectionMode=""Single"" Grid.Column=""0"" Grid.ColumnSpan=""3"" Grid.Row=""1"" Grid.RowSpan=""1"" HeightRequest=""200"" />
-    <CollectionView x:Name=""{nameof(PART_SourcesView)}"" SelectionMode=""Single"" Grid.Column=""0"" Grid.ColumnSpan=""3"" Grid.Row=""1"" HeightRequest=""150"" />
+<Grid Grid.Column=""0"" Grid.ColumnSpan=""3"" Grid.Row=""1"" >
+    <CollectionView x:Name=""{nameof(PART_SuggestionsView)}"" SelectionMode=""Single"" Grid.RowSpan=""2""  HeightRequest=""175"" />
+    <CollectionView x:Name=""{nameof(PART_ResultView)}"" SelectionMode=""Single"" Grid.RowSpan=""1"" HeightRequest=""200"" />
+    <CollectionView x:Name=""{nameof(PART_SourcesView)}"" SelectionMode=""Single"" HeightRequest=""150"" />
     <Grid x:Name=""{nameof(PART_ResultContainer)}"" Grid.ColumnSpan=""3"" Grid.Row=""1"" Padding=""8""  Style=""{{StaticResource SVDefaultGridStyle}}""><Label x:Name=""{nameof(PART_ResultLabel)}"" HorizontalOptions=""Center"" VerticalOptions=""Center"" FontAttributes=""Bold"" /></Grid>
+</Grid>
     <Grid x:Name=""{nameof(PART_RepeatButtonContainer)}"" Grid.Column=""0"" Grid.ColumnSpan=""3""  Grid.Row=""2""  Style=""{{StaticResource SVDefaultGridStyle}}"">
         <Button x:Name=""{nameof(PART_RepeatButton)}"" BackgroundColor=""{{AppThemeBinding Light=#007AC2, Dark=#00619B}}"" TextColor=""White"" CornerRadius=""0"" />
     </Grid>

--- a/src/Toolkit/Toolkit.Maui/SearchView/SearchView.cs
+++ b/src/Toolkit/Toolkit.Maui/SearchView/SearchView.cs
@@ -394,7 +394,7 @@ public partial class SearchView : TemplatedView, INotifyPropertyChanged
     private bool ResultLabelVisibility => (SearchViewModel?.Suggestions != null && SearchViewModel?.Suggestions?.Count == 0) ||
         (SearchViewModel?.Results != null && SearchViewModel?.Results?.Count == 0);
 
-    private bool RepeatSearchButtonVisibility => EnableRepeatSearchHereButton && (SearchViewModel?.IsEligibleForRequery ?? false);
+    private bool RepeatSearchButtonVisibility => EnableRepeatSearchHereButton && (SearchViewModel?.IsEligibleForRequery ?? false) && !SuggestionsViewVisibility;
 
     private bool SourcePopupVisibility => _sourceSelectToggled && SearchViewModel?.Sources.Count > 1;
 

--- a/src/Toolkit/Toolkit/UI/Controls/SearchView/SearchViewModel.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/SearchView/SearchViewModel.cs
@@ -127,7 +127,19 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         /// <remarks>
         /// Call <see cref="UpdateSuggestions"/> to refresh suggestions after updating the query.
         /// </remarks>
-        public string? CurrentQuery { get => _currentQuery; set => SetPropertyChanged(value, ref _currentQuery); }
+        public string? CurrentQuery
+        {
+            get => _currentQuery;
+            set
+            {
+                if (_currentQuery != value)
+                {
+                    IsEligibleForRequery = false;
+                    Results = null;
+                    SetPropertyChanged(value, ref _currentQuery);
+                }
+            }
+        }
 
         /// <summary>
         /// Gets or sets the default placeholder to use when there is no <see cref="ActiveSource"/> or the <see cref="ActiveSource"/> does not have a placeholder defined.


### PR DESCRIPTION
Ensures the collection views doesn't cover the text entry field by encapsulating the views in a grid to workaround a MAUI layout bug.
Also ensures that a new search can be performed when editing the text by clearing the previous results which prevented the suggestions from showing before.