### PR TITLE
Fix: MAUI Floor Filter Crash on Site Selection in .NET 9

### DIFF
--- a/src/Samples/Toolkit.SampleApp.WinUI/Toolkit.SampleApp.WinUI.csproj
+++ b/src/Samples/Toolkit.SampleApp.WinUI/Toolkit.SampleApp.WinUI.csproj
@@ -12,7 +12,6 @@
     <EnableMsixTooling>true</EnableMsixTooling>
     <DefineConstants>$(DefineConstants);WINUI</DefineConstants>
     <UseRidGraph>true</UseRidGraph>
-    <PublishAot>True</PublishAot>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Toolkit/Toolkit.Maui/FloorFilter/FloorFilter.cs
+++ b/src/Toolkit/Toolkit.Maui/FloorFilter/FloorFilter.cs
@@ -170,8 +170,8 @@ public partial class FloorFilter : TemplatedView
             finally
             {
                 _navigationStackCounter--;
+            }
         }
-    }
     }
 
     internal async void GoBack()
@@ -636,5 +636,5 @@ public partial class FloorFilter : TemplatedView
     /// </summary>
     /// <remarks>The 'All Floors' button is useful in 3D.</remarks>
     public bool ShowAllFloorsButton => GeoView is SceneView sv && sv.Scene is not null && SelectedFacility != null && SelectedFacility.Levels.Count > 1;
-#endregion UI State Management
+    #endregion UI State Management
 }

--- a/src/Toolkit/Toolkit.Maui/FloorFilter/FloorFilter.cs
+++ b/src/Toolkit/Toolkit.Maui/FloorFilter/FloorFilter.cs
@@ -150,7 +150,7 @@ public partial class FloorFilter : TemplatedView
             // Explanation: Due to a bug in .NET MAUI 9, navigating from a CollectionView selection using PushAsync avoids a crash that occurs when using PushModalAsync.
             // The crash is caused by the CollectionView's VirtualView not being null during navigation, leading to an unhandled exception.
             // This workaround uses PushAsync on Windows/Android platforms to prevent the crash. When the bug is fixed in MAUI, this conditional can be revisited.
-
+            // TODO: Remove this conditional when the MAUI bug is fixed.
 #if WINDOWS && ANDROID
             await Navigation.PushAsync(page); 
 #else
@@ -171,6 +171,8 @@ public partial class FloorFilter : TemplatedView
             try
             {
                 // Workaround for .NET MAUI issue: https://github.com/dotnet/maui/issues/29512
+                // Use PushAsync on Windows/Android platforms to avoid the crash.
+                // TODO: Remove this conditional when the MAUI bug is fixed.
 #if WINDOWS && ANDROID
                 await Navigation.PopAsync(); 
 #else
@@ -193,6 +195,8 @@ public partial class FloorFilter : TemplatedView
         try
         {
             // Workaround for .NET MAUI issue: https://github.com/dotnet/maui/issues/29512
+            // Use PushAsync on Windows/Android platforms to avoid the crash.
+            // TODO: Remove this conditional when the MAUI bug is fixed.
 #if WINDOWS && ANDROID
             await Navigation.PopAsync(); 
 #else

--- a/src/Toolkit/Toolkit.Maui/FloorFilter/FloorFilter.cs
+++ b/src/Toolkit/Toolkit.Maui/FloorFilter/FloorFilter.cs
@@ -146,6 +146,11 @@ public partial class FloorFilter : TemplatedView
     {
         try
         {
+            // See: https://github.com/dotnet/maui/issues/29512
+            // Explanation: Due to a bug in .NET MAUI 9, navigating from a CollectionView selection using PushAsync avoids a crash that occurs when using PushModalAsync.
+            // The crash is caused by the CollectionView's VirtualView not being null during navigation, leading to an unhandled exception.
+            // This workaround uses PushAsync on Windows/Android platforms to prevent the crash. When the bug is fixed in MAUI, this conditional can be revisited.
+
 #if WINDOWS && ANDROID
             await Navigation.PushAsync(page); 
 #else
@@ -165,6 +170,7 @@ public partial class FloorFilter : TemplatedView
         {
             try
             {
+                // Workaround for .NET MAUI issue: https://github.com/dotnet/maui/issues/29512
 #if WINDOWS && ANDROID
                 await Navigation.PopAsync(); 
 #else
@@ -186,6 +192,7 @@ public partial class FloorFilter : TemplatedView
     {
         try
         {
+            // Workaround for .NET MAUI issue: https://github.com/dotnet/maui/issues/29512
 #if WINDOWS && ANDROID
             await Navigation.PopAsync(); 
 #else

--- a/src/Toolkit/Toolkit.Maui/FloorFilter/FloorFilter.cs
+++ b/src/Toolkit/Toolkit.Maui/FloorFilter/FloorFilter.cs
@@ -636,5 +636,5 @@ public partial class FloorFilter : TemplatedView
     /// </summary>
     /// <remarks>The 'All Floors' button is useful in 3D.</remarks>
     public bool ShowAllFloorsButton => GeoView is SceneView sv && sv.Scene is not null && SelectedFacility != null && SelectedFacility.Levels.Count > 1;
-    #endregion UI State Management
+#endregion UI State Management
 }

--- a/src/Toolkit/Toolkit.Maui/FloorFilter/FloorFilter.cs
+++ b/src/Toolkit/Toolkit.Maui/FloorFilter/FloorFilter.cs
@@ -146,7 +146,11 @@ public partial class FloorFilter : TemplatedView
     {
         try
         {
-            await Navigation.PushAsync(page);
+#if WINDOWS && ANDROID
+            await Navigation.PushAsync(page); 
+#else
+            await Navigation.PushModalAsync(page);
+#endif
             _navigationStackCounter++;
         }
         catch (Exception ex)
@@ -161,7 +165,11 @@ public partial class FloorFilter : TemplatedView
         {
             try
             {
-                await Navigation.PopAsync();
+#if WINDOWS && ANDROID
+                await Navigation.PopAsync(); 
+#else
+                await Navigation.PopModalAsync();
+#endif
             }
             catch (Exception ex)
             {
@@ -178,7 +186,11 @@ public partial class FloorFilter : TemplatedView
     {
         try
         {
-            await Navigation.PopAsync();
+#if WINDOWS && ANDROID
+            await Navigation.PopAsync(); 
+#else
+            await Navigation.PopModalAsync();
+#endif
         }
         catch (Exception ex)
         {

--- a/src/Toolkit/Toolkit.Maui/FloorFilter/FloorFilter.cs
+++ b/src/Toolkit/Toolkit.Maui/FloorFilter/FloorFilter.cs
@@ -146,7 +146,7 @@ public partial class FloorFilter : TemplatedView
     {
         try
         {
-            await Navigation.PushModalAsync(page);
+            await Navigation.PushAsync(page);
             _navigationStackCounter++;
         }
         catch (Exception ex)
@@ -161,7 +161,7 @@ public partial class FloorFilter : TemplatedView
         {
             try
             {
-                await Navigation.PopModalAsync();
+                await Navigation.PopAsync();
             }
             catch (Exception ex)
             {
@@ -170,15 +170,15 @@ public partial class FloorFilter : TemplatedView
             finally
             {
                 _navigationStackCounter--;
-            }
         }
+    }
     }
 
     internal async void GoBack()
     {
         try
         {
-            await Navigation.PopModalAsync();
+            await Navigation.PopAsync();
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
Updated navigation methods to use `PushAsync` and `PopAsync` instead of `PushModalAsync` and `PopModalAsync`, shifting from modal to standard navigation.

This is temporary fix that prevents a MAUI bug reported
dotnet/maui#29512

