### PR TITLE
Add namespace and data binding in SymbolEditorSample to resolve bug with Angle property not being refresh in MAUI Android

### DIFF
--- a/src/Samples/Toolkit.SampleApp.Maui/Samples/SymbolEditorSample.xaml
+++ b/src/Samples/Toolkit.SampleApp.Maui/Samples/SymbolEditorSample.xaml
@@ -2,10 +2,11 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esri="clr-namespace:Esri.ArcGISRuntime.Toolkit.Maui;assembly=Esri.ArcGISRuntime.Toolkit.Maui"
+             xmlns:sym="clr-namespace:Esri.ArcGISRuntime.Symbology;assembly=Esri.ArcGISRuntime"
              x:Class="Toolkit.SampleApp.Maui.Samples.SymbolEditorSample"
              Title="SymbolDisplay - dynamic">
     <ContentPage.Content>
-        <Grid >
+        <Grid>
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition />
@@ -18,7 +19,10 @@
                 <Label Text="Style" />
                 <Picker ItemsSource="{Binding SimpleMarkerSymbolStyles}" SelectedItem="{Binding Symbol.Style, Source={x:Reference symbolDisplay}, Mode=TwoWay}"/>
                 <Label Text="Angle" />
-                <Slider Minimum="0" Maximum="360" Value="{Binding Symbol.Angle, Source={x:Reference symbolDisplay}, Mode=TwoWay}" />
+                <Slider Minimum="0" Maximum="360"
+                        BindingContext="{Binding Symbol, Source={x:Reference symbolDisplay}}"
+                        x:DataType="sym:SimpleMarkerSymbol"
+                        Value="{Binding Angle, Mode=TwoWay}" />
 
             </StackLayout>
 


### PR DESCRIPTION
#### Summary
Updated namespace declaration, improved data binding for the "Angle" property, and made minor formatting adjustments.
- `ContentPage`: Added `xmlns:sym` namespace for `Esri.ArcGISRuntime.Symbology`.
- `Slider`: Set `BindingContext` to `Symbol` property of `symbolDisplay`, set `x:DataType` to `sym:SimpleMarkerSymbol`, and updated `Value` binding to `Angle` property.
