### PR TITLE
Bugfix: WinUI - Use TwoWay binding for ToggleSwitch IsOn in SwitchFormInputView template

### DIFF
--- a/src/Toolkit/Toolkit.WinUI/UI/Controls/FeatureForm/FeatureForm.Theme.xaml
+++ b/src/Toolkit/Toolkit.WinUI/UI/Controls/FeatureForm/FeatureForm.Theme.xaml
@@ -49,7 +49,7 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="primitives:SwitchFormInputView">
-                    <ToggleSwitch IsOn="{TemplateBinding IsChecked}" OnContent="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Element.Input.OnValue.Name}" OffContent="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Element.Input.OffValue.Name}" IsEnabled="{TemplateBinding IsEnabled}" />
+                    <ToggleSwitch IsOn="{Binding IsChecked, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}" OnContent="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Element.Input.OnValue.Name}" OffContent="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Element.Input.OffValue.Name}" IsEnabled="{TemplateBinding IsEnabled}" />
                 </ControlTemplate>
             </Setter.Value>
         </Setter>


### PR DESCRIPTION
In WinUI, the `ToggleSwitch` inside the `SwitchFormInputView` control template used `TemplateBinding` for its `IsOn` property.
Unlike WPF, WinUI TemplateBinding is OneWay, so user interaction with the toggle did not propagate changes back to the IsChecked dependency property.

Before: 

https://github.com/user-attachments/assets/a7375630-0ccb-483d-be69-f87bf29d96a5

After:

https://github.com/user-attachments/assets/d7858061-4bd7-4d3f-b245-b5bded9a6567

