### PR TITLE
Ian/basemap item equality main

### DIFF
--- a/src/Samples/Toolkit.SampleApp.UWP/Samples/BasemapGallery/BasemapGalleryAppearanceSample.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.UWP/Samples/BasemapGallery/BasemapGalleryAppearanceSample.xaml.cs
@@ -51,7 +51,7 @@ namespace Esri.ArcGISRuntime.Toolkit.SampleApp.Samples.BasemapGallery
         {
             if (Gallery.AvailableBasemaps.Any())
             {
-                Gallery.AvailableBasemaps.Remove(Gallery.AvailableBasemaps.Last());
+                Gallery.AvailableBasemaps.RemoveAt(Gallery.AvailableBasemaps.Count - 1);
             }
         }
     }

--- a/src/Samples/Toolkit.SampleApp.UWP/Samples/BasemapGallery/BasemapGalleryBehaviorSample.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.UWP/Samples/BasemapGallery/BasemapGalleryBehaviorSample.xaml.cs
@@ -96,7 +96,7 @@ namespace Esri.ArcGISRuntime.Toolkit.SampleApp.Samples.BasemapGallery
         {
             if (Gallery.AvailableBasemaps.Any())
             {
-                Gallery.AvailableBasemaps.Remove(Gallery.AvailableBasemaps.Last());
+                Gallery.AvailableBasemaps.RemoveAt(Gallery.AvailableBasemaps.Count - 1);
             }
         }
 

--- a/src/Samples/Toolkit.SampleApp.UWP/Samples/BasemapGallery/BasemapGallerySceneViewAppearanceSample.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.UWP/Samples/BasemapGallery/BasemapGallerySceneViewAppearanceSample.xaml.cs
@@ -51,7 +51,7 @@ namespace Esri.ArcGISRuntime.Toolkit.SampleApp.Samples.BasemapGallery
         {
             if (Gallery.AvailableBasemaps.Any())
             {
-                Gallery.AvailableBasemaps.Remove(Gallery.AvailableBasemaps.Last());
+                Gallery.AvailableBasemaps.RemoveAt(Gallery.AvailableBasemaps.Count - 1);
             }
         }
     }

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/BasemapGallery/BasemapGalleryAppearanceSample.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/BasemapGallery/BasemapGalleryAppearanceSample.xaml.cs
@@ -53,7 +53,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.BasemapGallery
         {
             if (Gallery.AvailableBasemaps.Any())
             {
-                Gallery.AvailableBasemaps.Remove(Gallery.AvailableBasemaps.Last());
+                Gallery.AvailableBasemaps.RemoveAt(Gallery.AvailableBasemaps.Count - 1);
             }
         }
     }

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/BasemapGallery/BasemapGalleryBehaviorSample.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/BasemapGallery/BasemapGalleryBehaviorSample.xaml.cs
@@ -126,7 +126,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.BasemapGallery
         {
             if (Gallery.AvailableBasemaps.Any())
             {
-                Gallery.AvailableBasemaps.Remove(Gallery.AvailableBasemaps.Last());
+                Gallery.AvailableBasemaps.RemoveAt(Gallery.AvailableBasemaps.Count - 1);
             }
         }
 

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/BasemapGallery/BasemapGallerySceneViewAppearanceSample.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/BasemapGallery/BasemapGallerySceneViewAppearanceSample.xaml.cs
@@ -53,7 +53,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.BasemapGallery
         {
             if (Gallery.AvailableBasemaps.Any())
             {
-                Gallery.AvailableBasemaps.Remove(Gallery.AvailableBasemaps.Last());
+                Gallery.AvailableBasemaps.RemoveAt(Gallery.AvailableBasemaps.Count - 1);
             }
         }
     }

--- a/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryItem.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryItem.cs
@@ -322,14 +322,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
         /// <inheritdoc />
         public override int GetHashCode()
         {
-            unchecked
-            {
-                int hashCode = 17;
-                hashCode = 397 * (hashCode ^ (Name?.GetHashCode() ?? 0));
-                hashCode = 397 * (hashCode ^ (Tooltip?.GetHashCode() ?? 0));
-                hashCode = 397 * (hashCode ^ (Thumbnail?.GetHashCode() ?? 0));
-                return hashCode;
-            }
+            return Basemap?.Name?.GetHashCode() ?? -1;
         }
 
         /// <summary>

--- a/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryItem.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryItem.cs
@@ -242,7 +242,9 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
                 return false;
             }
 
-            return EqualsBasemap(other.Basemap);
+            return Name == other.Name && Tooltip == other.Tooltip
+                                      && Thumbnail == other.Thumbnail
+                                      && EqualsBasemap(other.Basemap);
         }
 
         /// <summary>

--- a/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryItem.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryItem.cs
@@ -322,7 +322,14 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
         /// <inheritdoc />
         public override int GetHashCode()
         {
-            return Basemap?.Name?.GetHashCode() ?? -1;
+            unchecked
+            {
+                int hashCode = 17;
+                hashCode = 397 * (hashCode ^ (Name?.GetHashCode() ?? 0));
+                hashCode = 397 * (hashCode ^ (Tooltip?.GetHashCode() ?? 0));
+                hashCode = 397 * (hashCode ^ (Thumbnail?.GetHashCode() ?? 0));
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryItem.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryItem.cs
@@ -242,9 +242,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
                 return false;
             }
 
-            return Name == other.Name && Tooltip == other.Tooltip
-                                      && Thumbnail == other.Thumbnail
-                                      && EqualsBasemap(other.Basemap);
+            return EqualsBasemap(other.Basemap);
         }
 
         /// <summary>


### PR DESCRIPTION
The basemap gallery samples demonstrate adding and removing example BasemapItems (for example here: https://github.com/Esri/arcgis-maps-sdk-dotnet-toolkit/blob/main/src/Samples/Toolkit.SampleApp.WPF/Samples/BasemapGallery/BasemapGalleryAppearanceSample.xaml.cs#L39-L58). The remove button claims to drop the "last" item in the gallery, but that is not actually what happens when the basemaps from the "add" button were involved. It turns out `BasemapItem.Equals()` currently only compares the items' `Basemap`s against each other, and ignores `.Name`, `.Tooltip`, and `.Thumbnail`. This meant the two items added by the "add" button were considered equal, so when `Gallery.AvailableBasemaps.Remove(Gallery.AvailableBasemaps.Last());` was called the first of the added items was being removed, not the actual last item.

This pull request updates the `.Equals()` function to add the metadata properties. It also changes the samples to explicitly remove the last item since even with this fix clicking the "add" button multiple times will still add items the new `.Equals()` function considers equal.