### PR TITLE
Fix: SymbolDisplay Light and Dark mode colors in Sample App

### DIFF
--- a/src/Samples/Toolkit.SampleApp.Maui/Samples/SymbolDisplaySample.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.Maui/Samples/SymbolDisplaySample.xaml.cs
@@ -16,10 +16,10 @@ namespace Toolkit.SampleApp.Maui.Samples
 
         private void LoadSymbols()
         {
-            AddSymbol(new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Circle, System.Drawing.Color.White, 10));
-            AddSymbol(new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Circle, System.Drawing.Color.White, 20));
-            AddSymbol(new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Circle, System.Drawing.Color.White, 30));
-            AddSymbol(new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Circle, System.Drawing.Color.White, 40));
+            AddSymbol(new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Circle, System.Drawing.Color.Gray, 10));
+            AddSymbol(new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Circle, System.Drawing.Color.Gray, 20));
+            AddSymbol(new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Circle, System.Drawing.Color.Gray, 30));
+            AddSymbol(new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Circle, System.Drawing.Color.Gray, 40));
 
             AddSymbol(new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Diamond, System.Drawing.Color.Red, 10));
             AddSymbol(new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Cross, System.Drawing.Color.Green, 20));

--- a/src/Samples/Toolkit.SampleApp.UWP/Samples/SymbolDisplay/SymbolDisplaySample.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.UWP/Samples/SymbolDisplay/SymbolDisplaySample.xaml.cs
@@ -16,10 +16,10 @@ namespace Esri.ArcGISRuntime.Toolkit.SampleApp.Samples.SymbolDisplay
 
         private void LoadSymbols()
         {
-            AddSymbol(new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Circle, System.Drawing.Color.White, 10));
-            AddSymbol(new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Circle, System.Drawing.Color.White, 20));
-            AddSymbol(new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Circle, System.Drawing.Color.White, 30));
-            AddSymbol(new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Circle, System.Drawing.Color.White, 40));
+            AddSymbol(new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Circle, System.Drawing.Color.Gray, 10));
+            AddSymbol(new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Circle, System.Drawing.Color.Gray, 20));
+            AddSymbol(new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Circle, System.Drawing.Color.Gray, 30));
+            AddSymbol(new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Circle, System.Drawing.Color.Gray, 40));
 
             AddSymbol(new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Diamond, System.Drawing.Color.Red, 10));
             AddSymbol(new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Cross, System.Drawing.Color.Green, 20));
@@ -43,11 +43,11 @@ namespace Esri.ArcGISRuntime.Toolkit.SampleApp.Samples.SymbolDisplay
 #if NETFX_CORE
                 HorizontalAlignment = Windows.UI.Xaml.HorizontalAlignment.Center,
                 VerticalAlignment = Windows.UI.Xaml.VerticalAlignment.Center,
-                BorderBrush = new SolidColorBrush(Windows.UI.Colors.Black),
+                BorderBrush = new SolidColorBrush(Windows.UI.Colors.Gray),
 #else
                 HorizontalAlignment = Microsoft.UI.Xaml.HorizontalAlignment.Center,
                 VerticalAlignment = Microsoft.UI.Xaml.VerticalAlignment.Center,
-                BorderBrush = new SolidColorBrush(Microsoft.UI.Colors.Black),
+                BorderBrush = new SolidColorBrush(Microsoft.UI.Colors.Gray),
 #endif
                 BorderThickness = new Thickness(1),
                 Padding = new Thickness(0)

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/SymbolDisplay/SymbolDisplaySample.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/SymbolDisplay/SymbolDisplaySample.xaml.cs
@@ -29,10 +29,10 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.SymbolDisplay
 
         private void LoadSymbols()
         {
-            AddSymbol(new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Circle, System.Drawing.Color.White, 10));
-            AddSymbol(new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Circle, System.Drawing.Color.White, 20));
-            AddSymbol(new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Circle, System.Drawing.Color.White, 30));
-            AddSymbol(new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Circle, System.Drawing.Color.White, 40));
+            AddSymbol(new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Circle, System.Drawing.Color.Gray, 10));
+            AddSymbol(new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Circle, System.Drawing.Color.Gray, 20));
+            AddSymbol(new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Circle, System.Drawing.Color.Gray, 30));
+            AddSymbol(new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Circle, System.Drawing.Color.Gray, 40));
 
             AddSymbol(new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Diamond, System.Drawing.Color.Red, 10));
             AddSymbol(new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Cross, System.Drawing.Color.Green, 20));


### PR DESCRIPTION
- Fixing Symbol Display Circle Symbol Color to make it visible in Light mode.

- Fixed color of border for symbol display in UWP app for dark mode.

| Before | After |
|-|-|
| ![image](https://github.com/user-attachments/assets/cd3399a4-f903-473d-a08a-d3aaf0dceb82) | ![image](https://github.com/user-attachments/assets/51b0cb73-3fc8-496d-8ec4-0f09e3fdbe0e) |
| ![image](https://github.com/user-attachments/assets/5a1c5810-ddad-43d5-a342-1f2492acf5a4) | ![image](https://github.com/user-attachments/assets/1f4ef3f5-e6d7-4c7b-a619-71fc88042bb3) |