### PR TITLE
Only show validation errors if a field got focus

### DIFF
--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/ComboboxFormInputView.Maui.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/ComboboxFormInputView.Maui.cs
@@ -23,6 +23,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
             Picker view = new Picker();
             view.SetBinding(Picker.IsEnabledProperty, static (ComboBoxFormInputView view) => view.Element?.IsEditable, source: RelativeBindingSource.TemplatedParent);
             view.ItemDisplayBinding = new Binding(nameof(CodedValue.Name));
+            view.Focused += static (s, e) => FeatureFormView.GetParent<FieldFormElementView>(s as Element)?.OnGotFocus();
             INameScope nameScope = new NameScope();
             NameScope.SetNameScope(view, nameScope);
             nameScope.RegisterName("Picker", view);

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/ComboboxFormInputView.Windows.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/ComboboxFormInputView.Windows.cs
@@ -25,14 +25,18 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
             if (_selector != null)
             {
                 _selector.SelectionChanged -= Selector_SelectionChanged;
+                _selector.GotFocus -= Selector_GotFocus;
             }
             _selector = GetTemplateChild("Selector") as Selector;
             if(_selector != null)
             {
                 _selector.SelectionChanged += Selector_SelectionChanged;
+                _selector.GotFocus += Selector_GotFocus;
             }
             UpdateItems();
         }
+
+        private void Selector_GotFocus(object sender, RoutedEventArgs e) => UI.Controls.FeatureFormView.GetParent<FieldFormElementView>(this)?.OnGotFocus();
 
         private void Selector_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/DateTimePickerFormInputView.Maui.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/DateTimePickerFormInputView.Maui.cs
@@ -36,6 +36,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
 
             var datePicker = new DatePicker();
             datePicker.HorizontalOptions = LayoutOptions.Fill;
+            datePicker.Focused += static (s, e) => FeatureFormView.GetParent<FieldFormElementView>(s as Element)?.OnGotFocus();
             container.Children.Add(datePicker);
             nameScope.RegisterName("DatePickerInput", datePicker);
 
@@ -54,6 +55,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
 #endif
 
             var timePicker = new TimePicker();
+            timePicker.Focused += static (s, e) => FeatureFormView.GetParent<FieldFormElementView>(s as Element)?.OnGotFocus();
             container.Children.Add(timePicker);
             Grid.SetRow(timePicker, 1);
             nameScope.RegisterName("TimePickerInput", timePicker);

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/DateTimePickerFormInputView.Windows.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/DateTimePickerFormInputView.Windows.cs
@@ -20,6 +20,20 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
 #endif
         {
             base.OnApplyTemplate();
+            if (_datePicker != null)
+            {
+                _datePicker.GotFocus -= Picker_GotFocus;
+                _datePicker.SelectedDateChanged -= DatePicker_SelectedDateChanged;
+            }
+            if (_timePicker != null)
+            {
+                _timePicker.GotFocus -= Picker_GotFocus;
+#if WINDOWS_XAML
+                _timePicker.SelectedTimeChanged -= TimePicker_SelectedTimeChanged;
+#else
+                _timePicker.TimeChanged -= TimePicker_TimeChanged;
+#endif
+            }
             _datePicker = GetTemplateChild("DatePicker") as DatePicker;
             _timePicker = GetTemplateChild("TimePicker") as TimePicker;
             if (_datePicker != null)

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/DateTimePickerFormInputView.Windows.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/DateTimePickerFormInputView.Windows.cs
@@ -24,10 +24,12 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
             _timePicker = GetTemplateChild("TimePicker") as TimePicker;
             if (_datePicker != null)
             {
+                _datePicker.GotFocus += Picker_GotFocus;
                 _datePicker.SelectedDateChanged += DatePicker_SelectedDateChanged;
             }
             if (_timePicker != null)
             {
+                _timePicker.GotFocus += Picker_GotFocus;
 #if WINDOWS_XAML
                 _timePicker.SelectedTimeChanged += TimePicker_SelectedTimeChanged;
 #else
@@ -36,6 +38,8 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
             }
             ConfigurePickers();
         }
+
+        private void Picker_GotFocus(object sender, RoutedEventArgs e) => UI.Controls.FeatureFormView.GetParent<FieldFormElementView>(this)?.OnGotFocus();
 
 #if WINDOWS_XAML
         private void TimePicker_SelectedTimeChanged(object? sender, TimePickerSelectedValueChangedEventArgs e) => UpdateValue();

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FeatureFormView.Maui.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FeatureFormView.Maui.cs
@@ -137,7 +137,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui
 
         internal static FeatureFormView? GetFeatureFormViewParent(Element child) => GetParent<FeatureFormView>(child);
 
-        private static T? GetParent<T>(Element child) where T : Element
+        internal static T? GetParent<T>(Element? child) where T : Element
         {
             var parent = child?.Parent;
             while (parent is not null && parent is not T page)
@@ -145,6 +145,26 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui
                 parent = parent.Parent;
             }
             return parent as T;
+        }
+
+        internal static IEnumerable<T> GetDescendentsOfType<T>(Element root)
+        {
+            if (root is null)
+                yield break;
+
+            
+            foreach (var child in root.GetVisualTreeDescendants())
+            {
+                if (child == root) continue;
+                if (child is Element frameworkElement)
+                {
+                    if (frameworkElement is T targetElement)
+                        yield return targetElement;
+
+                    foreach (var descendant in GetDescendentsOfType<T>(frameworkElement))
+                        yield return descendant;
+                }
+            }
         }
     }
 }

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FeatureFormView.Maui.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FeatureFormView.Maui.cs
@@ -149,22 +149,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui
 
         internal static IEnumerable<T> GetDescendentsOfType<T>(Element root)
         {
-            if (root is null)
-                yield break;
-
-            
-            foreach (var child in root.GetVisualTreeDescendants())
-            {
-                if (child == root) continue;
-                if (child is Element frameworkElement)
-                {
-                    if (frameworkElement is T targetElement)
-                        yield return targetElement;
-
-                    foreach (var descendant in GetDescendentsOfType<T>(frameworkElement))
-                        yield return descendant;
-                }
-            }
+            return root.GetVisualTreeDescendants().OfType<T>();
         }
     }
 }

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FeatureFormView.Windows.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FeatureFormView.Windows.cs
@@ -72,7 +72,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             if (root is null)
                 yield break;
 
-            for(int i = 0; i<VisualTreeHelper.GetChildrenCount(root);i++)
+            for (int i = 0; i < VisualTreeHelper.GetChildrenCount(root); i++)
             {
                 var child = VisualTreeHelper.GetChild(root, i);
                 if (child is FrameworkElement frameworkElement)

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FeatureFormView.Windows.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FeatureFormView.Windows.cs
@@ -54,15 +54,36 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         }
 #endif
 
-        internal static UI.Controls.FeatureFormView? GetFeatureFormViewParent(DependencyObject? child)
+        internal static UI.Controls.FeatureFormView? GetFeatureFormViewParent(DependencyObject? child) => GetParent<FeatureFormView>(child);
+
+        internal static T? GetParent<T>(DependencyObject? child) where T : FrameworkElement
         {
-            if (child is null) return null;
+            if (child is null) return default(T);
             var parent = VisualTreeHelper.GetParent(child);
-            while (parent is not null && parent is not UI.Controls.FeatureFormView view)
+            while (parent is not null && parent is not T view)
             {
                 parent = VisualTreeHelper.GetParent(parent);
             }
-            return parent as UI.Controls.FeatureFormView;
+            return parent as T;
+        }
+
+        internal static IEnumerable<T> GetDescendentsOfType<T>(FrameworkElement root)
+        {
+            if (root is null)
+                yield break;
+
+            for(int i = 0; i<VisualTreeHelper.GetChildrenCount(root);i++)
+            {
+                var child = VisualTreeHelper.GetChild(root, i);
+                if (child is FrameworkElement frameworkElement)
+                {
+                    if (frameworkElement is T targetElement)
+                        yield return targetElement;
+
+                    foreach (var descendant in GetDescendentsOfType<T>(frameworkElement))
+                        yield return descendant;
+                }
+            }
         }
     }
 }

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FeatureFormView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FeatureFormView.cs
@@ -246,6 +246,15 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
                 if (form.DefaultAttachmentsElement is not null)
                     await form.DefaultAttachmentsElement.FetchAttachmentsAsync();
                 await EvaluateExpressions(form).ConfigureAwait(false);
+                Esri.ArcGISRuntime.Toolkit.Internal.DispatcherExtensions.Dispatch(this, ResetValidationStates);
+            }
+        }
+
+        private void ResetValidationStates()
+        {
+            foreach (var item in GetDescendentsOfType<FieldFormElementView>(this))
+            {
+                item.ResetValidationState();
             }
         }
 
@@ -258,6 +267,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             if (FeatureForm is not null)
             {
                 await FeatureForm.FinishEditingAsync().ConfigureAwait(false);
+                Esri.ArcGISRuntime.Toolkit.Internal.DispatcherExtensions.Dispatch(this, ResetValidationStates);
             }
         }
 

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FieldFormElementView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FieldFormElementView.cs
@@ -118,6 +118,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                 inpcNew.PropertyChanged += _elementPropertyChangedListener.OnEvent;
                 UpdateVisibility();
             }
+            ResetValidationState();
         }
 
         private void OnValuePropertyChanged()
@@ -178,7 +179,31 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
             if (GetTemplateChild("ErrorLabel") is TextBlock tb)
             {
                 tb.Text = errMessage ?? string.Empty;
+#if MAUI
+                tb.IsVisible = !string.IsNullOrEmpty(errMessage) && _hadFocus;
+#else
+                tb.Visibility = !string.IsNullOrEmpty(errMessage) && _hadFocus ? Visibility.Visible : Visibility.Collapsed;
+#endif
             }
+        }
+
+        private bool _hadFocus = false;
+
+        internal void OnGotFocus()
+        {
+            if (!_hadFocus)
+            {
+                _hadFocus = true;
+                UpdateErrorMessages();
+            }
+        }
+
+        internal void ResetValidationState()
+        {
+            _hadFocus = false;
+            UpdateErrorMessages();
+            foreach (var child in FeatureFormView.GetDescendentsOfType<IInputViewFocusable>(this))
+                child.ResetFocusState();
         }
 
         /// <summary>
@@ -332,6 +357,10 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
 #else
             DependencyProperty.Register(nameof(TextFormElementTemplate), typeof(DataTemplate), typeof(FieldFormElementView), new PropertyMetadata(null));
 #endif
-        
+    }
+
+    internal interface IInputViewFocusable
+    {
+        void ResetFocusState();
     }
 }

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/RadioButtonsFormInputView.Maui.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/RadioButtonsFormInputView.Maui.cs
@@ -54,6 +54,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
                             button.IsEnabled = Element?.IsEditable == true;
                             button.GroupName = Element?.FieldName + "_" + _formid.ToString();
                             button.CheckedChanged += Button_CheckedChanged;
+                            button.Focused += static (s, e) => FeatureFormView.GetParent<FieldFormElementView>(s as Element)?.OnGotFocus();
                             layout.Children.Add(button);
                         }
                     }

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/RadioButtonsFormInputView.Windows.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/RadioButtonsFormInputView.Windows.cs
@@ -59,6 +59,10 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                 ParentSelector?.RaiseCheckedEvent(this, true);
             }
 #endif
+
+            protected override void OnGotFocus(RoutedEventArgs e)
+                => UI.Controls.FeatureFormView.GetParent<FieldFormElementView>(this)?.OnGotFocus();
+
             internal RadioButtonsFormInputView? ParentSelector => ItemsControl.ItemsControlFromItemContainer(this) as RadioButtonsFormInputView;
         }
 

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/SwitchFormInputView.Maui.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/SwitchFormInputView.Maui.cs
@@ -23,6 +23,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
         {
             Switch toggleSwitch = new Switch();
             toggleSwitch.SetBinding(Switch.IsToggledProperty, static (SwitchFormInputView view) => view.IsChecked, source: RelativeBindingSource.TemplatedParent);
+            toggleSwitch.Focused += static (s,e) => FeatureFormView.GetParent<FieldFormElementView>(s as Element)?.OnGotFocus();
             INameScope nameScope = new NameScope();
             nameScope.RegisterName(SwitchViewName, toggleSwitch);
 #if WINDOWS

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/SwitchFormInputView.Windows.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/SwitchFormInputView.Windows.cs
@@ -24,10 +24,13 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
     public partial class SwitchFormInputView :
 #if WPF
         CheckBox
-#else 
+#else
         Control
 #endif
     {
+        /// <inheritdoc/>
+        protected override void OnGotFocus(RoutedEventArgs e) => Esri.ArcGISRuntime.Toolkit.UI.Controls.FeatureFormView.GetParent<FieldFormElementView>(this)?.OnGotFocus();
+
 #if WPF
         /// <inheritdoc/>
         protected override void OnChecked(RoutedEventArgs e)

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/TextFormInputView.Maui.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/TextFormInputView.Maui.cs
@@ -81,23 +81,27 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
             base.OnApplyTemplate();
             if (_textLineInput != null)
             {
+                _textLineInput.Focused -= TextInput_Focused;
                 _textLineInput.Unfocused -= TextInput_Unfocused;
                 _textLineInput.TextChanged -= TextInput_TextChanged;
             }
             if (_textAreaInput != null)
             {
+                _textAreaInput.Focused -= TextInput_Focused;
                 _textAreaInput.Unfocused -= TextInput_Unfocused;
                 _textAreaInput.TextChanged -= TextInput_TextChanged;
             }
             _textLineInput = GetTemplateChild("TextInput") as Entry;
             if (_textLineInput != null)
             {
+                _textLineInput.Focused += TextInput_Focused;
                 _textLineInput.Unfocused += TextInput_Unfocused;
                 _textLineInput.TextChanged += TextInput_TextChanged;
             }
             _textAreaInput = GetTemplateChild("TextAreaInput") as Editor;
             if (_textAreaInput != null)
             {
+                _textAreaInput.Focused += TextInput_Focused;
                 _textAreaInput.Unfocused += TextInput_Unfocused;
                 _textAreaInput.TextChanged += TextInput_TextChanged;
             }
@@ -112,6 +116,11 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
             }
             ConfigureTextBox();
             UpdateValidationState();
+        }
+
+        private void TextInput_Focused(object? sender, FocusEventArgs e)
+        {
+            OnFocused();
         }
 
         private void BarcodeButton_Clicked(object? sender, EventArgs e)

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/TextFormInputView.Windows.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/TextFormInputView.Windows.cs
@@ -48,12 +48,14 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
             base.OnApplyTemplate();
             if (_textInput != null)
             {
+                _textInput.GotFocus -= TextInput_GotFocus;
                 _textInput.LostFocus -= TextInput_LostFocus;
                 _textInput.TextChanged -= TextInput_TextChanged;
             }
             _textInput = GetTemplateChild("TextInput") as TextBox;
             if (_textInput != null)
             {
+                _textInput.GotFocus += TextInput_GotFocus;
                 _textInput.LostFocus += TextInput_LostFocus;
                 _textInput.TextChanged += TextInput_TextChanged;
             }
@@ -69,6 +71,17 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
             }
             ConfigureTextBox();
             UpdateValidationState();
+        }
+
+        private void TextInput_GotFocus(object sender, RoutedEventArgs e)
+        {
+            if (!_hadFocus)
+            {
+                _hadFocus = true;
+                UpdateValidationState();
+            }
+            // Propagate focus state to parent
+            FeatureFormView.GetParent<FieldFormElementView>(this)?.OnGotFocus();
         }
 
         private void BarcodeButton_Click(object sender, RoutedEventArgs e)

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/TextFormInputView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/TextFormInputView.cs
@@ -22,6 +22,9 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
 using System.Text;
+#if !MAUI
+using Esri.ArcGISRuntime.Toolkit.UI.Controls;
+#endif
 #if MAUI
 using TextBox = Microsoft.Maui.Controls.InputView;
 #elif WPF
@@ -38,7 +41,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
     /// <summary>
     /// Text input for the <see cref="TextAreaFormInput"/> and <see cref="TextBoxFormInput"/> inputs.
     /// </summary>
-    public partial class TextFormInputView
+    public partial class TextFormInputView : IInputViewFocusable
     {
         private WeakEventListener<TextFormInputView, INotifyPropertyChanged, object?, PropertyChangedEventArgs>? _elementPropertyChangedListener;
 
@@ -308,6 +311,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
 #if MAUI
         public static readonly BindableProperty ElementProperty =
             BindableProperty.Create(nameof(Element), typeof(FieldFormElement), typeof(TextFormInputView), null, propertyChanged: (s, oldValue, newValue) => ((TextFormInputView)s).OnElementPropertyChanged(oldValue as FieldFormElement, newValue as FieldFormElement));
+
 #else
         public static readonly DependencyProperty ElementProperty =
             DependencyProperty.Register(nameof(Element), typeof(FieldFormElement), typeof(TextFormInputView), new PropertyMetadata(null, (s,e) => ((TextFormInputView)s).OnElementPropertyChanged(e.OldValue as FieldFormElement, e.NewValue as FieldFormElement)));
@@ -351,7 +355,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
         private void UpdateValidationState()
         {
             var err = Element?.ValidationErrors;
-            if (err != null && err.Any() && Element?.IsEditable == true)
+            if (err != null && err.Any() && Element?.IsEditable == true && _hadFocus)
             {
 #if MAUI
                 if (GetTemplateChild("ErrorBorder") is Border border)
@@ -405,5 +409,30 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
 
             }
         }
+
+        #region IInputViewFocusable
+
+        private bool _hadFocus = false;
+
+        private void OnFocused()
+        {
+            if (!_hadFocus)
+            {
+                _hadFocus = true;
+                UpdateValidationState();
+            }
+            // Propagate focus state to parent so it can show error text
+            FeatureFormView.GetParent<FieldFormElementView>(this)?.OnGotFocus();
+        }
+
+        void IInputViewFocusable.ResetFocusState()
+        {
+            if (_hadFocus)
+            {
+                _hadFocus = false;
+                UpdateValidationState();
+            }
+        }
+        #endregion IInputViewFocusable
     }
 }


### PR DESCRIPTION
Validation errors should only start showing when a control gets focus the first time.
`*InputView` controls notify the `FieldFormElementView` parent instance that it has received focus. This will make the `FieldFormElementView` display the validation error. In addition `TextFormInputView` shows the red outline, and this has the same form of first-time-focus tracking to show its error border.
Similarly the validation errors should go away on apply or discard and reset the "have had focus" flag.