### PR TITLE
Introduced error handling in the `BasemapGallery_Loaded` method to avoid crash

### DIFF
--- a/src/Toolkit/Toolkit.Maui/BasemapGallery/BasemapGallery.cs
+++ b/src/Toolkit/Toolkit.Maui/BasemapGallery/BasemapGallery.cs
@@ -46,12 +46,19 @@ public partial class BasemapGallery
 
     private async void BasemapGallery_Loaded(object? sender, EventArgs e)
     {
-        // Unsubscribe from the Loaded event to ensure this only runs once.
-        Loaded -= BasemapGallery_Loaded;
-
-        if (AvailableBasemaps is null)
+        try
         {
-            await _controller.LoadFromDefaultPortal();
+            // Unsubscribe from the Loaded event to ensure this only runs once.
+            Loaded -= BasemapGallery_Loaded;
+
+            if (AvailableBasemaps is null)
+            {
+                await _controller.LoadFromDefaultPortal();
+            }
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"Error loading basemaps: {ex.Message}");
         }
     }
 

--- a/src/Toolkit/Toolkit.UI.Controls/BasemapGallery/BasemapGallery.Windows.cs
+++ b/src/Toolkit/Toolkit.UI.Controls/BasemapGallery/BasemapGallery.Windows.cs
@@ -52,12 +52,19 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
 
         private async void BasemapGallery_Loaded(object? sender, RoutedEventArgs e)
         {
-            // Unsubscribe from the Loaded event to ensure this only runs once.
-            Loaded -= BasemapGallery_Loaded;
-
-            if ((AvailableBasemaps is null || !AvailableBasemaps.Any()) && isAvailableBasemapCollectionInitialized)
+            try
             {
-                await _controller.LoadFromDefaultPortal();
+                // Unsubscribe from the Loaded event to ensure this only runs once.
+                Loaded -= BasemapGallery_Loaded;
+
+                if ((AvailableBasemaps is null || !AvailableBasemaps.Any()) && isAvailableBasemapCollectionInitialized)
+                {
+                    await _controller.LoadFromDefaultPortal();
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Error loading basemaps: {ex.Message}");
             }
         }
 


### PR DESCRIPTION
## Related Issue #625 

- Introduced error handling in the `BasemapGallery_Loaded` method for both `BasemapGallery.cs` and `BasemapGallery.Windows.cs`.

- These changes prevent crashes and provide useful debug information during the basemap loading process.