### PR TITLE
Maui: Fix excess Search View events

### DIFF
--- a/src/Toolkit/Toolkit.Maui/SearchView/SearchView.cs
+++ b/src/Toolkit/Toolkit.Maui/SearchView/SearchView.cs
@@ -667,7 +667,6 @@ public partial class SearchView : TemplatedView, INotifyPropertyChanged
 
         if (SearchViewModel?.SelectedResult is SearchResult selectedResult)
         {
-            PART_ResultView?.SetValue(CollectionView.SelectedItemProperty, selectedResult);
             _resultOverlay?.Graphics.Clear();
             AddResultToGeoView(selectedResult);
 


### PR DESCRIPTION
Maui was raising 3 events any time a suggestion was selected. It was caused by a loop where the `HandleSelectedResultChanged()` function would update the `PART_ResultsView` selection which would trigger a listener to update the view model's `SelectedResult` again.

The current fix is just to remove the line where the `PART_ResultsView` selection gets updated as we immediately set it back to null* whenever a selection is made anyway.

*Or rather we attempt to. I assume the point of doing this is so that results can be selected more than once so that users can zoom back to the current result if they panned away. That doesn't work anyway, but why it doesn't work seems to be related to some Maui plumbing eccentricities and would require extra investigation