### PR TITLE
Bugfix: Android crash in BasemapGallery due to `Canvas trying to use a recycled bitmap` Exception

### DIFF
--- a/src/Toolkit/Toolkit.Maui/BasemapGallery/BasemapGallery.Appearance.cs
+++ b/src/Toolkit/Toolkit.Maui/BasemapGallery/BasemapGallery.Appearance.cs
@@ -16,6 +16,7 @@
 
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Shapes;
+using Microsoft.Maui.Platform;
 
 namespace Esri.ArcGISRuntime.Toolkit.Maui;
 
@@ -49,7 +50,24 @@ public partial class BasemapGallery : TemplatedView
             outerScrimContainer.RowSpacing = 4;
 
             Grid thumbnailGrid = new Grid() { WidthRequest = 64, HeightRequest = 64 };
+#if ANDROID
+            // Workaround for .NET MAUI Android bug where CollectionView throws
+            // Java.Lang.RuntimeException: 'Canvas: trying to use a recycled bitmap'
+            // (see https://github.com/dotnet/maui/issues/11519, affects MAUI 9.0.0).
+            // This occurs when images are reused in CollectionView, causing recycled bitmaps to be drawn.
+            // The workaround uses a custom ThumbnailImage control and a custom ImageHandler mapping
+            // to clear the native image view when the image source changes, preventing the recycled bitmap error.
+            ThumbnailImage thumbnail = new ThumbnailImage { Aspect = Aspect.AspectFill, BackgroundColor = Colors.Transparent, HorizontalOptions = LayoutOptions.Center };
+            Microsoft.Maui.Handlers.ImageHandler.Mapper.PrependToMapping(nameof(Microsoft.Maui.IImage.Source), static (handler, view) =>
+            {
+                if (view is ThumbnailImage)
+                {
+                    handler.PlatformView?.Clear();
+                }
+            });
+#else
             Image thumbnail = new Image { Aspect = Aspect.AspectFill, BackgroundColor = Colors.Transparent, HorizontalOptions = LayoutOptions.Center };
+#endif
             Border itemTypeBorder = new Border
             {
                 StrokeShape = new RoundRectangle { CornerRadius = new CornerRadius(7) },
@@ -386,3 +404,15 @@ public partial class BasemapGallery : TemplatedView
         HandleTemplateChange(width);
     }
 }
+
+#if ANDROID
+/// <summary>
+/// Represents an image used in the Basemap Gallery.
+/// <remarks>
+/// This class is only used on Android to work around a .NET MAUI bug where CollectionView may attempt to use a recycled bitmap,
+/// resulting in a Java.Lang.RuntimeException. By using a custom Image control and clearing the native image view when the source changes,
+/// this issue is avoided. See https://github.com/dotnet/maui/issues/11519 for more details.
+/// </remarks>
+/// </summary>
+internal class ThumbnailImage : Image { } 
+#endif

--- a/src/Toolkit/Toolkit.Maui/BasemapGallery/BasemapGallery.Appearance.cs
+++ b/src/Toolkit/Toolkit.Maui/BasemapGallery/BasemapGallery.Appearance.cs
@@ -409,10 +409,10 @@ public partial class BasemapGallery : TemplatedView
 /// <summary>
 /// Represents an image used in the Basemap Gallery.
 /// <remarks>
-/// This class is only used on Android to work around a .NET MAUI bug where CollectionView may attempt to use a recycled bitmap,
-/// resulting in a Java.Lang.RuntimeException. By using a custom Image control and clearing the native image view when the source changes,
-/// this issue is avoided. See https://github.com/dotnet/maui/issues/11519 for more details.
+///  This class is only used on Android to work around a .NET MAUI bug where CollectionView may attempt to use a recycled bitmap,
+///  resulting in a Java.Lang.RuntimeException. By using a custom Image control and clearing the native image view when the source changes,
+///  this issue is avoided. See https://github.com/dotnet/maui/issues/11519 for more details.
 /// </remarks>
 /// </summary>
-internal class ThumbnailImage : Image { } 
+internal class ThumbnailImage : Image { }
 #endif

--- a/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryItem.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryItem.cs
@@ -111,7 +111,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
 
                 if (Thumbnail?.LoadStatus == LoadStatus.Loaded)
                 {
-                    var stream = await Thumbnail.GetEncodedBufferAsync();
+                    using var stream = await Thumbnail.GetEncodedBufferAsync();
                     var buffer = new byte[stream.Length];
 #if NET8_0_OR_GREATER
                     await stream.ReadExactlyAsync(buffer);


### PR DESCRIPTION
- Added a new `ThumbnailImage` class in `BasemapGallery` as workaround to address a [known issue](https://github.com/dotnet/maui/issues/11519) with recycled bitmaps in MAUI `CollectionView` on Android, preventing related Java exceptions.
- This bug is observed in MAUI version 9.0.0.
- Added a `using` statement for the stream from `Thumbnail.GetEncodedBufferAsync()`, ensuring proper disposal.