### PR TITLE
Fix: Floor Filter List UI width

### DIFF
--- a/src/Toolkit/Toolkit.Maui/FloorFilter/FloorFilter.DefaultTemplates.cs
+++ b/src/Toolkit/Toolkit.Maui/FloorFilter/FloorFilter.DefaultTemplates.cs
@@ -32,7 +32,6 @@ public partial class FloorFilter
         {
             Grid containingGrid = new Grid
             {
-                WidthRequest = 48,
                 HeightRequest = 48,
                 InputTransparent = false,
                 CascadeInputTransparent = false,


### PR DESCRIPTION
Removeed WidthRequest from Grid in FloorFilter template
This corrects the position of Floor filter UI in Windows MAUI

| Before | After |
|--|--|
| ![image](https://github.com/user-attachments/assets/20f5a736-38cd-450d-9b8d-13d4576ee7ae) | ![image](https://github.com/user-attachments/assets/be7fb83d-8d3a-4b8e-84f0-5158e44d8c3e) |