### PR TITLE
Remove SketchEditor dependency from MeasureToolbar

### DIFF
--- a/src/Samples/Toolkit.SampleApp.UWP/Samples/MeasureToolbar/MeasureToolbarSample.xaml
+++ b/src/Samples/Toolkit.SampleApp.UWP/Samples/MeasureToolbar/MeasureToolbarSample.xaml
@@ -1,7 +1,6 @@
 ﻿<Page x:Class="Esri.ArcGISRuntime.Toolkit.SampleApp.Samples.MeasureToolbar.MeasureToolbarSample"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-      xmlns:local="using:Esri.ArcGISRuntime.Toolkit.SampleApp.Samples.FeatureDataField"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:symbology="using:Esri.ArcGISRuntime.Symbology"

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/MeasureToolbar/MeasureToolbar.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/MeasureToolbar/MeasureToolbar.Theme.xaml
@@ -128,7 +128,7 @@
                                     ToolTip="Undo"
                                     Grid.Column="5"
                                     DataContext="{TemplateBinding MapView}"
-                                    Command="{Binding Path=SketchEditor.UndoCommand}"
+                                    Command="{Binding Path=GeometryEditor.UndoCommand}"
                                     FontSize="20"
                                     FontFamily="Wingdings 3"
                                     Content="Q" />
@@ -143,7 +143,7 @@
                                     ToolTip="Redo"
                                     Grid.Column="6"
                                     DataContext="{TemplateBinding MapView}"
-                                    Command="{Binding Path=SketchEditor.RedoCommand}"
+                                    Command="{Binding Path=GeometryEditor.RedoCommand}"
                                     FontSize="20"
                                     FontFamily="Wingdings 3"
                                     Content="P" />

--- a/src/Toolkit/Toolkit.WinUI/UI/Controls/MeasureToolbar/MeasureToolbar.Theme.xaml
+++ b/src/Toolkit/Toolkit.WinUI/UI/Controls/MeasureToolbar/MeasureToolbar.Theme.xaml
@@ -122,7 +122,7 @@
                                     ToolTipService.ToolTip="Undo"
                                     Grid.Column="5"
                                     DataContext="{TemplateBinding MapView}"
-                                    Command="{Binding Path=SketchEditor.UndoCommand}"
+                                    Command="{Binding Path=GeometryEditor.UndoCommand}"
                                     FontFamily="Segoe MDL2 Assets"
                                     Content="&#xE7A7;" />
                             <Button x:Name="Redo"
@@ -135,7 +135,7 @@
                                     ToolTipService.ToolTip="Redo"
                                     Grid.Column="6"
                                     DataContext="{TemplateBinding MapView}"
-                                    Command="{Binding Path=SketchEditor.RedoCommand}"
+                                    Command="{Binding Path=GeometryEditor.RedoCommand}"
                                     FontFamily="Segoe MDL2 Assets"
                                     Content="&#xE7A6;" />
                             <Button x:Name="Clear"


### PR DESCRIPTION
Replaced obsolete SketchEditor with the new GeometryEditor  in MeasureToolbar.