### PR TITLE
FeatureForm: Expose bindable apply/discard commands

### DIFF
--- a/src/Samples/Toolkit.SampleApp.Maui/Samples/FeatureFormViewSample.xaml
+++ b/src/Samples/Toolkit.SampleApp.Maui/Samples/FeatureFormViewSample.xaml
@@ -35,8 +35,8 @@
                                     <ColumnDefinition />
                                 </Grid.ColumnDefinitions>
                                 <Button Text="Close" Background="#007AC2" TextColor="White" Clicked="CloseButton_Click" Grid.Column="0" />
-                                <Button Text="Reset" Background="#D83020" TextColor="White" Clicked="DiscardButton_Click" Grid.Column="1" />
-                                <Button Text="Apply" Background="#35AC46" TextColor="White" Clicked="UpdateButton_Click" Grid.Column="2" />
+                                <Button Text="Reset" Background="#D83020" TextColor="White" Command="{Binding DiscardEditsCommand, Source={x:Reference formViewer}}" Grid.Column="1" />
+                                <Button Text="Apply" Background="#35AC46" TextColor="White" Command="{Binding FinishEditingCommand, Source={x:Reference formViewer}}"  Grid.Column="2" />
                             </Grid>
                         </Border>
                     </Grid>

--- a/src/Samples/Toolkit.SampleApp.Maui/Samples/FeatureFormViewSample.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.Maui/Samples/FeatureFormViewSample.xaml.cs
@@ -62,48 +62,10 @@ namespace Toolkit.SampleApp.Maui.Samples
             Debug.WriteLine("Attachment clicked: " + e.Attachment.Name);
         }
 
-        private async void DiscardButton_Click(object sender, EventArgs e)
-        {
-            var result = await DisplayAlert("Confirm", "Discard edits?", "Yes", "Cancel");
-            if (result)
-            {
-
-                ((Button)sender).IsEnabled = false;
-                try
-                {
-                    await formViewer.DiscardEditsAsync();
-                } catch { }
-
-                ((Button)sender).IsEnabled = true;
-            }
-        }
-
         private void CloseButton_Click(object sender, EventArgs e)
         {
             formViewer.FeatureForm = null;
             SidePanel.IsVisible = false;
-        }
-
-        private async void UpdateButton_Click(object sender, EventArgs e)
-        {
-            if (formViewer.FeatureForm == null) return;
-            if (!formViewer.IsValid)
-            {
-                var errorsMessages = formViewer.FeatureForm.Elements.OfType<FieldFormElement>().Where(e=>e.ValidationErrors.Any()).Select(s => s.FieldName + ": " + string.Join(",", s.ValidationErrors.Select(e=>e.Message)));
-                if (errorsMessages.Any())
-                {
-                    await DisplayAlert("Form has errors", string.Join("\n", errorsMessages), "OK");
-                    return;
-                }
-            }
-            try
-            {
-                await formViewer.FinishEditingAsync();
-            }
-            catch (Exception ex)
-            {
-                await DisplayAlert("Error", "Failed to apply edits:\n" + ex.Message, "OK");
-            }
         }
 
         private void FeatureFormViewSample_SizeChanged(object? sender, EventArgs e)

--- a/src/Samples/Toolkit.SampleApp.UWP/Samples/Forms/FeatureFormViewSample.xaml
+++ b/src/Samples/Toolkit.SampleApp.UWP/Samples/Forms/FeatureFormViewSample.xaml
@@ -38,8 +38,8 @@
                                 <ColumnDefinition />
                             </Grid.ColumnDefinitions>
                             <Button Content="Close" Background="#007AC2" Foreground="White" Padding="5" Click="CloseButton_Click" Grid.Column="0" HorizontalAlignment="Stretch" />
-                            <Button Content="Reset" Margin="5,0" Background="#D83020" Foreground="White" Padding="5" Click="DiscardButton_Click" Grid.Column="1" HorizontalAlignment="Stretch" />
-                            <Button Content="Apply" Background="#35AC46" Foreground="White" Padding="5" Click="UpdateButton_Click" Grid.Column="2" HorizontalAlignment="Stretch" />
+                            <Button Content="Reset" Margin="5,0" Background="#D83020" Foreground="White" Padding="5" Command="{x:Bind formViewer.DiscardEditsCommand}" Grid.Column="1" HorizontalAlignment="Stretch" />
+                            <Button Content="Apply" Background="#35AC46" Foreground="White" Padding="5" Command="{x:Bind formViewer.FinishEditingCommand}" Grid.Column="2" HorizontalAlignment="Stretch" />
                         </Grid>
                     </Border>
                 </Grid>

--- a/src/Samples/Toolkit.SampleApp.UWP/Samples/Forms/FeatureFormViewSample.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.UWP/Samples/Forms/FeatureFormViewSample.xaml.cs
@@ -58,72 +58,10 @@ namespace Esri.ArcGISRuntime.Toolkit.SampleApp.Samples.Forms
             return null;
         }
 
-        private async void DiscardButton_Click(object sender, RoutedEventArgs e)
-        {
-            ContentDialog dialog = new ContentDialog
-            {
-                Title = "Discard edits?",
-                Content = "Are you sure you want to discard edits?",
-                PrimaryButtonText = "Yes",
-                CloseButtonText = "No",
-#if !WINDOWS_UWP
-                XamlRoot = this.XamlRoot
-#endif
-            };
-            var result = await dialog.ShowAsync();
-            if (result == ContentDialogResult.Primary)
-            {
-                ((Button)sender).IsEnabled = false;
-                try
-                {
-                    await formViewer.DiscardEditsAsync();
-                }
-                catch { }
-                 ((Button)sender).IsEnabled = true;
-            }
-        }
-
         private void CloseButton_Click(object sender, RoutedEventArgs e)
         {
             formViewer.FeatureForm = null;
             SidePanel.Visibility = Visibility.Collapsed;
-        }
-
-        private async void UpdateButton_Click(object sender, RoutedEventArgs e)
-        {
-            if (!formViewer.IsValid)
-            {
-                var errorsMessages = formViewer.FeatureForm.Elements.OfType<FieldFormElement>().Where(e => e.ValidationErrors.Any()).Select(s => s.FieldName + ": " + string.Join(",", s.ValidationErrors.Select(e => e.Message)));
-                if (errorsMessages.Any())
-                {
-                    await new ContentDialog
-                    {
-                        Title = "Can't apply",
-                        Content = "Form has errors:\n" + string.Join("\n", errorsMessages),
-                        PrimaryButtonText = "OK",
-#if !WINDOWS_UWP
-                        XamlRoot = this.XamlRoot
-#endif
-                    }.ShowAsync();
-                    return;
-                }
-            }
-            try
-            {
-                await formViewer.FinishEditingAsync();
-            }
-            catch (Exception ex)
-            {
-                await new ContentDialog
-                {
-                    Title = "Error",
-                    Content = "Failed to apply edits:\n" + ex.Message,
-                    PrimaryButtonText = "OK",
-#if !WINDOWS_UWP
-                    XamlRoot = this.XamlRoot
-#endif
-                }.ShowAsync();
-            }
         }
     }
 }

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/Forms/FeatureFormViewSample.xaml
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/Forms/FeatureFormViewSample.xaml
@@ -35,8 +35,8 @@
                                 <ColumnDefinition />
                             </Grid.ColumnDefinitions>
                             <Button Content="Close" Background="#007AC2" Foreground="White" Padding="5" Click="CloseButton_Click" Grid.Column="0" />
-                            <Button Content="Reset" Margin="5,0" Background="#D83020" Foreground="White" Padding="5" Click="DiscardButton_Click" Grid.Column="1" />
-                            <Button Content="Apply" Background="#35AC46" Foreground="White" Padding="5" Click="UpdateButton_Click" Grid.Column="2" />
+                            <Button Content="Reset" Margin="5,0" Background="#D83020" Foreground="White" Padding="5" Command="{Binding DiscardEditsCommand, ElementName=formViewer}" Grid.Column="1" />
+                            <Button Content="Apply" Background="#35AC46" Foreground="White" Padding="5" Command="{Binding FinishEditingCommand, ElementName=formViewer}" Grid.Column="2" />
                         </Grid>
                     </Border>
                 </Grid>

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/Forms/FeatureFormViewSample.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/Forms/FeatureFormViewSample.xaml.cs
@@ -55,46 +55,10 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.Forms
             return null;
         }
 
-        private async void DiscardButton_Click(object sender, RoutedEventArgs e)
-        {
-            var result = MessageBox.Show("Discard edits?", "Confirm", MessageBoxButton.YesNo);
-            if (result == MessageBoxResult.Yes)
-            {
-                ((Button)sender).IsEnabled = false;
-                try
-                {
-                    await formViewer.DiscardEditsAsync();
-                }
-                catch { }
-                ((Button)sender).IsEnabled = true;
-            }
-        }
-
         private void CloseButton_Click(object sender, RoutedEventArgs e)
         {
             formViewer.FeatureForm = null;
             SidePanel.Visibility = Visibility.Collapsed;
-        }
-
-        private async void UpdateButton_Click(object sender, RoutedEventArgs e)
-        {
-            if (!formViewer.IsValid)
-            {
-                var errorsMessages = formViewer.FeatureForm.Elements.OfType<FieldFormElement>().Where(e => e.ValidationErrors.Any()).Select(s => s.FieldName + ": " + string.Join(",", s.ValidationErrors.Select(e => e.Message)));
-                if (errorsMessages.Any())
-                {
-                    MessageBox.Show("Form has errors:\n" + string.Join("\n", errorsMessages), "Can't apply");
-                    return;
-                }
-            }
-            try
-            {
-                await formViewer.FinishEditingAsync();
-            }
-            catch (Exception ex)
-            {
-                MessageBox.Show("Failed to apply edits:\n" + ex.Message, "Error");
-            }
         }
     }
 }

--- a/src/Toolkit/Toolkit/LocalizedStrings/Resources.resx
+++ b/src/Toolkit/Toolkit/LocalizedStrings/Resources.resx
@@ -545,7 +545,11 @@
     <value>Discard</value>
     <comment>The text on the Discard button of the unsaved-edits warning dialog</comment>
   </data>
-  <data name="FeatureFormPendingEditsMessage" xml:space="preserve">
+    <data name="FeatureFormApplyEditsErrorTitle" xml:space="preserve">
+    <value>Error</value>
+    <comment>The text on the dialog shown if saving edits to a feature form fails</comment>
+  </data>
+    <data name="FeatureFormPendingEditsMessage" xml:space="preserve">
     <value>You need to apply or discard edits of the current feature before moving to another feature. Do you want to apply the changes?</value>
     <comment>The content of the dialog when user is warned about unsaved edits</comment>
   </data>

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FeatureFormView.Maui.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FeatureFormView.Maui.cs
@@ -62,11 +62,6 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui
         private const string FeatureFormTitleStyleName = "FeatureFormTitleStyle";
         private const string FeatureFormCaptionStyleName = "FeatureFormCaptionStyle";
 
-        /// <summary>
-        /// Template name of the form's content's <see cref="ScrollView"/>.
-        /// </summary>
-        public const string FeatureFormContentScrollViewerName = "FeatureFormContentScrollViewer";
-
         static FeatureFormView()
         {
             DefaultControlTemplate = new ControlTemplate(BuildDefaultTemplate);
@@ -88,7 +83,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui
         private static object BuildDefaultTemplate()
         {
             NavigationSubView root = new NavigationSubView();
-            root.SetBinding(NavigationSubView.VerticalScrollBarVisibilityProperty, static (PopupViewer viewer) => viewer.VerticalScrollBarVisibility, source: RelativeBindingSource.TemplatedParent);
+            root.SetBinding(NavigationSubView.VerticalScrollBarVisibilityProperty, static (FeatureFormView viewer) => viewer.VerticalScrollBarVisibility, source: RelativeBindingSource.TemplatedParent);
             root.HeaderTemplateSelector = BuildHeaderTemplateSelector();
             root.ContentTemplateSelector = BuildContentTemplateSelector();
             INameScope nameScope = new NameScope();

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FeatureFormView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FeatureFormView.cs
@@ -743,7 +743,8 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         {
 #if MAUI
             var page = GetParent<Page>(this);
-            if(page is not null) {
+            if (page is not null)
+            {
                 await page.DisplayAlert(title, content, Properties.Resources.GetString("FeatureFormPendingEditsCancel")!);
             }
 #elif WINDOWS_XAML

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FeatureFormView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FeatureFormView.cs
@@ -138,24 +138,12 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             });
         }
 
-        public enum ShowErrorsVisibility
-        {
-            /// <summary>
-            /// Errors are shown when a field gets focus, or when the user tries to finish editing the form.
-            /// </summary>
-            Automatic,
-            /// <summary>
-            /// Validation errors are always shown, even if the user has not interacted with or edited the field.
-            /// </summary>
-            Always
-        }
-
         /// <summary>
         /// Gets or sets the associated PopupManager which contains popup and sketch editor.
         /// </summary>
-        public ShowErrorsVisibility ErrorsVisibility
+        public ValidationErrorVisibility ErrorsVisibility
         {
-            get { return (ShowErrorsVisibility)GetValue(ErrorsVisibilityProperty); }
+            get { return (ValidationErrorVisibility)GetValue(ErrorsVisibilityProperty); }
             set { SetValue(ErrorsVisibilityProperty, value); }
         }
 
@@ -163,9 +151,9 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         /// Identifies the <see cref="ErrorsVisibility"/> dependency property.
         /// </summary>
         public static readonly DependencyProperty ErrorsVisibilityProperty =
-            PropertyHelper.CreateProperty<ShowErrorsVisibility, FeatureFormView>(nameof(ErrorsVisibility), ShowErrorsVisibility.Always, (s, oldValue, newValue) => s.OnErrorsVisibilityChanged(oldValue, newValue));
+            PropertyHelper.CreateProperty<ValidationErrorVisibility, FeatureFormView>(nameof(ErrorsVisibility), ValidationErrorVisibility.Visible, (s, oldValue, newValue) => s.OnErrorsVisibilityChanged(oldValue, newValue));
 
-        private void OnErrorsVisibilityChanged(ShowErrorsVisibility oldValue, ShowErrorsVisibility newValue)
+        private void OnErrorsVisibilityChanged(ValidationErrorVisibility oldValue, ValidationErrorVisibility newValue)
         {
             foreach (var item in GetDescendentsOfType<FieldFormElementView>(this))
             {
@@ -314,7 +302,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
 
         internal bool ShouldShowError()
         {
-            return ErrorsVisibility == ShowErrorsVisibility.Always || _wasFinishEditingAttempted;
+            return ErrorsVisibility == ValidationErrorVisibility.Visible || _wasFinishEditingAttempted;
         }
 
         private IEnumerable<FieldFormElement> EnumerateVisibleElements(IEnumerable<FormElement>? elements)
@@ -816,5 +804,22 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         /// Gets the element that was clicked.
         /// </summary>
         public FieldFormElement FormElement { get; }
+    }
+
+    /// <summary>
+    /// Defines when validation errors should be shown in the <see cref="FeatureFormView"/>.
+    /// </summary>
+    /// <seealso cref="FeatureFormView.ErrorsVisibility"/>
+    public enum ValidationErrorVisibility
+    {
+        /// <summary>
+        /// All errors are visible for every editable element.
+        /// </summary>
+        Visible,
+
+        /// <summary>
+        /// All errors are hidden by default and made visible once an element has received interaction or the user attempts to finish editing.
+        /// </summary>
+        Automatic,
     }
 }

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FeatureFormView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FeatureFormView.cs
@@ -756,7 +756,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             dialog.XamlRoot = this.XamlRoot;
             var result = await dialog.ShowAsync();
 #elif WPF
-            MessageBox.Show(title, content);
+            MessageBox.Show(content, title);
 #endif
             }
 

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FieldFormElementView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FieldFormElementView.cs
@@ -179,15 +179,18 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
             if (GetTemplateChild("ErrorLabel") is TextBlock tb)
             {
                 tb.Text = errMessage ?? string.Empty;
+                bool showError = false;
+                if (!string.IsNullOrEmpty(errMessage) && (_hadFocus || FeatureFormView.GetFeatureFormViewParent(this)?.ShouldShowError() == true))
+                    showError = true;
 #if MAUI
-                tb.IsVisible = !string.IsNullOrEmpty(errMessage) && _hadFocus;
+                tb.IsVisible = showError;
 #else
-                tb.Visibility = !string.IsNullOrEmpty(errMessage) && _hadFocus ? Visibility.Visible : Visibility.Collapsed;
+                tb.Visibility = showError ? Visibility.Visible : Visibility.Collapsed;
 #endif
             }
         }
 
-        private bool _hadFocus = false;
+        private bool _hadFocus = false; // Tracks if the control has ever had focus, and will then show errors if FeatureFormView.ErrorsVisibility is set to "Automatic".
 
         internal void OnGotFocus()
         {

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/TextFormInputView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/TextFormInputView.cs
@@ -162,7 +162,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
 
         private void Apply()
         {
-            if (_textInput is null || _textInput.Text == Element?.Value as string) return;
+            if (Element?.IsEditable == false || _textInput is null || _textInput.Text == Element?.Value as string) return;
             string strvalue = _textInput.Text;
             object? value = strvalue;
             if (string.IsNullOrEmpty(strvalue))

--- a/src/Toolkit/Toolkit/UI/Controls/PopupViewer/NavigationSubView.Maui.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/PopupViewer/NavigationSubView.Maui.cs
@@ -61,6 +61,15 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
             nameScope.RegisterName("ScrollViewer", scrollview);
             return root;
         }
+
+        internal Task ScrollToAsync(Element element, ScrollToPosition position, bool animated)
+        {
+            if (GetTemplateChild("ScrollViewer") is ScrollView scrollView)
+            {
+                return scrollView.ScrollToAsync(element, position, animated);
+            }
+            return Task.CompletedTask;
+        }
     }
 }
 #endif


### PR DESCRIPTION
- New `FinishEditingCommand` and `DiscardEditsCommand` + Auto-scroll to first error on FinishEditing, and allow developer to perform similar scrolling when using custom validation workflows. This greatly reduces the amount of code the user have to write, while getting a good default editing experience.
- Adds ability to always show errors, or only show on finishediting/focus. Also fixes: https://github.com/Esri/arcgis-maps-sdk-dotnet-toolkit/issues/662
- Better handle apply errors when applying edits from a sub-featureform.