### PR TITLE
Bugfix: Fixing bug with EnableDefaultWorldGeocode value not being honored in MAUI

### DIFF
--- a/src/Toolkit/Toolkit.Maui/SearchView/SearchView.cs
+++ b/src/Toolkit/Toolkit.Maui/SearchView/SearchView.cs
@@ -84,17 +84,10 @@ public partial class SearchView : TemplatedView, INotifyPropertyChanged
         SearchCommand = new DelegateCommand(HandleSearchCommand);
         RepeatSearchHereCommand = new DelegateCommand(HandleRepeatSearchHereCommand);
         Loaded += SearchView_Loaded;
-        Unloaded += SearchView_Unloaded;
     }
-
-    private void SearchView_Unloaded(object? sender, EventArgs e) => _loadedHandled = false;
 
     private void SearchView_Loaded(object? sender, EventArgs e)
     {
-        if (_loadedHandled)
-            return;
-        _loadedHandled = true;
-
         if (GeoView != null)
         {
             HandleViewpointChanged();

--- a/src/Toolkit/Toolkit.Maui/SearchView/SearchView.cs
+++ b/src/Toolkit/Toolkit.Maui/SearchView/SearchView.cs
@@ -81,6 +81,19 @@ public partial class SearchView : TemplatedView, INotifyPropertyChanged
         ClearCommand = new DelegateCommand(HandleClearSearchCommand);
         SearchCommand = new DelegateCommand(HandleSearchCommand);
         RepeatSearchHereCommand = new DelegateCommand(HandleRepeatSearchHereCommand);
+        Loaded += SearchView_Loaded;
+    }
+
+    private void SearchView_Loaded(object? sender, EventArgs e)
+    {
+        // Unsubscribe from the Loaded event to ensure this only runs once.
+        Loaded -= SearchView_Loaded;
+
+        if (GeoView != null)
+        {
+            HandleViewpointChanged();
+        }
+        _ = ConfigureForCurrentConfiguration();
     }
 
     private void InitializeLocalizedStrings()
@@ -450,8 +463,6 @@ public partial class SearchView : TemplatedView, INotifyPropertyChanged
                 newGeoView.ViewpointChanged += sendingView.GeoView_ViewpointChanged;
                 newGeoView.GraphicsOverlays?.Add(sendingView._resultOverlay);
             }
-
-            _ = sendingView.ConfigureForCurrentConfiguration();
         }
     }
 
@@ -531,7 +542,6 @@ public partial class SearchView : TemplatedView, INotifyPropertyChanged
     {
         if (e.PropertyName == nameof(Mapping.Map) || e.PropertyName == nameof(Scene))
         {
-            _ = ConfigureForCurrentConfiguration();
             return;
         }
 
@@ -545,8 +555,6 @@ public partial class SearchView : TemplatedView, INotifyPropertyChanged
             {
                 _lastUsedGeomodel = scene;
             }
-
-            _ = ConfigureForCurrentConfiguration();
         }
     }
 

--- a/src/Toolkit/Toolkit.Maui/SearchView/SearchView.cs
+++ b/src/Toolkit/Toolkit.Maui/SearchView/SearchView.cs
@@ -48,6 +48,8 @@ public partial class SearchView : TemplatedView, INotifyPropertyChanged
 
     private bool _sourceSelectToggled;
 
+    private bool _loadedHandled;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="SearchView"/> class.
     /// </summary>
@@ -82,10 +84,17 @@ public partial class SearchView : TemplatedView, INotifyPropertyChanged
         SearchCommand = new DelegateCommand(HandleSearchCommand);
         RepeatSearchHereCommand = new DelegateCommand(HandleRepeatSearchHereCommand);
         Loaded += SearchView_Loaded;
+        Unloaded += SearchView_Unloaded;
     }
+
+    private void SearchView_Unloaded(object? sender, EventArgs e) => _loadedHandled = false;
 
     private void SearchView_Loaded(object? sender, EventArgs e)
     {
+        if (_loadedHandled)
+            return;
+        _loadedHandled = true;
+
         if (GeoView != null)
         {
             HandleViewpointChanged();

--- a/src/Toolkit/Toolkit.Maui/SearchView/SearchView.cs
+++ b/src/Toolkit/Toolkit.Maui/SearchView/SearchView.cs
@@ -86,9 +86,6 @@ public partial class SearchView : TemplatedView, INotifyPropertyChanged
 
     private void SearchView_Loaded(object? sender, EventArgs e)
     {
-        // Unsubscribe from the Loaded event to ensure this only runs once.
-        Loaded -= SearchView_Loaded;
-
         if (GeoView != null)
         {
             HandleViewpointChanged();
@@ -628,7 +625,7 @@ public partial class SearchView : TemplatedView, INotifyPropertyChanged
     /// </summary>
     private void HandleViewpointChanged()
     {
-        if (SearchViewModel == null)
+        if (!IsLoaded || SearchViewModel == null)
         {
             return;
         }

--- a/src/Toolkit/Toolkit.UI.Controls/SearchView/SearchView.cs
+++ b/src/Toolkit/Toolkit.UI.Controls/SearchView/SearchView.cs
@@ -615,7 +615,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         /// Identifies the <see cref="EnableDefaultWorldGeocoder"/> dependency property.
         /// </summary>
         public static readonly DependencyProperty EnableDefaultWorldGeocoderProperty =
-            DependencyProperty.Register(nameof(EnableDefaultWorldGeocoder), typeof(bool), typeof(SearchView), new PropertyMetadata(false, OnEnableDefualtWorldGeocoderPropertyChanged));
+            DependencyProperty.Register(nameof(EnableDefaultWorldGeocoder), typeof(bool), typeof(SearchView), new PropertyMetadata(true, OnEnableDefualtWorldGeocoderPropertyChanged));
 
         /// <summary>
         /// Identifies the <see cref="EnableRepeatSearchHereButton"/> dependency proeprty.

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/SearchView/SearchView.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/SearchView/SearchView.Theme.xaml
@@ -569,6 +569,5 @@
         <Setter Property="VerticalAlignment" Value="Top" />
         <Setter Property="Width" Value="256" />
         <Setter Property="Margin" Value="4" />
-        <Setter Property="EnableDefaultWorldGeocoder" Value="True" />
     </Style>
 </ResourceDictionary>

--- a/src/Toolkit/Toolkit.WinUI/UI/Controls/SearchView/SearchView.Theme.xaml
+++ b/src/Toolkit/Toolkit.WinUI/UI/Controls/SearchView/SearchView.Theme.xaml
@@ -653,6 +653,5 @@
         <Setter Property="VerticalAlignment" Value="Top" />
         <Setter Property="Width" Value="256" />
         <Setter Property="Margin" Value="4" />
-        <Setter Property="EnableDefaultWorldGeocoder" Value="True" />
     </Style>
 </ResourceDictionary>

--- a/src/Toolkit/Toolkit/LocalizedStrings/Resources.resx
+++ b/src/Toolkit/Toolkit/LocalizedStrings/Resources.resx
@@ -509,4 +509,8 @@
     <value>Zoom to result</value>
     <comment>The text on button that zooms to the selected trace result.</comment>
   </data>
+  <data name="Locator_DefaultName" xml:space="preserve">
+    <value>Locator</value>
+    <comment>Default display name for LocatorSearchSource if locator name is not set.</comment>
+  </data>
 </root>

--- a/src/Toolkit/Toolkit/UI/Controls/SearchView/LocatorSearchSource.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/SearchView/LocatorSearchSource.cs
@@ -189,7 +189,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
                 else if (!string.IsNullOrWhiteSpace(info.Description))
                     _displayName = info.Description;
                 else
-                    _displayName = string.Empty;
+                    _displayName = Properties.Resources.GetString("Locator_DefaultName") ?? string.Empty;
 
                 OnPropertyChanged(nameof(DisplayName));
             }

--- a/src/Toolkit/Toolkit/UI/Controls/SearchView/LocatorSearchSource.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/SearchView/LocatorSearchSource.cs
@@ -63,11 +63,17 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             return new WorldGeocoderSearchSource(_worldGeocoderTask, null);
         }
 
-        private readonly Lazy<Task> _loadTask;
 
         /// <inheritdoc/>
         public event PropertyChangedEventHandler? PropertyChanged;
 
+        /// <summary>
+        /// Raises the <see cref="PropertyChanged"/> event for the specified property.
+        /// </summary>
+        /// <param name="propertyName">The name of the property that changed.</param>
+        protected virtual void OnPropertyChanged(string propertyName) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+
+        private readonly Lazy<Task> _loadTask;
         /// <summary>
         /// Gets the task used to perform initial locator setup.
         /// </summary>
@@ -88,7 +94,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
                 {
                     _displayName = value;
                     _displayNameSetExternally = true;
-                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(DisplayName)));
+                    OnPropertyChanged(nameof(DisplayName));
                 }
             }
         }
@@ -179,13 +185,13 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             {
                 // Locators from online services have descriptions but not names.
                 if (!string.IsNullOrWhiteSpace(info.Name) && info.Name != Locator.Uri?.ToString())
-                {
                     _displayName = info.Name;
-                }
                 else if (!string.IsNullOrWhiteSpace(info.Description))
-                {
                     _displayName = info.Description;
-                }
+                else
+                    _displayName = string.Empty;
+
+                OnPropertyChanged(nameof(DisplayName));
             }
 
             GeocodeParameters.ResultAttributeNames.Add("*");

--- a/src/Toolkit/Toolkit/UI/Controls/SearchView/LocatorSearchSource.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/SearchView/LocatorSearchSource.cs
@@ -183,7 +183,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
                     _displayName = info.Name;
                 }
                 else if (!string.IsNullOrWhiteSpace(info.Description))
-            {
+                {
                     _displayName = info.Description;
                 }
             }
@@ -212,7 +212,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
                 pinSymbol.OffsetY = 16.5;
                 DefaultSymbol = pinSymbol;
             }
-            }
+        }
 
         /// <summary>
         /// This search source does not track selection state.

--- a/src/Toolkit/Toolkit/UI/Controls/SearchView/WorldGeocoderSearchSource.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/SearchView/WorldGeocoderSearchSource.cs
@@ -39,7 +39,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         // Attribute used to identify the type of result coming from the locaotr.
         private const string LocatorIconAttributeKey = "Type";
 
-        private readonly Task _additionalLoadTask;
+        private readonly Lazy<Task> _additionalLoadTask;
 
         /// <summary>
         /// Gets or sets the minimum number of results to attempt to return.
@@ -87,14 +87,13 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             {
                 ResultSymbolStyle = style;
             }
+            InitializeLocatorAttributes();
 
-            _additionalLoadTask = EnsureLoaded();
+            _additionalLoadTask = new Lazy<Task>(EnsureLoaded);
         }
 
-        private async Task EnsureLoaded()
+        private void InitializeLocatorAttributes()
         {
-            await LoadTask;
-
             if (Locator.LocatorInfo is LocatorInfo info)
             {
                 // Locators from online services have descriptions but not names.
@@ -127,6 +126,8 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             }
         }
 
+        private async Task EnsureLoaded() => await LoadTask.Value;
+
         /// <summary>
         /// Converts suggest result list into list of suggestions, applying result limits and calling necessary callbacks.
         /// </summary>
@@ -140,7 +141,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         /// <inheritdoc />
         public override async Task<IList<SearchResult>> SearchAsync(SearchSuggestion suggestion, CancellationToken cancellationToken = default)
         {
-            await _additionalLoadTask;
+            await _additionalLoadTask.Value;
             cancellationToken.ThrowIfCancellationRequested();
 
             var tempParams = new GeocodeParameters();
@@ -167,7 +168,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         /// <inheritdoc/>
         public override async Task<IList<SearchSuggestion>> SuggestAsync(string queryString, CancellationToken cancellationToken = default)
         {
-            await _additionalLoadTask;
+            await _additionalLoadTask.Value;
             cancellationToken.ThrowIfCancellationRequested();
 
             SuggestParameters.PreferredSearchLocation = PreferredSearchLocation;
@@ -197,7 +198,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         /// <inheritdoc/>
         public override async Task<IList<SearchResult>> SearchAsync(string queryString, CancellationToken cancellationToken = default)
         {
-            await _additionalLoadTask;
+            await _additionalLoadTask.Value;
             cancellationToken.ThrowIfCancellationRequested();
 
             // Reset spatial parameters
@@ -230,7 +231,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         /// </summary>
         public override async Task<IList<SearchResult>> RepeatSearchAsync(string queryString, Geometry.Envelope queryArea, CancellationToken cancellationToken = default)
         {
-            await _additionalLoadTask;
+            await _additionalLoadTask.Value;
             cancellationToken.ThrowIfCancellationRequested();
 
             // Reset spatial parameters

--- a/src/Toolkit/Toolkit/UI/Controls/SearchView/WorldGeocoderSearchSource.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/SearchView/WorldGeocoderSearchSource.cs
@@ -39,8 +39,6 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         // Attribute used to identify the type of result coming from the locaotr.
         private const string LocatorIconAttributeKey = "Type";
 
-        private readonly Lazy<Task> _additionalLoadTask;
-
         /// <summary>
         /// Gets or sets the minimum number of results to attempt to return.
         /// If there are too few results, the search is repeated with loosened parameters until enough results are accumulated.
@@ -88,25 +86,10 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
                 ResultSymbolStyle = style;
             }
             InitializeLocatorAttributes();
-
-            _additionalLoadTask = new Lazy<Task>(EnsureLoaded);
         }
 
         private void InitializeLocatorAttributes()
         {
-            if (Locator.LocatorInfo is LocatorInfo info)
-            {
-                // Locators from online services have descriptions but not names.
-                if (!string.IsNullOrWhiteSpace(info.Name) && info.Name != Locator.Uri?.ToString())
-                {
-                    DisplayName = info.Name;
-                }
-                else if (!string.IsNullOrWhiteSpace(info.Description))
-                {
-                    DisplayName = info.Description;
-                }
-            }
-
             // Add attributes expected from the World Geocoder Service if present, otherwise default to all attributes.
             if (Locator.Uri?.ToString() == WorldGeocoderUriString &&
                 (Locator.LocatorInfo?.ResultAttributes?.Any() == true))
@@ -126,8 +109,6 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             }
         }
 
-        private async Task EnsureLoaded() => await LoadTask.Value;
-
         /// <summary>
         /// Converts suggest result list into list of suggestions, applying result limits and calling necessary callbacks.
         /// </summary>
@@ -141,7 +122,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         /// <inheritdoc />
         public override async Task<IList<SearchResult>> SearchAsync(SearchSuggestion suggestion, CancellationToken cancellationToken = default)
         {
-            await _additionalLoadTask.Value;
+            await LoadTask.Value;
             cancellationToken.ThrowIfCancellationRequested();
 
             var tempParams = new GeocodeParameters();
@@ -168,7 +149,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         /// <inheritdoc/>
         public override async Task<IList<SearchSuggestion>> SuggestAsync(string queryString, CancellationToken cancellationToken = default)
         {
-            await _additionalLoadTask.Value;
+            await LoadTask.Value;
             cancellationToken.ThrowIfCancellationRequested();
 
             SuggestParameters.PreferredSearchLocation = PreferredSearchLocation;
@@ -198,7 +179,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         /// <inheritdoc/>
         public override async Task<IList<SearchResult>> SearchAsync(string queryString, CancellationToken cancellationToken = default)
         {
-            await _additionalLoadTask.Value;
+            await LoadTask.Value;
             cancellationToken.ThrowIfCancellationRequested();
 
             // Reset spatial parameters
@@ -231,7 +212,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         /// </summary>
         public override async Task<IList<SearchResult>> RepeatSearchAsync(string queryString, Geometry.Envelope queryArea, CancellationToken cancellationToken = default)
         {
-            await _additionalLoadTask.Value;
+            await LoadTask.Value;
             cancellationToken.ThrowIfCancellationRequested();
 
             // Reset spatial parameters


### PR DESCRIPTION
- Add Loaded event handler to SearchView for initialization.
- Removed calls ConfigureForCurrentConfiguration as it is being called before EnableDefaultWorldGeocode property is assigned.
- Updated the way default value is set for EnableDefaultWorldGeocode in WPF, UWP and WinUI.