### PR TITLE
Bugfix: Refactor MAUI platform checks for editable state update

### DIFF
--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/SwitchFormInputView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/SwitchFormInputView.cs
@@ -80,8 +80,11 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                 inpcNew.PropertyChanged += _elementPropertyChangedListener.OnEvent;
             }
             UpdateCheckState();
-#if MAUI && WINDOWS
+#if MAUI
+            UpdateEditableState();
+#if WINDOWS
             UpdateOnOffContent();
+#endif
 #endif
         }
 


### PR DESCRIPTION
Update SwitchFormInputView to always call `UpdateEditableState()` on all MAUI platforms.


https://github.com/user-attachments/assets/a9743a8c-00dd-4eac-94e1-1591a3a431a4

