### PR TITLE
BugFix: Fixing BasemapGallery Sceneview appears blank sometimes.

### DIFF
--- a/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryController.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryController.cs
@@ -201,27 +201,29 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
 
         public async Task UpdateBasemaps()
         {
+            // Cancel any pending load before starting a new one
+            _loadCancellationTokenSource?.Cancel();
+
             await _updateBasemapsSemaphore.WaitAsync();
             try
             {
-            IsLoading = true;
-            // Cancel any pending load before starting a new one
-            _loadCancellationTokenSource?.Cancel();
-            _loadCancellationTokenSource = new CancellationTokenSource();
-            try
-            {
-                _availableBasemaps = await PopulateBasemaps(_loadCancellationTokenSource.Token);
-                HandleAvailableBasemapsChanged();
+                IsLoading = true;
+                _loadCancellationTokenSource = new CancellationTokenSource();
+                try
+                {
+                    _availableBasemaps = await PopulateBasemaps(_loadCancellationTokenSource.Token);
+                    HandleAvailableBasemapsChanged();
+                }
+                catch (OperationCanceledException) { }
+                catch (Exception ex)
+                {
+                    System.Diagnostics.Trace.WriteLine(ex.Message);
+                }
+                finally
+                {
+                    IsLoading = false;
+                }
             }
-            catch (Exception ex)
-            {
-                System.Diagnostics.Trace.WriteLine(ex.Message);
-            }
-            finally
-            {
-                IsLoading = false;
-            }
-        }
             finally
             {
                 _updateBasemapsSemaphore.Release();

--- a/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryController.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryController.cs
@@ -301,13 +301,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
 
         private Task<ObservableCollection<BasemapGalleryItem>> LoadBasemapGalleryItems(ArcGISPortal portal, CancellationToken cancellationToken = default)
         {
-            if (_loadBasemapGalleryItemsTask is null || _loadBasemapGalleryItemsTask.IsCompleted)
-            {
-                _loadBasemapGalleryItemsTask = LoadBasemapGalleryItemsInternal(portal, cancellationToken);
-                return _loadBasemapGalleryItemsTask;
-            }
-
-            return _loadBasemapGalleryItemsTask;
+            return LoadBasemapGalleryItemsInternal(portal, cancellationToken);
         }
 
         private async Task<ObservableCollection<BasemapGalleryItem>> LoadBasemapGalleryItemsInternal(ArcGISPortal portal, CancellationToken cancellationToken = default)

--- a/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryController.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryController.cs
@@ -299,12 +299,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
             return await LoadBasemapGalleryItems(Portal, cancellationToken);
         }
 
-        private Task<ObservableCollection<BasemapGalleryItem>> LoadBasemapGalleryItems(ArcGISPortal portal, CancellationToken cancellationToken = default)
-        {
-            return LoadBasemapGalleryItemsInternal(portal, cancellationToken);
-        }
-
-        private async Task<ObservableCollection<BasemapGalleryItem>> LoadBasemapGalleryItemsInternal(ArcGISPortal portal, CancellationToken cancellationToken = default)
+        private async Task<ObservableCollection<BasemapGalleryItem>> LoadBasemapGalleryItems(ArcGISPortal portal, CancellationToken cancellationToken = default)
         {
             async Task<List<BasemapGalleryItem>> LoadBasemapsAsync(Func<CancellationToken, Task<IEnumerable<Basemap>>> getBasemapsFunc)
             {

--- a/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryController.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryController.cs
@@ -148,7 +148,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
                 PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(AvailableBasemaps)));
 
                 // Update validity
-                AvailableBasemaps?.ToList()?.ForEach(bmgi => _ = bmgi.NotifySpatialReferenceChanged(GeoModel));
+                AvailableBasemaps?.ToList()?.ForEach(async bmgi => await bmgi.NotifySpatialReferenceChanged(GeoModel));
 
                 // Update selection.
                 UpdateSelectionForGeoModelBasemap();
@@ -168,7 +168,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
                 case NotifyCollectionChangedAction.Move:
                 case NotifyCollectionChangedAction.Replace:
                 case NotifyCollectionChangedAction.Reset:
-                    e.NewItems?.OfType<BasemapGalleryItem>().ToList().ForEach(bmgi => _ = bmgi.NotifySpatialReferenceChanged(GeoModel));
+                    e.NewItems?.OfType<BasemapGalleryItem>().ToList().ForEach(async bmgi => await bmgi.NotifySpatialReferenceChanged(GeoModel));
                     UpdateSelectionForGeoModelBasemap();
                     break;
                 case NotifyCollectionChangedAction.Remove:
@@ -187,7 +187,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
             }
             else if (e.PropertyName == nameof(GeoModel.SpatialReference))
             {
-                AvailableBasemaps?.ToList().ForEach(item => _ = item.NotifySpatialReferenceChanged(GeoModel));
+                AvailableBasemaps?.ToList().ForEach(async item => await item.NotifySpatialReferenceChanged(GeoModel));
             }
         }
 

--- a/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryController.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryController.cs
@@ -148,7 +148,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
                 PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(AvailableBasemaps)));
 
                 // Update validity
-                AvailableBasemaps?.ToList()?.ForEach(async bmgi => await bmgi.NotifySpatialReferenceChanged(GeoModel));
+                AvailableBasemaps?.ToList()?.ForEach(bmgi => bmgi.NotifySpatialReferenceChanged(GeoModel));
 
                 // Update selection.
                 UpdateSelectionForGeoModelBasemap();
@@ -168,7 +168,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
                 case NotifyCollectionChangedAction.Move:
                 case NotifyCollectionChangedAction.Replace:
                 case NotifyCollectionChangedAction.Reset:
-                    e.NewItems?.OfType<BasemapGalleryItem>().ToList().ForEach(async bmgi => await bmgi.NotifySpatialReferenceChanged(GeoModel));
+                    e.NewItems?.OfType<BasemapGalleryItem>().ToList().ForEach(bmgi => bmgi.NotifySpatialReferenceChanged(GeoModel));
                     UpdateSelectionForGeoModelBasemap();
                     break;
                 case NotifyCollectionChangedAction.Remove:
@@ -187,7 +187,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
             }
             else if (e.PropertyName == nameof(GeoModel.SpatialReference))
             {
-                AvailableBasemaps?.ToList().ForEach(async item => await item.NotifySpatialReferenceChanged(GeoModel));
+                AvailableBasemaps?.ToList().ForEach(item => item.NotifySpatialReferenceChanged(GeoModel));
             }
         }
 
@@ -197,8 +197,13 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
             await UpdateBasemaps();
         }
 
+        private readonly SemaphoreSlim _updateBasemapsSemaphore = new(1, 1);
+
         public async Task UpdateBasemaps()
         {
+            await _updateBasemapsSemaphore.WaitAsync();
+            try
+            {
             IsLoading = true;
             // Cancel any pending load before starting a new one
             _loadCancellationTokenSource?.Cancel();
@@ -215,6 +220,11 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
             finally
             {
                 IsLoading = false;
+            }
+        }
+            finally
+            {
+                _updateBasemapsSemaphore.Release();
             }
         }
 

--- a/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryController.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryController.cs
@@ -148,7 +148,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
                 PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(AvailableBasemaps)));
 
                 // Update validity
-                AvailableBasemaps?.ToList()?.ForEach(bmgi => bmgi.NotifySpatialReferenceChanged(GeoModel));
+                AvailableBasemaps?.ToList()?.ForEach(bmgi => _ = bmgi.NotifySpatialReferenceChanged(GeoModel));
 
                 // Update selection.
                 UpdateSelectionForGeoModelBasemap();
@@ -168,7 +168,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
                 case NotifyCollectionChangedAction.Move:
                 case NotifyCollectionChangedAction.Replace:
                 case NotifyCollectionChangedAction.Reset:
-                    e.NewItems?.OfType<BasemapGalleryItem>().ToList().ForEach(bmgi => bmgi.NotifySpatialReferenceChanged(GeoModel));
+                    e.NewItems?.OfType<BasemapGalleryItem>().ToList().ForEach(bmgi => _ = bmgi.NotifySpatialReferenceChanged(GeoModel));
                     UpdateSelectionForGeoModelBasemap();
                     break;
                 case NotifyCollectionChangedAction.Remove:
@@ -187,7 +187,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
             }
             else if (e.PropertyName == nameof(GeoModel.SpatialReference))
             {
-                AvailableBasemaps?.ToList().ForEach(item => item.NotifySpatialReferenceChanged(GeoModel));
+                AvailableBasemaps?.ToList().ForEach(item => _ = item.NotifySpatialReferenceChanged(GeoModel));
             }
         }
 

--- a/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryController.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryController.cs
@@ -201,12 +201,15 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
 
         public async Task UpdateBasemaps()
         {
-            // Cancel any pending load before starting a new one
-            _loadCancellationTokenSource?.Cancel();
-
-            await _updateBasemapsSemaphore.WaitAsync();
+            // Try to enter the semaphore without waiting
+            if (!await _updateBasemapsSemaphore.WaitAsync(0))
+            {
+                // Another update is already running; exit immediately
+                return;
+            }
             try
             {
+            _loadCancellationTokenSource?.Cancel();
                 IsLoading = true;
                 _loadCancellationTokenSource = new CancellationTokenSource();
                 try

--- a/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryController.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryController.cs
@@ -198,15 +198,14 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
         }
 
         private bool _pendingUpdateBasemaps;
-        private bool _isUpdatingBasemaps;
 
         public async Task UpdateBasemaps()
         {
             _pendingUpdateBasemaps = true;
-            if (_isUpdatingBasemaps)
+            if (IsLoading)
                 return;
 
-            _isUpdatingBasemaps = true;
+            IsLoading = true;
             try
             {
                 while (_pendingUpdateBasemaps)
@@ -214,7 +213,6 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
                     _pendingUpdateBasemaps = false;
                     
                     _loadCancellationTokenSource?.Cancel();
-                    IsLoading = true;
                     _loadCancellationTokenSource = new CancellationTokenSource();
                     try
                     {
@@ -226,15 +224,11 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
                     {
                         System.Diagnostics.Trace.WriteLine(ex.Message);
                     }
-                    finally
-                    {
-                        IsLoading = false;
-                    }
                 }
             }
             finally
             {
-                _isUpdatingBasemaps = false;
+                IsLoading = false;
             }
         }
 

--- a/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryController.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryController.cs
@@ -209,7 +209,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
             }
             try
             {
-            _loadCancellationTokenSource?.Cancel();
+                _loadCancellationTokenSource?.Cancel();
                 IsLoading = true;
                 _loadCancellationTokenSource = new CancellationTokenSource();
                 try

--- a/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryItem.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryItem.cs
@@ -135,7 +135,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
             }
         }
 
-        internal async Task NotifySpatialReferenceChanged(GeoModel? gm)
+        internal async void NotifySpatialReferenceChanged(GeoModel? gm)
         {
             try
             {

--- a/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryItem.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryItem.cs
@@ -135,7 +135,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
             }
         }
 
-        internal async void NotifySpatialReferenceChanged(GeoModel? gm)
+        internal async Task NotifySpatialReferenceChanged(GeoModel? gm)
         {
             try
             {


### PR DESCRIPTION
Introduced a semaphore for thread-safe access to UpdateBasemaps.
This avoids multiple invocations of UpdateBasemaps() and NotifySpatialReferenceChanged() and locks resource when in use by another call.

Did testing by opening SceneView multipel times and did not observed the bug.