### PR TITLE
Update obsolete credential creation method in samples

### DIFF
--- a/src/Samples/Toolkit.SampleApp.Maui/Samples/UtilityNetworkTraceToolSample.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.Maui/Samples/UtilityNetworkTraceToolSample.xaml.cs
@@ -34,8 +34,8 @@ namespace Toolkit.SampleApp.Maui.Samples
             try
             {
                 // Using public credentials from https://developers.arcgis.com/javascript/latest/sample-code/widgets-untrace/
-                var preCredential = await AccessTokenCredential.CreateAsync(new Uri("https://sampleserver7.arcgisonline.com/portal/sharing/rest"), "viewer01", "I68VGU^nMurF");
-                AuthenticationManager.Current.AddCredential(preCredential);
+                var portal1Credential = await AccessTokenCredential.CreateAsync(new Uri("https://sampleserver7.arcgisonline.com/portal/sharing/rest"), "viewer01", "I68VGU^nMurF");
+                AuthenticationManager.Current.AddCredential(portal1Credential);
 
                 MyMapView.Map = new Map(new Uri(WebmapURL));
             }

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/UtilityNetworkTraceTool/UNTraceSimple.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/UtilityNetworkTraceTool/UNTraceSimple.xaml.cs
@@ -22,8 +22,8 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.UtilityNetworkTraceTool
             try
             {
                 // Using public credentials from https://developers.arcgis.com/javascript/latest/sample-code/widgets-untrace/
-                var preCredential = await AccessTokenCredential.CreateAsync(new Uri("https://sampleserver7.arcgisonline.com/portal/sharing/rest"), "viewer01", "I68VGU^nMurF");
-                AuthenticationManager.Current.AddCredential(preCredential);
+                var portal1Credential = await AccessTokenCredential.CreateAsync(new Uri("https://sampleserver7.arcgisonline.com/portal/sharing/rest"), "viewer01", "I68VGU^nMurF");
+                AuthenticationManager.Current.AddCredential(portal1Credential);
 
                 MyMapView.Map = new Map(new Uri(WebmapURL));
             }

--- a/src/Samples/Toolkit.SampleApp.WinUI/Samples/UtilityNetworkTraceTool/UtilityNetworkTraceToolSample.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.WinUI/Samples/UtilityNetworkTraceTool/UtilityNetworkTraceToolSample.xaml.cs
@@ -21,8 +21,8 @@ namespace Esri.ArcGISRuntime.Toolkit.SampleApp.Samples.UtilityNetworkTraceTool
             try
             {
                 // Using public credentials from https://developers.arcgis.com/javascript/latest/sample-code/widgets-untrace/
-                var preCredential = await AccessTokenCredential.CreateAsync(new Uri("https://sampleserver7.arcgisonline.com/portal/sharing/rest"), "viewer01", "I68VGU^nMurF");
-                AuthenticationManager.Current.AddCredential(preCredential);
+                var portal1Credential = await AccessTokenCredential.CreateAsync(new Uri("https://sampleserver7.arcgisonline.com/portal/sharing/rest"), "viewer01", "I68VGU^nMurF");
+                AuthenticationManager.Current.AddCredential(portal1Credential);
 
                 MyMapView.Map = new Map(new Uri(WebmapURL));
             }


### PR DESCRIPTION
`GenerateCredentialAsync` does not exists anymore in 300.0.0 release and broke the v.next build.