### PR TITLE
Restoring a breaking change in `LoadTask`

### DIFF
--- a/src/Toolkit/Toolkit/UI/Controls/SearchView/LocatorSearchSource.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/SearchView/LocatorSearchSource.cs
@@ -77,7 +77,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         /// <summary>
         /// Gets the task used to perform initial locator setup.
         /// </summary>
-        protected Lazy<Task> LoadTask => _loadTask;
+        protected Task LoadTask => _loadTask.Value;
 
         private string _displayName = string.Empty;
         private bool _displayNameSetExternally = false;
@@ -239,7 +239,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         /// <inheritdoc/>
         public virtual async Task<IList<SearchSuggestion>> SuggestAsync(string queryString, CancellationToken cancellationToken = default)
         {
-            await LoadTask.Value;
+            await LoadTask;
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -256,7 +256,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         /// <inheritdoc/>
         public virtual async Task<IList<SearchResult>> SearchAsync(SearchSuggestion suggestion, CancellationToken cancellationToken = default)
         {
-            await LoadTask.Value;
+            await LoadTask;
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -270,7 +270,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         /// <inheritdoc/>
         public virtual async Task<IList<SearchResult>> SearchAsync(string queryString, CancellationToken cancellationToken = default)
         {
-            await LoadTask.Value;
+            await LoadTask;
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -288,7 +288,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         /// <inheritdoc />
         public virtual async Task<IList<SearchResult>> RepeatSearchAsync(string queryString, Envelope queryExtent, CancellationToken cancellationToken = default)
         {
-            await LoadTask.Value;
+            await LoadTask;
 
             cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Toolkit/Toolkit/UI/Controls/SearchView/WorldGeocoderSearchSource.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/SearchView/WorldGeocoderSearchSource.cs
@@ -122,7 +122,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         /// <inheritdoc />
         public override async Task<IList<SearchResult>> SearchAsync(SearchSuggestion suggestion, CancellationToken cancellationToken = default)
         {
-            await LoadTask.Value;
+            await LoadTask;
             cancellationToken.ThrowIfCancellationRequested();
 
             var tempParams = new GeocodeParameters();
@@ -149,7 +149,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         /// <inheritdoc/>
         public override async Task<IList<SearchSuggestion>> SuggestAsync(string queryString, CancellationToken cancellationToken = default)
         {
-            await LoadTask.Value;
+            await LoadTask;
             cancellationToken.ThrowIfCancellationRequested();
 
             SuggestParameters.PreferredSearchLocation = PreferredSearchLocation;
@@ -179,7 +179,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         /// <inheritdoc/>
         public override async Task<IList<SearchResult>> SearchAsync(string queryString, CancellationToken cancellationToken = default)
         {
-            await LoadTask.Value;
+            await LoadTask;
             cancellationToken.ThrowIfCancellationRequested();
 
             // Reset spatial parameters
@@ -212,7 +212,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         /// </summary>
         public override async Task<IList<SearchResult>> RepeatSearchAsync(string queryString, Geometry.Envelope queryArea, CancellationToken cancellationToken = default)
         {
-            await LoadTask.Value;
+            await LoadTask;
             cancellationToken.ThrowIfCancellationRequested();
 
             // Reset spatial parameters


### PR DESCRIPTION
Directly using the LoadTask instead of using Lazy loaded protected property.