### PR TITLE
Added logic so that the error message and text box outline updates are displayed based on ErrorsVisibility

### DIFF
--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FieldFormElementView.Maui.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FieldFormElementView.Maui.cs
@@ -131,7 +131,16 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
             {
                 content.ContentTemplate = new FieldTemplateSelector(this);
             }
+            
+            // JH: If UpdateErrorMessages is called before the FieldFormElementView is Loaded it fails
+            Loaded += OnLoaded;
             UpdateErrorMessages();
+        }
+
+        private void OnLoaded(object? sender, EventArgs e)
+        {
+            UpdateErrorMessages();
+            Loaded -= OnLoaded;
         }
     }
 }

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FieldFormElementView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FieldFormElementView.cs
@@ -178,6 +178,9 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
             }
             if (GetTemplateChild("ErrorLabel") is TextBlock tb)
             {
+                // JH: If the control is not loaded yet, updating error message will fail.
+                if ( !IsLoaded ) return;
+                
                 tb.Text = errMessage ?? string.Empty;
                 bool showError = false;
                 if (!string.IsNullOrEmpty(errMessage) && (_hadFocus || FeatureFormView.GetFeatureFormViewParent(this)?.ShouldShowError() == true))

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/TextFormInputView.Maui.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/TextFormInputView.Maui.cs
@@ -119,6 +119,14 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
                 button.Clicked += BarcodeButton_Clicked;
             }
             ConfigureTextBox();
+            
+            //JH: Same issue as in FieldFormElement, the first time UpdateValidationState is called Element is null
+            Loaded += OnLoaded;
+            UpdateValidationState();
+        }
+
+        private void OnLoaded(object? sender, EventArgs e)
+        {
             UpdateValidationState();
         }
 

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/TextFormInputView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/TextFormInputView.cs
@@ -364,11 +364,15 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                 this.Dispatch(UpdateValidationState);
             }
         }
-
+        
         private void UpdateValidationState()
         {
             var err = Element?.ValidationErrors;
-            if (err != null && err.Any() && Element?.IsEditable == true && _hadFocus)
+
+            //JH: Add a check to see if the ErrorsVisibility is set to true, not only if _hadFocus is true
+            bool shouldShowError = (FeatureFormView.GetFeatureFormViewParent(this)?.ShouldShowError() ?? false) || _hadFocus;
+            
+            if (err != null && err.Any() && Element?.IsEditable == true && shouldShowError)
             {
 #if MAUI
                 if (GetTemplateChild("ErrorBorder") is Border border)


### PR DESCRIPTION
The FieldFormElementView and TextFormInputView call code to update based on if an error is found (missing Required data).  When this is initially the controls have not fully loaded and so the code to make these updates is not executed properly.

Code was added to tie in the Loaded event handler and when OnLoaded gets call the methods to update the view 
```
// FeatureFormInputView
protected override void OnApplyTemplate()
{
	base.OnApplyTemplate();
	/* Removed from bevity */
	ConfigureTextBox();
	
	//JH: Same issue as in FieldFormElement, the first time UpdateValidationState is called Element is null
	Loaded += OnLoaded;
	UpdateValidationState();
}
```


```
// FieldForElementView
protected override void OnApplyTemplate()
{
	base.OnApplyTemplate();
	if (GetTemplateChild(FieldInputName) is ContentControl content)
	{
		content.ContentTemplate = new FieldTemplateSelector(this);
	}
	
	// JH: If UpdateErrorMessages is called before the FieldFormElementView is Loaded it fails
	Loaded += OnLoaded;
	UpdateErrorMessages();
}

private void OnLoaded(object? sender, EventArgs e)
{
	UpdateErrorMessages();
	Loaded -= OnLoaded;
}
```

In UpdateValidationState where the TextInput border is set to red when the ErrorsVisibility="Visible" property is set


```
	private void UpdateValidationState()
	{
		var err = Element?.ValidationErrors;

		//JH: Add a check to see if the ErrorsVisibility is set to true, not only if _hadFocus is true
		bool shouldShowError = (FeatureFormView.GetFeatureFormViewParent(this)?.ShouldShowError() ?? false) || _hadFocus;
		
		if (err != null && err.Any() && Element?.IsEditable == true && shouldShowError)
		{
#if MAUI
  //replaced with above...    
     // if (err != null && err.Any() && Element?.IsEditable == true && _hadFocus)
```
