### PR TITLE
Handle nullable DatePicker.Date for .NET 10 compatibility

### DIFF
--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/DateTimePickerFormInputView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/DateTimePickerFormInputView.cs
@@ -63,14 +63,14 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
 #elif IOS || ANDROID
                 if (_datePicker.Handler?.PlatformView is not Microsoft.Maui.Platform.MauiDatePicker nativePicker || !String.IsNullOrEmpty(nativePicker.Text))
                 {
-                    // Date property is nullable in .NET 10 - this code works with both .net9 and .net10
+                    // Date property is nullable in .NET 10 - this code works with both .NET 9 and .NET 10
                     var d = (DateTime?)_datePicker.Date;
                     date = d?.ToUniversalTime();
                 }
 #elif MACCATALYST
                 if (_hasValueSwitch?.IsToggled != false)
                 {
-                    // Date property is nullable in .NET 10 - this code works with both .net9 and .net10
+                    // Date property is nullable in .NET 10 - this code works with both .NET 9 and .NET 10
                     var d = (DateTime?)_datePicker.Date;
                     date = d?.ToUniversalTime();
                 }

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/DateTimePickerFormInputView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/DateTimePickerFormInputView.cs
@@ -63,12 +63,16 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
 #elif IOS || ANDROID
                 if (_datePicker.Handler?.PlatformView is not Microsoft.Maui.Platform.MauiDatePicker nativePicker || !String.IsNullOrEmpty(nativePicker.Text))
                 {
-                    date = _datePicker.Date.ToUniversalTime();
+                    // Date property is nullable in .NET 10 - this code works with both .net9 and .net10
+                    var d = (DateTime?)_datePicker.Date;
+                    date = d?.ToUniversalTime();
                 }
 #elif MACCATALYST
                 if (_hasValueSwitch?.IsToggled != false)
                 {
-                    date = _datePicker.Date.ToUniversalTime();
+                    // Date property is nullable in .NET 10 - this code works with both .net9 and .net10
+                    var d = (DateTime?)_datePicker.Date;
+                    date = d?.ToUniversalTime();
                 }
 #endif
 #elif WINDOWS_XAML

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/DateTimePickerFormInputView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/DateTimePickerFormInputView.cs
@@ -64,15 +64,13 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                 if (_datePicker.Handler?.PlatformView is not Microsoft.Maui.Platform.MauiDatePicker nativePicker || !String.IsNullOrEmpty(nativePicker.Text))
                 {
                     // Date property is nullable in .NET 10 - this code works with both .NET 9 and .NET 10
-                    var d = (DateTime?)_datePicker.Date;
-                    date = d?.ToUniversalTime();
+                    date = (DateTime?)_datePicker.Date?.ToUniversalTime();
                 }
 #elif MACCATALYST
                 if (_hasValueSwitch?.IsToggled != false)
                 {
                     // Date property is nullable in .NET 10 - this code works with both .NET 9 and .NET 10
-                    var d = (DateTime?)_datePicker.Date;
-                    date = d?.ToUniversalTime();
+                    date = (DateTime?)_datePicker.Date?.ToUniversalTime();
                 }
 #endif
 #elif WINDOWS_XAML


### PR DESCRIPTION
Issue: The feature form with a date picker does not load in in .net 10

In .NET 10, DatePicker.Date is nullable. Casted to DateTime? before converting to UTC to safely handle null values and keep the code compatible with both .NET 9 and .NET 10.

Workaround for breaking change introduced in https://github.com/dotnet/maui/pull/27921