### PR TITLE
BugFix: Fix border (remove HasShadow) in UtilityNetworkTraceTool UI

### DIFF
--- a/src/Toolkit/Toolkit.Maui/UtilityNetworkTraceTool/UtilityNetworkTraceTool.Appearance.cs
+++ b/src/Toolkit/Toolkit.Maui/UtilityNetworkTraceTool/UtilityNetworkTraceTool.Appearance.cs
@@ -238,7 +238,7 @@ xmlns:esriTK=""clr-namespace:Esri.ArcGISRuntime.Toolkit.Maui;assembly=Esri.ArcGI
             </BindableLayout.ItemTemplate>
         </Grid>
     </Grid>
-    <Border x:Name=""{nameof(PART_ActivityIndicator)}"" IsVisible=""false"" Grid.RowSpan=""3"" VerticalOptions=""FillAndExpand"" HorizontalOptions=""FillAndExpand"" Background=""{backgroundColor}"" HasShadow=""False"" Stroke=""{backgroundColor}"">
+    <Border x:Name=""{nameof(PART_ActivityIndicator)}"" IsVisible=""false"" Grid.RowSpan=""3"" VerticalOptions=""FillAndExpand"" HorizontalOptions=""FillAndExpand"" Background=""{backgroundColor}"" Stroke=""{backgroundColor}"">
         <StackLayout Spacing=""8"" VerticalOptions=""Center"" HorizontalOptions=""CenterAndExpand"">
             <ActivityIndicator IsRunning=""True"" Color=""{{AppThemeBinding Light=#007AC2,Dark=#009AF2}}"" />
             <Button x:Name=""{nameof(PART_ButtonCancelActivity)}"" Text=""{cancel}"" />


### PR DESCRIPTION
Removes `HasShadow` from `Border` (recently updated from `Frame`) in `UtilityNetworkTraceTool` UI.

`Border` does not contain a `HasShadow` property, and the app throws an exception when creating the page. In release mode, this results in a silent error when adding the page to the navigation stack. This PR removes the `HasShadow` property, allowing the page to be created and added to the navigation stack.