### PR TITLE
Fixing API Key window in MAUI to fix iPhone SE Bug

### DIFF
--- a/src/Samples/Toolkit.SampleApp.Maui/MainPage.xaml
+++ b/src/Samples/Toolkit.SampleApp.Maui/MainPage.xaml
@@ -11,7 +11,7 @@
             </ListView.ItemTemplate>
         </ListView>
 
-        <Border  x:Name="ApiKeyWindow" Background="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray600}}" IsVisible="false">
+        <Grid x:Name="ApiKeyWindow" Background="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray600}}" IsVisible="false">
             <Grid HorizontalOptions="Center" VerticalOptions="Center">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />
@@ -49,6 +49,6 @@
                     </VerticalStackLayout>
                 </Border>
             </Grid>
-        </Border>
+        </Grid>
     </Grid>
 </ContentPage>

--- a/src/Samples/Toolkit.SampleApp.WinUI/Toolkit.SampleApp.WinUI.csproj
+++ b/src/Samples/Toolkit.SampleApp.WinUI/Toolkit.SampleApp.WinUI.csproj
@@ -12,7 +12,6 @@
     <EnableMsixTooling>true</EnableMsixTooling>
     <DefineConstants>$(DefineConstants);WINUI</DefineConstants>
     <UseRidGraph>true</UseRidGraph>
-    <PublishAot>True</PublishAot>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixing the Background of `API Key Required` window in iPhone SE.
There seems to be bug with MAUI in Border for iPhone SE.


| Before | After |
|-|-|
| ![image](https://github.com/user-attachments/assets/055c82b5-42f3-4c70-b68f-4aac1ba04923) | ![image](https://github.com/user-attachments/assets/507526ef-9fe6-426d-863e-1ed7939ac680) |