### PR TITLE
Feature forms: Fix for MAUI windows bug where the DateTimePicker would enter an infinite loop

### DIFF
--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/DateTimePickerFormInputView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/DateTimePickerFormInputView.cs
@@ -100,7 +100,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                 // - the date has changed, or
                 // - the value has changed to/from null, or
                 // - the time has changed and IncludeTime is true
-                if (date != oldDate && (date == null || oldDate == null || date != oldDate.Value.Date || input.IncludeTime))
+                if (date != oldDate && (date == null || oldDate == null || date.Value.Date != oldDate.Value.Date || input.IncludeTime))
                 {
 #if MAUI
                     if (date != null && oldDate != null && oldDate.Value.AddSeconds(-oldDate.Value.Second).AddMilliseconds(-oldDate.Value.Millisecond) == date.Value)


### PR DESCRIPTION
Feature forms: Fix for MAUI windows bug where the DateTimePicker would enter an infinite loop

# Context
On Maui Windows feature forms sample, the app enters an infinite loop and becomes unresponsive when clicking any but the two specific features circled in green. Once either one of the green features is selected, all subsequent selected features will display feature forms properly.
<img width="518" height="380" alt="good_bad_spots" src="https://github.com/user-attachments/assets/aa32a22f-7c89-4656-a486-f89cabcea669" />

# Short Description
When creating a form with a date element, the `DateTimePickerFormInputView.TimePicker_PropertyChanged()` handler gets called an extra time for certain features. This starts an infinite loop where `DateTimePickerFormInputView.TimePicker_PropertyChanged()` begins to be called indefinitely. Why this extra call happens and why the infinite loop will only start during form creation is unclear. This fix this branch introduces ensures we compare dates alone unless selecting a time is enabled, which avoids the extra call.

# Long Description
It appears that when one of the offending points is clicked, `DateTimePickerFormInputView.UpdateValue()` gets called an extra time by way of `DateTimePickerFormInputView.TimePicker_PropertyChanged()` (the latter function is defined in `DateTimePickerFormInputView.Maui.cs`). Within the `UpdateValue()` function, the `Element.UpdateValue();` line  at the very end seems to be the issue. Notably it only seems to initiate an infinite loop on the first extra call: skipping the first execution of the line leads to the the form functioning as intended, even when the line is called again thanks to user interaction with the date picker.

In the first extra trigger to `DateTimePickerFormInputView.TimePicker_PropertyChanged()` (and on subsequent triggers), there is nothing in the call stack that I recognize as having an obvious cause from our toolkit code. There also do not seem to be any notable differences in data between the good and bad points from the sample.

In the first call to `Element.UpdateValue();`, the DatePicker and TimePicker have values identical to the original value from the `FieldFormElement`, but this was not recognized because the code was not accounting for the DatePicker date not including the time. This branch ensures that when comparing values we ignore time unless `IncludeTime` is true.

The following MAUI issue is probably related to the loop: https://github.com/dotnet/maui/issues/26415

# Testing
Tested using the sample app data

Tested on MAUI Windows and Android
