### PR TITLE
Allow Android PopupViewer to open web links without intent configuration

### DIFF
--- a/src/Samples/Toolkit.SampleApp.Maui/Platforms/Android/AndroidManifest.xml
+++ b/src/Samples/Toolkit.SampleApp.Maui/Platforms/Android/AndroidManifest.xml
@@ -8,13 +8,5 @@
         <intent>
             <action android:name="android.media.action.IMAGE_CAPTURE" />
         </intent>
-        <intent>
-          <action android:name="android.intent.action.VIEW" />
-          <data android:scheme="http"/>
-        </intent>
-        <intent>
-          <action android:name="android.intent.action.VIEW" />
-          <data android:scheme="https"/>
-        </intent>
     </queries>
 </manifest>

--- a/src/Toolkit/Toolkit/Internal/Launcher.cs
+++ b/src/Toolkit/Toolkit/Internal/Launcher.cs
@@ -22,7 +22,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Internal
             process.StartInfo.UseShellExecute = true;
             return Task.FromResult(process.Start());
 #elif MAUI
-            return Microsoft.Maui.ApplicationModel.Launcher.Default.TryOpenAsync(uri);
+            return Microsoft.Maui.ApplicationModel.Launcher.Default.OpenAsync(uri);
 #endif
         }
     }

--- a/src/Toolkit/Toolkit/Internal/Launcher.cs
+++ b/src/Toolkit/Toolkit/Internal/Launcher.cs
@@ -22,7 +22,11 @@ namespace Esri.ArcGISRuntime.Toolkit.Internal
             process.StartInfo.UseShellExecute = true;
             return Task.FromResult(process.Start());
 #elif MAUI
-            return Microsoft.Maui.ApplicationModel.Launcher.Default.OpenAsync(uri);
+            try
+            {
+                return Microsoft.Maui.ApplicationModel.Launcher.Default.OpenAsync(uri);
+            }
+            catch { }
 #endif
         }
     }

--- a/src/Toolkit/Toolkit/Internal/Launcher.cs
+++ b/src/Toolkit/Toolkit/Internal/Launcher.cs
@@ -26,7 +26,10 @@ namespace Esri.ArcGISRuntime.Toolkit.Internal
             {
                 return Microsoft.Maui.ApplicationModel.Launcher.Default.OpenAsync(uri);
             }
-            catch { }
+            catch
+            {
+                return Task.FromResult<bool>(false);
+            }
 #endif
         }
     }


### PR DESCRIPTION
Follow up on #730 after more discussion with Matvei. Changing what Launcher function we use lets us open links on Android without needing to explicitly configure intents in the samples app.