### PR TITLE
Accessibility changes for ScaleLine control

### DIFF
--- a/src/Toolkit/Toolkit.UI.Controls/Esri.ArcGISRuntime.Toolkit.UI.Controls.projitems
+++ b/src/Toolkit/Toolkit.UI.Controls/Esri.ArcGISRuntime.Toolkit.UI.Controls.projitems
@@ -33,6 +33,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)OverviewMap\OverviewMap.Windows.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ScaleLine\ScaleLine.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ScaleLine\ScaleLine.Windows.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ScaleLine\ScaleLineAutomationPeer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SearchView\SearchView.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SymbolDisplay\SymbolDisplay.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SymbolDisplay\SymbolDisplay.Windows.cs" />

--- a/src/Toolkit/Toolkit.UI.Controls/ScaleLine/ScaleLine.Windows.cs
+++ b/src/Toolkit/Toolkit.UI.Controls/ScaleLine/ScaleLine.Windows.cs
@@ -160,50 +160,6 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         {
             Visibility = isVisible ? Visibility.Visible : Visibility.Collapsed;
         }
-#if WPF || WINDOWS_XAML
-        /// <inheritdoc />
-        public partial class ScaleLineAutomationPeer : FrameworkElementAutomationPeer, IValueProvider
-        {
-            private readonly ScaleLine _owner;
-
-            internal ScaleLineAutomationPeer(ScaleLine owner) : base(owner)
-            {
-                _owner = owner;
-            }
-            /// <inheritdoc />
-            protected override string GetLocalizedControlTypeCore() => Properties.Resources.GetString("ScaleLineAutomationTypeName")!;
-            /// <inheritdoc />
-            protected override AutomationControlType GetAutomationControlTypeCore() => AutomationControlType.Text;
-
-            /// <inheritdoc />
-            protected override AutomationLiveSetting GetLiveSettingCore() => AutomationLiveSetting.Polite;
-
-            /// <inheritdoc />
-        #if WPF
-            public override object GetPattern(PatternInterface patternInterface)
-        #elif WINDOWS_XAML
-            protected override object GetPatternCore(PatternInterface patternInterface)
-        #endif           
-            {
-                if (patternInterface == PatternInterface.Value)
-                {
-                    return this;
-                }
-            #if WPF
-                return base.GetPattern(patternInterface);
-            #elif WINDOWS_XAML
-                return base.GetPatternCore(patternInterface);
-            #endif
-            }
-            /// <inheritdoc />
-            public string Value => String.Format(Properties.Resources.GetString("ScaleLineAutomationValue")!, GetRoundedValue(_owner.MapScale));
-            
-            /// <inheritdoc />
-            public bool IsReadOnly => true;
-            /// <inheritdoc />
-            public void SetValue(string value) => throw new System.NotSupportedException("ScaleLine value is read-only.");
-        }
-#endif
     }
 }
 #endif

--- a/src/Toolkit/Toolkit.UI.Controls/ScaleLine/ScaleLine.Windows.cs
+++ b/src/Toolkit/Toolkit.UI.Controls/ScaleLine/ScaleLine.Windows.cs
@@ -178,9 +178,12 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             /// <inheritdoc />
             protected override AutomationLiveSetting GetLiveSettingCore() => AutomationLiveSetting.Polite;
 
-        #if WPF
             /// <inheritdoc />
+        #if WPF
             public override object GetPattern(PatternInterface patternInterface)
+        #elif WINDOWS_XAML
+            protected override object GetPatternCore(PatternInterface patternInterface)
+        #endif           
             {
                 if (patternInterface == PatternInterface.Value)
                 {
@@ -188,17 +191,6 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
                 }
                 return base.GetPattern(patternInterface);
             }
-        #else
-            /// <inheritdoc />
-            protected override object GetPatternCore(PatternInterface patternInterface)
-            {
-                if (patternInterface == PatternInterface.Value)
-                {
-                    return this;
-                }
-                return base.GetPatternCore(patternInterface);
-            }
-        #endif
             /// <inheritdoc />
             public string Value
             {

--- a/src/Toolkit/Toolkit.UI.Controls/ScaleLine/ScaleLine.Windows.cs
+++ b/src/Toolkit/Toolkit.UI.Controls/ScaleLine/ScaleLine.Windows.cs
@@ -173,10 +173,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             /// <inheritdoc />
             protected override string GetLocalizedControlTypeCore() => Properties.Resources.GetString("ScaleLineAutomationTypeName")!;
             /// <inheritdoc />
-            protected override AutomationControlType GetAutomationControlTypeCore()
-            {
-                return AutomationControlType.Text;
-            }
+            protected override AutomationControlType GetAutomationControlTypeCore() => AutomationControlType.Text;
 
             /// <inheritdoc />
             protected override AutomationLiveSetting GetLiveSettingCore() => AutomationLiveSetting.Polite;

--- a/src/Toolkit/Toolkit.UI.Controls/ScaleLine/ScaleLine.Windows.cs
+++ b/src/Toolkit/Toolkit.UI.Controls/ScaleLine/ScaleLine.Windows.cs
@@ -189,23 +189,19 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
                 {
                     return this;
                 }
+            #if WPF
                 return base.GetPattern(patternInterface);
+            #elif WINDOWS_XAML
+                return base.GetPatternCore(patternInterface);
+            #endif
             }
             /// <inheritdoc />
-            public string Value
-            {
-                get
-                {
-                    return String.Format(Properties.Resources.GetString("ScaleLineAutomationValue")!, GetRoundedValue(_owner.MapScale));
-                }
-            }
+            public string Value => String.Format(Properties.Resources.GetString("ScaleLineAutomationValue")!, GetRoundedValue(_owner.MapScale));
+            
             /// <inheritdoc />
             public bool IsReadOnly => true;
             /// <inheritdoc />
-            public void SetValue(string value)
-            {
-                throw new System.NotSupportedException("ScaleLine value is read-only.");
-            }
+            public void SetValue(string value) => throw new System.NotSupportedException("ScaleLine value is read-only.");
         }
 #endif
     }

--- a/src/Toolkit/Toolkit.UI.Controls/ScaleLine/ScaleLine.cs
+++ b/src/Toolkit/Toolkit.UI.Controls/ScaleLine/ScaleLine.cs
@@ -165,31 +165,11 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             return MapScale;
         }
 
-        private static double GetRoundedValue(double value)
+        internal static double GetRoundedValue(double value)
         {
             if (double.IsNaN(value))
             {
                 return 0;
-            }
-            else if(value >= 100000000)
-            {
-                return value - (value % 100000000);
-            }
-            else if(value >= 10000000)
-            {
-                return value - (value % 10000000);
-            }
-            else if(value >= 1000000)
-            {
-                return value - (value % 1000000);
-            }
-            else if (value >= 100000)
-            {
-                return value - (value % 100000);
-            }
-            else if (value >= 10000)
-            {
-                return value - (value % 10000);
             }
             else if (value >= 1000)
             {

--- a/src/Toolkit/Toolkit.UI.Controls/ScaleLine/ScaleLine.cs
+++ b/src/Toolkit/Toolkit.UI.Controls/ScaleLine/ScaleLine.cs
@@ -171,6 +171,26 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             {
                 return 0;
             }
+            else if(value >= 100000000)
+            {
+                return value - (value % 100000000);
+            }
+            else if(value >= 10000000)
+            {
+                return value - (value % 10000000);
+            }
+            else if(value >= 1000000)
+            {
+                return value - (value % 1000000);
+            }
+            else if (value >= 100000)
+            {
+                return value - (value % 100000);
+            }
+            else if (value >= 10000)
+            {
+                return value - (value % 10000);
+            }
             else if (value >= 1000)
             {
                 return value - (value % 1000);

--- a/src/Toolkit/Toolkit.UI.Controls/ScaleLine/ScaleLineAutomationPeer.cs
+++ b/src/Toolkit/Toolkit.UI.Controls/ScaleLine/ScaleLineAutomationPeer.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+#if WPF
+using System.Windows.Automation;
+using System.Windows.Automation.Peers;
+using System.Windows.Automation.Provider;
+#elif WINDOWS_UWP
+using Windows.UI.Xaml.Automation;
+using Windows.UI.Xaml.Automation.Peers;
+using Windows.UI.Xaml.Automation.Provider;
+#elif WINUI
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Automation.Provider;
+#endif
+
+namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
+{
+    /// <inheritdoc />
+    public partial class ScaleLineAutomationPeer : FrameworkElementAutomationPeer, IValueProvider
+    {
+        private readonly ScaleLine _owner;
+
+        internal ScaleLineAutomationPeer(ScaleLine owner) : base(owner ?? throw new ArgumentNullException(nameof(owner)))
+        {
+            _owner = owner;
+        }
+        /// <inheritdoc />
+        protected override string GetLocalizedControlTypeCore() => Properties.Resources.GetString("ScaleLineAutomationTypeName")!;
+        /// <inheritdoc />
+        protected override AutomationControlType GetAutomationControlTypeCore() => AutomationControlType.Text;
+
+        /// <inheritdoc />
+        protected override AutomationLiveSetting GetLiveSettingCore() => AutomationLiveSetting.Polite;
+
+        /// <inheritdoc />
+#if WPF
+        public override object GetPattern(PatternInterface patternInterface)
+#elif WINDOWS_XAML
+        protected override object GetPatternCore(PatternInterface patternInterface)
+#endif
+        {
+            if (patternInterface == PatternInterface.Value)
+            {
+                return this;
+            }
+    #if WPF
+            return base.GetPattern(patternInterface);
+    #elif WINDOWS_XAML
+            return base.GetPatternCore(patternInterface);
+    #endif
+        }
+        /// <inheritdoc />
+        public string Value => String.Format(Properties.Resources.GetString("ScaleLineAutomationValue")!, GetRoundedValueForAutomationPeer(_owner.MapScale));
+        /// <inheritdoc />
+        public bool IsReadOnly => true;
+        /// <inheritdoc />
+        public void SetValue(string value) => throw new System.NotSupportedException("ScaleLine value is read-only.");
+        private static double GetRoundedValueForAutomationPeer(double value)
+        {
+           if (value >= 1000000)
+           {
+                return value - (value % 1000000);
+           }
+           else
+           {
+               return ScaleLine.GetRoundedValue(value);
+           }
+        }
+    }
+}

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/ScaleLine/ScaleLine.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/ScaleLine/ScaleLine.Theme.xaml
@@ -1,7 +1,8 @@
 ﻿<ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:controls="clr-namespace:Esri.ArcGISRuntime.Toolkit.UI.Controls">
+    xmlns:controls="clr-namespace:Esri.ArcGISRuntime.Toolkit.UI.Controls"
+    xmlns:internal="clr-namespace:Esri.ArcGISRuntime.Toolkit.Internal">
 
     <Style TargetType="{x:Type controls:ScaleLine}" >
         <Setter Property="HorizontalContentAlignment" Value="Left" />
@@ -9,6 +10,10 @@
         <Setter Property="HorizontalAlignment" Value="Left " />
         <Setter Property="Foreground" Value="Black"/>
         <Setter Property="TargetWidth" Value="200" />
+        <Setter Property="IsTabStop" Value="False"/>
+        <Setter Property="Focusable" Value="False"/>
+        <Setter Property="AutomationProperties.Name" Value="{internal:LocalizedString Key=ScaleLineAutomationName}"/>
+        <Setter Property="AutomationProperties.HelpText" Value="{internal:LocalizedString Key=ScaleLineAutomationHelpText}"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type controls:ScaleLine}">

--- a/src/Toolkit/Toolkit/LocalizedStrings/Resources.resx
+++ b/src/Toolkit/Toolkit/LocalizedStrings/Resources.resx
@@ -313,6 +313,10 @@
     <value>Indicates the current scale for the map</value>
     <comment>UIA AutomationProperties.HelpText for the ScaleLine control, providing context for accessibility tools</comment>
   </data>
+  <data name="ScaleLineAutomationValue" xml:space="preserve">
+    <value>1 to {0}</value>
+    <comment>UIA ValueProperty.Value for the ScaleLine control, announces the map scale to screen readers</comment>
+  </data>
   <data name="ScaleLineMilesAbbreviation" xml:space="preserve">
     <value>mi</value>
     <comment>Abbreviation of "Miles" displayed in the scale bar</comment>

--- a/src/Toolkit/Toolkit/LocalizedStrings/Resources.resx
+++ b/src/Toolkit/Toolkit/LocalizedStrings/Resources.resx
@@ -301,6 +301,18 @@
     <value>m</value>
     <comment>Abbreviation of "Meters" displayed in the scale bar</comment>
   </data>
+  <data name="ScaleLineAutomationTypeName" xml:space="preserve">
+    <value>Scale</value>
+    <comment>The type name of the ScaleLine control for accessibility uses</comment>
+  </data>
+  <data name="ScaleLineAutomationName" xml:space="preserve">
+    <value>Map Scale</value>
+    <comment>UIA AutomationProperties.Name for the ScaleLine control, used by screen readers to identify the control</comment>
+  </data>
+  <data name="ScaleLineAutomationHelpText" xml:space="preserve">
+    <value>Indicates the current scale for the map</value>
+    <comment>UIA AutomationProperties.HelpText for the ScaleLine control, providing context for accessibility tools</comment>
+  </data>
   <data name="ScaleLineMilesAbbreviation" xml:space="preserve">
     <value>mi</value>
     <comment>Abbreviation of "Miles" displayed in the scale bar</comment>


### PR DESCRIPTION
- Set the value of IsTabSop and Focusable to False by default
- Added Automation name, help text for the scaleline control
- Updated the "custom" control type to "Scale"
- Exposed the Value of Scale Line for the automation tools  -- 1 to (roundedValue of MapScale)
- Added programmatic control type of ScaleLine as Text. So that the narrator knows to read the value of the control
- Set AutomationProperties.LiveSetting to Polite on the control, so that screen readers (like Narrator) will announce the scale value changes automatically in a polite, non-interruptive manner. This is useful when the control is configured with IsTabStop = true or Focusable = true and if the user has logic that announces the scale whenever it changes — such as when the MapScale property is updated programmatically.