### PR TITLE
Add Manual provisioning for iOS and Mac Catalyst

### DIFF
--- a/src/Samples/Toolkit.SampleApp.Maui/Toolkit.SampleApp.Maui.csproj
+++ b/src/Samples/Toolkit.SampleApp.Maui/Toolkit.SampleApp.Maui.csproj
@@ -30,7 +30,9 @@
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.0</TargetPlatformMinVersion>
   </PropertyGroup>
-
+  <PropertyGroup Condition="$(TargetFramework.Contains('-ios')) OR $(TargetFramework.Contains('-maccatalyst'))">
+    <ProvisioningType>manual</ProvisioningType>
+  </PropertyGroup>
   <ItemGroup>
     <Using Remove="Microsoft.Maui.ApplicationModel" />
     <!-- App Icon -->


### PR DESCRIPTION
This offers functionality similar to automatic provisioning.
With this enhancement, developers no longer need to manually configure provisioning settings for each build.
Instead, the system and Visual Studio automatically detect and apply the appropriate provisioning profile credentials.

