### PR TITLE
Rewrites several parts of the SearchView to make it AoT compatible in WinUI

### DIFF
--- a/src/Samples/Toolkit.SampleApp.UWP/Samples/SearchView/SearchViewCustomizationSample.xaml
+++ b/src/Samples/Toolkit.SampleApp.UWP/Samples/SearchView/SearchViewCustomizationSample.xaml
@@ -48,12 +48,12 @@
                 <TextBox Header="Repeat search button text" Text="{x:Bind MySearchView.RepeatSearchButtonText, Mode=TwoWay}" />
                 <Button
                     HorizontalAlignment="Stretch"
-                    Command="{x:Bind MySearchView.RepeatSearchHereCommand, Mode=OneWay}"
+                    Command="{x:Bind MySearchView.TemplateSettings.RepeatSearchHereCommand, Mode=OneWay}"
                     Content="Repeat Search"
                     IsEnabled="{x:Bind MySearchView.SearchViewModel.IsEligibleForRequery, Mode=OneWay}" />
                 <Button
                     HorizontalAlignment="Stretch"
-                    Command="{x:Bind MySearchView.ClearCommand, Mode=OneWay}"
+                    Command="{x:Bind MySearchView.TemplateSettings.ClearCommand, Mode=OneWay}"
                     Content="Clear Search" />
                 <ListView
                     DisplayMemberPath="DisplayTitle"

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/SearchView/SearchViewCustomizationSample.xaml
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/SearchView/SearchViewCustomizationSample.xaml
@@ -58,10 +58,10 @@
                     <TextBox Text="{Binding ElementName=MySearchView, Path=RepeatSearchButtonText, Mode=TwoWay}" />
                 </GroupBox>
                 <Button
-                    Command="{Binding ElementName=MySearchView, Path=RepeatSearchHereCommand, Mode=OneWay}"
+                    Command="{Binding ElementName=MySearchView, Path=TemplateSettings.RepeatSearchHereCommand, Mode=OneWay}"
                     Content="Repeat Search"
                     IsEnabled="{Binding ElementName=MySearchView, Path=SearchViewModel.IsEligibleForRequery, Mode=OneWay}" />
-                <Button Command="{Binding ElementName=MySearchView, Path=ClearCommand, Mode=OneWay}" Content="Clear Search" />
+                <Button Command="{Binding ElementName=MySearchView, Path=TemplateSettings.ClearCommand, Mode=OneWay}" Content="Clear Search" />
                 <Label Content="Results:" />
                 <ListView
                     DisplayMemberPath="DisplayTitle"

--- a/src/Toolkit/Toolkit.UI.Controls/SearchView/SearchView.cs
+++ b/src/Toolkit/Toolkit.UI.Controls/SearchView/SearchView.cs
@@ -746,7 +746,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
 #endif
 
         /// <summary>
-        /// SearchViewTemplateSettings provides a set of properties that are used when you define a new control template for a control that derives from <see cref="SearchView"/>.
+        /// <see cref="SearchViewTemplateSettings"/> provides a set of properties that are used when you define a new control template for a control that derives from <see cref="SearchView"/>.
         /// </summary>
         public SearchViewTemplateSettings TemplateSettings
         {
@@ -771,7 +771,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
     }
 
     /// <summary>
-    /// SearchViewTemplateSettings provides a set of properties that are used when you define a new control template for a control that derives from <see cref="SearchView"/>.
+    /// <see cref="SearchViewTemplateSettings"/> provides a set of properties that are used when you define a new control template for a control that derives from <see cref="SearchView"/>.
     /// </summary>
     /// <remarks>
     /// TemplateSettings properties are always intended to be used in XAML, not code. They are read-only sub-properties of a read-only TemplateSettings property of a parent control.

--- a/src/Toolkit/Toolkit.UI.Controls/SearchView/SearchView.cs
+++ b/src/Toolkit/Toolkit.UI.Controls/SearchView/SearchView.cs
@@ -697,8 +697,6 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             _groupListSelectionFlag = false;
         }
 
-        // private List<SuggestionsGrouped>? _groupedSuggestions;
-
         /// <summary>
         /// Gets the grouped list of suggestions.
         /// </summary>

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/SearchView/SearchView.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/SearchView/SearchView.Theme.xaml
@@ -322,9 +322,9 @@
                         x:Name="SourceSelectToggle"
                         Grid.Column="0"
                         BorderThickness="0,0,1,0"
-                        IsChecked="{Binding IsSourceSelectOpen, Mode=TwoWay}"
+                        IsChecked="{TemplateBinding IsSourceSelectOpen}"
                         Style="{StaticResource BarActionButtonStyle}"
-                        Visibility="{Binding SourceSelectVisibility, Mode=OneWay}">
+                        Visibility="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=TemplateSettings.SourceSelectVisibility, Mode=OneWay}">
                         <Path
                             Width="12"
                             Height="12"
@@ -336,7 +336,7 @@
                     <Popup
                         Width="{Binding ElementName=Self, Path=ActualWidth, Mode=OneWay}"
                         HorizontalOffset="-1"
-                        IsOpen="{Binding IsSourceSelectOpen, Mode=TwoWay}"
+                        IsOpen="{TemplateBinding IsSourceSelectOpen}"
                         Placement="Bottom"
                         PlacementTarget="{Binding ElementName=PopupTarget}"
                         StaysOpen="False">
@@ -346,7 +346,7 @@
                                     Width="{Binding ElementName=sourceList, Path=ActualWidth, Mode=OneWay}"
                                     HorizontalContentAlignment="Left"
                                     BorderThickness="0"
-                                    IsChecked="{Binding SearchViewModel.ActiveSource, Mode=TwoWay, Converter={StaticResource NullToBoolSelectionConverter}}"
+                                    IsChecked="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=SearchViewModel.ActiveSource, Mode=TwoWay, Converter={StaticResource NullToBoolSelectionConverter}}"
                                     Style="{StaticResource ProminentButtonStyle}">
                                     <TextBlock Text="{TemplateBinding AllSourceSelectText}" />
                                 </ToggleButton>
@@ -354,8 +354,8 @@
                                     x:Name="sourceList"
                                     ItemContainerStyle="{StaticResource ListContainerStyle}"
                                     ItemTemplate="{StaticResource SourceTemplate}"
-                                    ItemsSource="{Binding SearchViewModel.Sources, Mode=OneWay}"
-                                    SelectedItem="{Binding SearchViewModel.ActiveSource, Mode=TwoWay}"
+                                    ItemsSource="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=SearchViewModel.Sources, Mode=OneWay}"
+                                    SelectedItem="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=SearchViewModel.ActiveSource, Mode=TwoWay}"
                                     SelectionMode="Single"
                                     Style="{StaticResource ListStyle}" />
                             </StackPanel>
@@ -365,15 +365,15 @@
                         x:Name="QueryEntry"
                         Grid.Column="1"
                         Style="{StaticResource QueryEntryStyle}"
-                        Text="{Binding SearchViewModel.CurrentQuery, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                        Text="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=SearchViewModel.CurrentQuery, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                     <TextBlock
                         Grid.Column="1"
                         Style="{StaticResource QueryPlaceholderStyle}"
-                        Text="{Binding SearchViewModel.ActivePlaceholder, Mode=OneWay}"
+                        Text="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=SearchViewModel.ActivePlaceholder, Mode=OneWay}"
                         Visibility="{Binding ElementName=QueryEntry, Path=Text, Converter={StaticResource PlaceholderVisibilityConverter}}" />
                     <Button
                         Grid.Column="2"
-                        Command="{Binding ClearCommand}"
+                        Command="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=TemplateSettings.ClearCommand}"
                         Style="{StaticResource BarActionButtonStyle}"
                         ToolTip="{TemplateBinding ClearSearchTooltipText}"
                         Visibility="{Binding ElementName=QueryEntry, Path=Text, Converter={StaticResource PlaceholderVisibilityConverter}, ConverterParameter='NotEmpty'}">
@@ -390,11 +390,11 @@
                     <Popup
                         Width="{Binding ElementName=Self, Path=ActualWidth, Mode=OneWay}"
                         HorizontalOffset="-1"
-                        IsOpen="{Binding SearchViewModel.Suggestions.Count, Mode=OneWay, Converter={StaticResource CollectionIsEmptyToBoolConverter}, ConverterParameter='NotEmpty'}"
+                        IsOpen="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=SearchViewModel.Suggestions.Count, Mode=OneWay, Converter={StaticResource CollectionIsEmptyToBoolConverter}, ConverterParameter='NotEmpty'}"
                         Placement="Bottom"
                         PlacementTarget="{Binding ElementName=PopupTarget}">
                         <Popup.Resources>
-                            <CollectionViewSource x:Key="GroupedSuggestions" Source="{Binding SearchViewModel.Suggestions}">
+                            <CollectionViewSource x:Key="GroupedSuggestions" Source="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=SearchViewModel.Suggestions}">
                                 <CollectionViewSource.GroupDescriptions>
                                     <PropertyGroupDescription PropertyName="OwningSource" />
                                 </CollectionViewSource.GroupDescriptions>
@@ -404,7 +404,7 @@
                             <ListView
                                 ItemContainerStyle="{StaticResource ListContainerStyle}"
                                 ItemsSource="{Binding Source={StaticResource GroupedSuggestions}}"
-                                SelectedItem="{Binding SelectedSuggestion, Mode=OneWayToSource}"
+                                SelectedItem="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=SelectedSuggestion, Mode=OneWayToSource}"
                                 Style="{StaticResource ListStyle}">
                                 <ListView.ItemTemplate>
                                     <DataTemplate DataType="{x:Type controls:SearchSuggestion}">
@@ -470,7 +470,7 @@
                     <Button
                         Grid.Column="3"
                         BorderThickness="1,0,0,0"
-                        Command="{Binding SearchCommand, Mode=OneTime}"
+                        Command="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=TemplateSettings.SearchCommand, Mode=OneTime}"
                         Style="{StaticResource BarActionButtonStyle}"
                         ToolTip="{TemplateBinding SearchTooltipText}">
                         <Path
@@ -486,14 +486,14 @@
                     <Border
                         Grid.Row="1"
                         Grid.ColumnSpan="4"
-                        Visibility="{Binding ResultViewVisibility, Mode=OneWay}">
+                        Visibility="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=TemplateSettings.ResultViewVisibility, Mode=OneWay}">
                         <Grid>
                             <ListView
                                 MaxHeight="300"
-                                IsEnabled="{Binding SearchViewModel.Results.Count, Mode=OneWay, Converter={StaticResource CollectionIsSingletonToBoolConverter}, ConverterParameter='Inverse'}"
+                                IsEnabled="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=SearchViewModel.Results.Count, Mode=OneWay, Converter={StaticResource CollectionIsSingletonToBoolConverter}, ConverterParameter='Inverse'}"
                                 ItemContainerStyle="{StaticResource ListContainerStyle}"
-                                ItemsSource="{Binding SearchViewModel.Results, Mode=OneWay}"
-                                SelectedItem="{Binding SearchViewModel.SelectedResult, Mode=OneWayToSource}"
+                                ItemsSource="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=SearchViewModel.Results, Mode=OneWay}"
+                                SelectedItem="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=SearchViewModel.SelectedResult, Mode=OneWayToSource}"
                                 SelectionMode="Single"
                                 Style="{StaticResource ListStyle}">
                                 <ListView.ItemTemplate>
@@ -530,7 +530,7 @@
                             <Border
                                 BorderThickness="0,1,0,0"
                                 Style="{StaticResource ResultAreaBorderStyle}"
-                                Visibility="{Binding ResultMessageVisibility, Mode=OneWay}">
+                                Visibility="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=TemplateSettings.ResultMessageVisibility, Mode=OneWay}">
                                 <TextBlock
                                     Margin="8"
                                     HorizontalAlignment="Center"
@@ -543,22 +543,22 @@
                         Grid.Row="0"
                         Grid.ColumnSpan="4"
                         Style="{StaticResource ProgressIndicatorStyle}"
-                        Visibility="{Binding SearchViewModel.IsWaiting, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
+                        Visibility="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=SearchViewModel.IsWaiting, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
                 </Grid>
             </Border>
             <Grid
                 Grid.Row="1"
                 Margin="0,8,0,0"
-                Visibility="{Binding EnableRepeatSearchHereButton, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
+                Visibility="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=EnableRepeatSearchHereButton, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
                 <Button
                     HorizontalAlignment="Stretch"
                     BorderThickness="0"
-                    Command="{Binding RepeatSearchHereCommand, Mode=OneTime}"
+                    Command="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=TemplateSettings.RepeatSearchHereCommand, Mode=OneTime}"
                     Content="{TemplateBinding RepeatSearchButtonText}"
                     Foreground="White"
                     Style="{StaticResource ProminentButtonStyle}"
                     Template="{StaticResource FloatingButtonTemplate}"
-                    Visibility="{Binding SearchViewModel.IsEligibleForRequery, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
+                    Visibility="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=SearchViewModel.IsEligibleForRequery, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
             </Grid>
         </Grid>
     </ControlTemplate>

--- a/src/Toolkit/Toolkit.WinUI/UI/Controls/SearchView/SearchView.Theme.xaml
+++ b/src/Toolkit/Toolkit.WinUI/UI/Controls/SearchView/SearchView.Theme.xaml
@@ -500,9 +500,9 @@
                         x:Name="SourceSelectToggle"
                         Grid.Column="0"
                         BorderThickness="0,0,1,0"
-                        IsChecked="{Binding IsSourceSelectOpen, Mode=TwoWay}"
+                        IsChecked="{TemplateBinding IsSourceSelectOpen}"
                         Style="{StaticResource BarActionButtonStyle}"
-                        Visibility="{Binding SourceSelectVisibility, Mode=OneWay}">
+                        Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.SourceSelectVisibility}">
                         <Path
                             Data="M13.1 6L8 11.1 2.9 6z"
                             Fill="Transparent"
@@ -514,17 +514,17 @@
                         x:Name="QueryEntry"
                         Grid.Column="1"
                         Style="{StaticResource QueryEntryStyle}"
-                        Text="{Binding SearchViewModel.CurrentQuery, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                        Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=SearchViewModel.CurrentQuery, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                     <TextBlock
                         Grid.Column="1"
                         VerticalAlignment="Center"
                         Style="{StaticResource QueryPlaceholderStyle}"
-                        Text="{Binding SearchViewModel.ActivePlaceholder, Mode=OneWay}"
+                        Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=SearchViewModel.ActivePlaceholder, Mode=OneWay}"
                         Visibility="{Binding ElementName=QueryEntry, Path=Text, Converter={StaticResource PlaceholderVisibilityConverter}}" />
                     <Button
                         Grid.Column="2"
                         BorderThickness="0"
-                        Command="{Binding ClearCommand, Mode=OneTime}"
+                        Command="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.ClearCommand}"
                         Style="{StaticResource BarActionButtonStyle}"
                         ToolTipService.ToolTip="{TemplateBinding ClearSearchTooltipText}"
                         Visibility="{Binding ElementName=QueryEntry, Path=Text, Converter={StaticResource PlaceholderVisibilityConverter}, ConverterParameter='NotEmpty'}">
@@ -533,7 +533,7 @@
                     <Button
                         Grid.Column="3"
                         BorderThickness="1,0,0,0"
-                        Command="{Binding SearchCommand, Mode=OneTime}"
+                        Command="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.SearchCommand, Mode=OneTime}"
                         Style="{StaticResource BarActionButtonStyle}"
                         ToolTipService.ToolTip="{TemplateBinding SearchTooltipText}">
                         <Path Data="M13.936 13.24L9.708 9.01a4.8 4.8 0 1 0-.69.69l4.228 4.228a.488.488 0 0 0 .69-.69zM6.002 9.8A3.8 3.8 0 1 1 8.69 8.686a3.778 3.778 0 0 1-2.687 1.112z" Style="{StaticResource ActionButtonPathStyle}" />
@@ -542,34 +542,34 @@
                         Grid.Row="0"
                         Grid.ColumnSpan="4"
                         Style="{StaticResource ProgressIndicatorStyle}"
-                        Visibility="{Binding SearchViewModel.IsWaiting, Mode=OneWay}" />
+                        Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=SearchViewModel.IsWaiting, Mode=OneWay}" />
                 </Grid>
             </Border>
-            <Popup IsOpen="{Binding SearchViewModel.Suggestions.Count, Mode=OneWay, Converter={StaticResource CollectionIsEmptyToBoolConverter}, ConverterParameter='NotEmpty'}" VerticalOffset="34">
+            <Popup IsOpen="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=SearchViewModel.Suggestions.Count, Mode=OneWay, Converter={StaticResource CollectionIsEmptyToBoolConverter}, ConverterParameter='NotEmpty'}" VerticalOffset="34">
                 <Popup.Resources>
                     <CollectionViewSource
                         x:Key="GroupedSuggestionsEx"
                         IsSourceGrouped="True"
-                        Source="{Binding GroupedSuggestions, Mode=OneWay}" />
+                        Source="{TemplateBinding GroupedSuggestions}" />
                 </Popup.Resources>
                 <Border
                     Width="{TemplateBinding Width}"
                     BorderThickness="1,0,1,1"
                     Style="{StaticResource ResultAreaBorderStyle}"
-                    Visibility="{Binding SearchViewModel.Results.Count, Mode=OneWay, Converter={StaticResource CollectionIsEmptyToBoolConverter}, ConverterParameter='Empty'}">
+                    Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=SearchViewModel.Results.Count, Mode=OneWay, Converter={StaticResource CollectionIsEmptyToBoolConverter}, ConverterParameter='Empty'}">
                     <Grid>
                         <ListView
                             ItemTemplate="{StaticResource SuggestionTemplate}"
-                            ItemsSource="{Binding SearchViewModel.Suggestions, Mode=OneWay}"
-                            SelectedItem="{Binding SelectedSuggestion, Mode=TwoWay}"
+                            ItemsSource="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=SearchViewModel.Suggestions, Mode=OneWay}"
+                            SelectedItem="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=SelectedSuggestion, Mode=TwoWay}"
                             Style="{StaticResource ListStyle}"
-                            Visibility="{Binding SearchViewModel.Sources.Count, Mode=OneWay, Converter={StaticResource CollectionIsSingletonToBoolConverter}}" />
+                            Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=SearchViewModel.Sources.Count, Mode=OneWay, Converter={StaticResource CollectionIsSingletonToBoolConverter}}" />
                         <ListView
                             x:Name="PART_SuggestionList"
                             ItemTemplate="{StaticResource SuggestionTemplate}"
                             ItemsSource="{Binding Source={StaticResource GroupedSuggestionsEx}, Mode=OneWay}"
                             Style="{StaticResource ListStyle}"
-                            Visibility="{Binding SourceSelectVisibility, Mode=OneWay}">
+                            Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.SourceSelectVisibility, Mode=OneWay}">
                             <ListView.GroupStyle>
                                 <GroupStyle>
                                     <GroupStyle.HeaderTemplate>
@@ -601,35 +601,35 @@
             <Border
                 Grid.Row="1"
                 Style="{StaticResource ResultAreaBorderStyle}"
-                Visibility="{Binding ResultViewVisibility, Mode=OneWay}">
+                Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.ResultViewVisibility, Mode=OneWay}">
                 <Grid>
                     <ListView
                         MaxHeight="300"
-                        IsEnabled="{Binding SearchViewModel.Results.Count, Mode=OneWay, Converter={StaticResource CollectionIsSingletonToBoolConverter}, ConverterParameter='Inverse'}"
+                        IsEnabled="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=SearchViewModel.Results.Count, Mode=OneWay, Converter={StaticResource CollectionIsSingletonToBoolConverter}, ConverterParameter='Inverse'}"
                         ItemTemplate="{StaticResource ResultTemplate}"
-                        ItemsSource="{Binding SearchViewModel.Results, Mode=OneWay}"
-                        SelectedItem="{Binding SearchViewModel.SelectedResult, Mode=TwoWay}"
+                        ItemsSource="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=SearchViewModel.Results, Mode=OneWay}"
+                        SelectedItem="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=SearchViewModel.SelectedResult, Mode=TwoWay}"
                         Style="{StaticResource ListStyle}" />
                     <TextBlock
                         Style="{StaticResource ResultMessageStyle}"
                         Text="{TemplateBinding NoResultMessage}"
-                        Visibility="{Binding ResultMessageVisibility, Mode=OneWay}" />
+                        Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.ResultMessageVisibility, Mode=OneWay}" />
                 </Grid>
             </Border>
             <Popup
                 IsLightDismissEnabled="True"
-                IsOpen="{Binding IsSourceSelectOpen, Mode=TwoWay}"
+                IsOpen="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsSourceSelectOpen, Mode=TwoWay}"
                 VerticalOffset="34">
                 <Border Width="{TemplateBinding Width}" Style="{StaticResource ResultAreaBorderStyle}">
                     <StackPanel>
                         <ToggleButton
                             Content="{TemplateBinding AllSourceSelectText}"
-                            IsChecked="{Binding SearchViewModel.ActiveSource, Mode=TwoWay, Converter={StaticResource NullToBoolSelectionConverter}}"
+                            IsChecked="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=SearchViewModel.ActiveSource, Mode=TwoWay, Converter={StaticResource NullToBoolSelectionConverter}}"
                             Style="{StaticResource AllSourceButtonStyle}" />
                         <ListView
                             ItemTemplate="{StaticResource SourceTemplate}"
-                            ItemsSource="{Binding SearchViewModel.Sources, Mode=OneWay}"
-                            SelectedItem="{Binding SearchViewModel.ActiveSource, Mode=TwoWay}"
+                            ItemsSource="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=SearchViewModel.Sources, Mode=OneWay}"
+                            SelectedItem="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=SearchViewModel.ActiveSource, Mode=TwoWay}"
                             Style="{StaticResource ListStyle}" />
                     </StackPanel>
                 </Border>
@@ -637,12 +637,12 @@
             <StackPanel
                 Grid.Row="2"
                 Margin="0,8,0,0"
-                Visibility="{Binding EnableRepeatSearchHereButton, Mode=OneWay}">
+                Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EnableRepeatSearchHereButton, Mode=OneWay}">
                 <Button
-                    Command="{Binding RepeatSearchHereCommand, Mode=OneTime}"
+                    Command="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.RepeatSearchHereCommand, Mode=OneTime}"
                     Content="{TemplateBinding RepeatSearchButtonText}"
                     Style="{StaticResource FloatingButtonStyle}"
-                    Visibility="{Binding SearchViewModel.IsEligibleForRequery, Mode=OneWay}" />
+                    Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=SearchViewModel.IsEligibleForRequery, Mode=OneWay}" />
             </StackPanel>
         </Grid>
     </ControlTemplate>

--- a/src/Toolkit/Toolkit/Internal/DelegateCommand.cs
+++ b/src/Toolkit/Toolkit/Internal/DelegateCommand.cs
@@ -22,7 +22,10 @@ namespace Esri.ArcGISRuntime.Toolkit.Internal
     /// <summary>
     /// Simple command implementation.
     /// </summary>
-    internal class DelegateCommand : ICommand
+#if WINUI
+    [WinRT.GeneratedBindableCustomProperty]
+#endif
+    internal partial class DelegateCommand : ICommand
     {
         private bool _canExecute = true;
         private readonly Action<object?>? _onExecute;

--- a/src/Toolkit/Toolkit/UI/Controls/SearchView/SearchResult.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/SearchView/SearchResult.cs
@@ -33,7 +33,10 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
     /// <summary>
     /// Wraps a search result for display.
     /// </summary>
-    public class SearchResult : INotifyPropertyChanged
+#if WINUI
+    [WinRT.GeneratedBindableCustomProperty]
+#endif
+    public partial class SearchResult : INotifyPropertyChanged
     {
 #pragma warning disable SA1011 // Closing square brackets should be spaced correctly - catch-22
         private byte[]? _markerData;

--- a/src/Toolkit/Toolkit/UI/Controls/SearchView/SearchViewModel.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/SearchView/SearchViewModel.cs
@@ -254,7 +254,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         /// <summary>
         /// Gets the list of search suggestions. This value is set after calls to <see cref="UpdateSuggestions"/>.
         /// </summary>
-        public IList<SearchSuggestion>? Suggestions { get => _suggestions; } //private set => SetPropertyChanged(value, ref _suggestions); }
+        public IList<SearchSuggestion>? Suggestions { get => _suggestions; }
 
         private void SetSuggestions(IEnumerable<SearchSuggestion>? suggestions)
         {

--- a/src/Toolkit/Toolkit/UI/Controls/SearchView/SearchViewModel.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/SearchView/SearchViewModel.cs
@@ -238,7 +238,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         /// Gets or sets the list of available search sources, which can be updated dynamically.
         /// </summary>
         /// <remarks>See <see cref="ConfigureDefaultWorldGeocoder(CancellationToken)"/> for a convenient method to populate this collection automatically.</remarks>
-        public IList<ISearchSource> Sources { get; set; } = new SourceSourceCollection();
+        public IList<ISearchSource> Sources { get; set; } = new SearchSourceCollection();
 
         /// <summary>
         /// Gets the list of search results for the most-recently completed query.
@@ -598,7 +598,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
 #if WINUI
         [WinRT.GeneratedBindableCustomProperty]
 #endif
-        private partial class SourceSourceCollection : ObservableCollection<ISearchSource>
+        private partial class SearchSourceCollection : ObservableCollection<ISearchSource>
         {
         }
 

--- a/src/Toolkit/Toolkit/UI/Controls/SearchView/SearchViewModel.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/SearchView/SearchViewModel.cs
@@ -138,7 +138,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
                 if (_currentQuery != value)
                 {
                     IsEligibleForRequery = false;
-                    Results = null;
+                    SetResults(null);
                     SetPropertyChanged(value, ref _currentQuery);
                 }
             }
@@ -238,18 +238,29 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         /// Gets or sets the list of available search sources, which can be updated dynamically.
         /// </summary>
         /// <remarks>See <see cref="ConfigureDefaultWorldGeocoder(CancellationToken)"/> for a convenient method to populate this collection automatically.</remarks>
-        public IList<ISearchSource> Sources { get; set; } = new ObservableCollection<ISearchSource>();
+        public IList<ISearchSource> Sources { get; set; } = new SourceSourceCollection();
 
         /// <summary>
         /// Gets the list of search results for the most-recently completed query.
         /// Clearing a search via <see cref="ClearSearch"/> will set this collection to <c>null</c>.
         /// </summary>
-        public IList<SearchResult>? Results { get => _results; private set => SetPropertyChanged(value, ref _results); }
+        public IList<SearchResult>? Results { get => _results; }
+
+        private void SetResults(IEnumerable<SearchResult>? results)
+        {
+            SetPropertyChanged<IList<SearchResult>?>(results is null ? null : new SearchResultList(results), ref _results, nameof(Results));
+        }
 
         /// <summary>
         /// Gets the list of search suggestions. This value is set after calls to <see cref="UpdateSuggestions"/>.
         /// </summary>
-        public IList<SearchSuggestion>? Suggestions { get => _suggestions; private set => SetPropertyChanged(value, ref _suggestions); }
+        public IList<SearchSuggestion>? Suggestions { get => _suggestions; } //private set => SetPropertyChanged(value, ref _suggestions); }
+
+        private void SetSuggestions(IEnumerable<SearchSuggestion>? suggestions)
+        {
+            SetPropertyChanged<IList<SearchSuggestion>?>(suggestions is null ? null : new SearchSuggestionList(suggestions), ref _suggestions, nameof(Suggestions));
+        }
+
 
         private bool _viewpointChangedSinceResultReturned;
 
@@ -371,7 +382,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
 
             if (string.IsNullOrWhiteSpace(CurrentQuery))
             {
-                Suggestions = null;
+                SetSuggestions(null);
                 return;
             }
 
@@ -380,7 +391,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             {
                 IsSuggestInProgress = true;
                 _activeSuggestCancellation = suggestCancellation;
-                Suggestions = null;
+                SetSuggestions(null);
 
                 var sourcesToSearch = SourcesToSearch();
                 foreach (var source in sourcesToSearch)
@@ -391,11 +402,11 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
 
                 var allSuggestions = await Task.WhenAll(sourcesToSearch.Select(s => s.SuggestAsync(CurrentQuery!, suggestCancellation.Token)));
 
-                Suggestions = allSuggestions.SelectMany(l => l).ToList();
+                SetSuggestions(allSuggestions.SelectMany(l => l));
             }
             catch (TaskCanceledException)
             {
-                Suggestions = new List<SearchSuggestion>(0);
+                SetSuggestions(Enumerable.Empty<SearchSuggestion>());
             }
             finally
             {
@@ -449,8 +460,8 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         private void PrepareForNewSearch()
         {
             SelectedResult = null;
-            Suggestions = null;
-            Results = null;
+            SetSuggestions(null);
+            SetResults(null);
             IsEligibleForRequery = false;
             IsSearchInProgress = true;
         }
@@ -459,13 +470,13 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         {
             if (!results.Any())
             {
-                Results = new List<SearchResult>();
+                SetResults(Enumerable.Empty<SearchResult>());
                 return;
             }
 
             if (results.Count == 1)
             {
-                Results = results.ToList();
+                SetResults(results);
                 SelectedResult = results.First();
                 return;
             }
@@ -473,20 +484,20 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             switch (SearchMode)
             {
                 case SearchResultMode.Single:
-                    Results = new List<SearchResult> { results.First() };
-                    SelectedResult = Results.First();
+                    SetResults(results.Take(1));
+                    SelectedResult = Results!.First();
                     break;
                 case SearchResultMode.Multiple:
-                    Results = results.ToList();
+                    SetResults(results);
                     break;
                 case SearchResultMode.Automatic:
                     if (originatingSuggestion?.IsCollection ?? false)
                     {
-                        Results = results.ToList();
+                        SetResults(results);
                     }
                     else
                     {
-                        Results = new List<SearchResult>() { results.First() };
+                        SetResults(results.Take(1));
                     }
 
                     break;
@@ -506,8 +517,8 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             _activeSearchCancellation?.Cancel();
             _activeSuggestCancellation?.Cancel();
             SelectedResult = null;
-            Results = null;
-            Suggestions = null;
+            SetResults(null);
+            SetSuggestions(null);
             CurrentQuery = null;
             IsEligibleForRequery = false;
             _lastSuggestion = null;
@@ -580,5 +591,38 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
 
         /// <inheritdoc/>
         public event PropertyChangedEventHandler? PropertyChanged;
+
+        #region Collection Types
+        // These types are here to support WinUI's code-generator to support bindings.
+
+#if WINUI
+        [WinRT.GeneratedBindableCustomProperty]
+#endif
+        private partial class SourceSourceCollection : ObservableCollection<ISearchSource>
+        {
+        }
+
+#if WINUI
+        [WinRT.GeneratedBindableCustomProperty]
+#endif
+        private partial class SearchResultList : List<SearchResult>
+        {
+            public SearchResultList(IEnumerable<SearchResult> list)
+            {
+                AddRange(list);
+            }
+        }
+
+#if WINUI
+        [WinRT.GeneratedBindableCustomProperty]
+#endif
+        private partial class SearchSuggestionList : List<SearchSuggestion>
+        {
+            public SearchSuggestionList(IEnumerable<SearchSuggestion> list)
+            {
+                AddRange(list);
+            }
+        }
+        #endregion Collection Types
     }
 }


### PR DESCRIPTION
Main change is to move away from raising INPC in SearchView and instead rely on a TemplateSettings class to act as a view model. This is following the common WinUI/UWP pattern described here: https://learn.microsoft.com/en-us/windows/uwp/xaml-platform/template-settings-classes. Since so much code is shared with WPF, I made the same changes there, so that the code doesn't get too platform-convoluted. It also does clean up the control class nicely. Basically a bunch of readonly properties that raises INPC has been moved to the `SearchViewTemplateSettings` class.

Other things of note:
- Mark classes with `[WinRT.GeneratedBindableCustomProperty]` and make them partial so code generation will occur for types being bound in XAML.
- Use dependency properties when possible
- `IList<T>` is problematic for code generation since you can't generate binding code for it, so introduced some private collection classes that inherit from List<T> and adds the `GeneratedBindableCustomProperty` attribute. Replaced the setter with a Set method instead to ensure the correct type would be used.

Internal ref: 13091