### PR TITLE
Bugfix: Adding converter to handle nullable bindings to boolean

### DIFF
--- a/src/Toolkit/Toolkit.Maui/Internal/BoolOrNullToBoolConverter.cs
+++ b/src/Toolkit/Toolkit.Maui/Internal/BoolOrNullToBoolConverter.cs
@@ -1,0 +1,36 @@
+﻿// /*******************************************************************************
+//  * Copyright 2012-2018 Esri
+//  *
+//  *  Licensed under the Apache License, Version 2.0 (the "License");
+//  *  you may not use this file except in compliance with the License.
+//  *  You may obtain a copy of the License at
+//  *
+//  *  http://www.apache.org/licenses/LICENSE-2.0
+//  *
+//  *   Unless required by applicable law or agreed to in writing, software
+//  *   distributed under the License is distributed on an "AS IS" BASIS,
+//  *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  *   See the License for the specific language governing permissions and
+//  *   limitations under the License.
+//  ******************************************************************************/
+
+
+namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
+{
+    internal class BoolOrNullToBoolConverter : IValueConverter
+    {
+        public static readonly BoolOrNullToBoolConverter Instance = new();
+
+        public object? Convert(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture)
+        {
+            if (value is bool b)
+                return b;
+            return false;
+        }
+
+        public object? ConvertBack(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture)
+        {
+            return value;
+        }
+    }
+}

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/AttachmentsFormElementView.Maui.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/AttachmentsFormElementView.Maui.cs
@@ -53,7 +53,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
         private static object BuildDefaultTemplate()
         {
             var root = new VerticalStackLayout();
-            root.SetBinding(VerticalStackLayout.IsVisibleProperty, static (AttachmentsFormElementView view) => view.Element?.IsVisible, source: RelativeBindingSource.TemplatedParent);
+            root.SetBinding(VerticalStackLayout.IsVisibleProperty, static (AttachmentsFormElementView view) => view.Element?.IsVisible, source: RelativeBindingSource.TemplatedParent, converter: BoolOrNullToBoolConverter.Instance);
 
             Grid header = new Grid();
             header.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Star));
@@ -89,7 +89,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
             
             Grid.SetColumn(addButton, 1);
             Grid.SetRowSpan(addButton, 2);
-            addButton.SetBinding(VisualElement.IsVisibleProperty, static (AttachmentsFormElementView view) => view.Element?.IsEditable, source: RelativeBindingSource.TemplatedParent);
+            addButton.SetBinding(VisualElement.IsVisibleProperty, static (AttachmentsFormElementView view) => view.Element?.IsEditable, source: RelativeBindingSource.TemplatedParent, converter: BoolOrNullToBoolConverter.Instance);
             header.Children.Add(addButton);
 
             root.Children.Add(header);

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/ComboboxFormInputView.Maui.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/ComboboxFormInputView.Maui.cs
@@ -21,7 +21,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
         private static object BuildDefaultTemplate()
         {
             Picker view = new Picker();
-            view.SetBinding(Picker.IsEnabledProperty, static (ComboBoxFormInputView view) => view.Element?.IsEditable, source: RelativeBindingSource.TemplatedParent);
+            view.SetBinding(Picker.IsEnabledProperty, static (ComboBoxFormInputView view) => view.Element?.IsEditable, source: RelativeBindingSource.TemplatedParent, converter: BoolOrNullToBoolConverter.Instance);
             view.ItemDisplayBinding = new Binding(nameof(CodedValue.Name));
             view.Focused += static (s, e) => FeatureFormView.GetParent<FieldFormElementView>(s as Element)?.OnGotFocus();
             INameScope nameScope = new NameScope();

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FieldFormElementView.Maui.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FieldFormElementView.Maui.cs
@@ -98,7 +98,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
         private static object BuildDefaultTemplate()
         {
             var root = new VerticalStackLayout();
-            root.SetBinding(VerticalStackLayout.IsVisibleProperty, static (FieldFormElementView view) => view.Element?.IsVisible);
+            root.SetBinding(VerticalStackLayout.IsVisibleProperty, static (FieldFormElementView view) => view.Element?.IsVisible, converter: BoolOrNullToBoolConverter.Instance);
             var label = new Label();
             label.SetBinding(Label.TextProperty, static (FieldFormElementView view) => view.Element?.Label, source: RelativeBindingSource.TemplatedParent);
             label.SetBinding(View.IsVisibleProperty, static (Label lbl) => lbl.Text, source: RelativeBindingSource.Self, converter: EmptyStringToBoolConverter.Instance);

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/TextFormInputView.Maui.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/TextFormInputView.Maui.cs
@@ -55,10 +55,10 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
             Entry textInput = new Entry();
             Grid.SetColumnSpan(textInput, 2);
             root.Add(textInput);
-            textInput.SetBinding(Entry.IsEnabledProperty, static (TextFormInputView view) => view.Element?.IsEditable, source: RelativeBindingSource.TemplatedParent);
+            textInput.SetBinding(Entry.IsEnabledProperty, static (TextFormInputView view) => view.Element?.IsEditable, source: RelativeBindingSource.TemplatedParent, converter: BoolOrNullToBoolConverter.Instance);
             Editor textArea = new Editor() { IsVisible = false, HeightRequest = 100, AutoSize = EditorAutoSizeOption.Disabled };
             Grid.SetColumnSpan(textArea, 2);
-            textArea.SetBinding(Editor.IsEnabledProperty, static (TextFormInputView view) => view.Element?.IsEditable, source: RelativeBindingSource.TemplatedParent);
+            textArea.SetBinding(Editor.IsEnabledProperty, static (TextFormInputView view) => view.Element?.IsEditable, source: RelativeBindingSource.TemplatedParent, converter: BoolOrNullToBoolConverter.Instance);
             root.Add(textArea);
             Label readonlyText = new Label() { IsVisible = false, LineBreakMode = LineBreakMode.WordWrap };
             readonlyText.SetBinding(Label.TextProperty, static (TextFormInputView view) => view.Element?.Value, source: RelativeBindingSource.TemplatedParent);


### PR DESCRIPTION
Introduce a Converter class to convert nullable values to Boolean.
This is required as part of a bug that is in MAUI Windows new static bindings.