### PR TITLE
FeatureForm .net10 fix

### DIFF
--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/DateTimePickerFormInputView.Maui.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/DateTimePickerFormInputView.Maui.cs
@@ -6,6 +6,7 @@ using Microsoft.Maui;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Platform;
 using System.ComponentModel;
+using System.Runtime.CompilerServices;
 
 namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
 {
@@ -152,6 +153,56 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
         }
 
         private void DatePicker_DateSelected(object? sender, DateChangedEventArgs e) => UpdateValue();
+
+
+#if MAUI && !NET10_0_OR_GREATER // Work around for breaking change in .NET MAUI 10.0
+        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_MinimumDate")]
+        extern static void SetMinimumDate(DatePicker p, DateTime? value);
+        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_MaximumDate")]
+        extern static void SetMaximumDate(DatePicker p, DateTime? value);
+        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_Date")]
+        extern static void SetDate(DatePicker p, DateTime? value);
+        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "get_Date")]
+        extern static DateTime? GetDate(DatePicker p);
+        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_Time")]
+        extern static void SetTime(TimePicker p, TimeSpan? value);
+        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "get_Time")]
+        extern static TimeSpan? GetTime(TimePicker p);
+
+        private static void SetMinMaxDate_Net9(DatePicker _datePicker, DateTime? minValue, DateTime? maxValue)
+        {
+            _datePicker.MinimumDate = minValue?.ToLocalTime().Date ?? DateTime.MinValue;
+            _datePicker.MaximumDate = maxValue?.ToLocalTime().Date ?? DateTime.MaxValue;
+        }
+        private static void SetMinMaxDate_Net10(DatePicker _datePicker, DateTime? minValue, DateTime? maxValue)
+        {
+            SetMinimumDate(_datePicker, minValue?.ToLocalTime().Date);
+            SetMaximumDate(_datePicker, maxValue?.ToLocalTime().Date);
+        }
+        private static void SetDate_Net9(DatePicker datePicker, DateTime value) => datePicker.Date = value;
+        private static void SetDate_Net10(DatePicker datePicker, DateTime? value) => SetDate(datePicker, value);
+        private static DateTime? GetDateMAUI(DatePicker datePicker)
+        {
+            if (Environment.Version.Major < 10)
+                return GetDate_Net9(datePicker);
+            else
+                return GetDate_Net10(datePicker);
+        }
+        private static DateTime? GetDate_Net9(DatePicker datePicker) => datePicker.Date;
+        private static DateTime? GetDate_Net10(DatePicker datePicker) => GetDate(datePicker);
+        private static void SetTime_Net9(TimePicker timePicker, TimeSpan value) => timePicker.Time = value;
+        private static void SetTime_Net10(TimePicker timePicker, TimeSpan? value) => SetTime(timePicker, value);
+        private static TimeSpan? GetTimeMAUI(TimePicker timePicker)
+        {
+            if (Environment.Version.Major < 10)
+                return GetTime_Net9(timePicker);
+            else
+                return GetTime_Net10(timePicker);
+        }
+        private static TimeSpan? GetTime_Net9(TimePicker timePicker) => timePicker.Time;
+        private static TimeSpan? GetTime_Net10(TimePicker timePicker) => GetTime(timePicker);
+#endif
+
     }
 }
 #endif

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/DateTimePickerFormInputView.Maui.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/DateTimePickerFormInputView.Maui.cs
@@ -176,8 +176,13 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
         }
         private static void SetMinMaxDate_Net10(DatePicker _datePicker, DateTime? minValue, DateTime? maxValue)
         {
+#if WINDOWS
+            SetMinimumDate(_datePicker, minValue?.ToLocalTime().Date ?? DateTime.MinValue);
+            SetMaximumDate(_datePicker, maxValue?.ToLocalTime().Date ?? DateTime.MaxValue);
+#else
             SetMinimumDate(_datePicker, minValue?.ToLocalTime().Date);
             SetMaximumDate(_datePicker, maxValue?.ToLocalTime().Date);
+#endif
         }
         private static void SetDate_Net9(DatePicker datePicker, DateTime value) => datePicker.Date = value;
         private static void SetDate_Net10(DatePicker datePicker, DateTime? value) => SetDate(datePicker, value);
@@ -203,6 +208,6 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
         private static TimeSpan? GetTime_Net10(TimePicker timePicker) => GetTime(timePicker);
 #endif
 
+        }
     }
-}
 #endif

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/DateTimePickerFormInputView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/DateTimePickerFormInputView.cs
@@ -63,14 +63,12 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
 #elif IOS || ANDROID
                 if (_datePicker.Handler?.PlatformView is not Microsoft.Maui.Platform.MauiDatePicker nativePicker || !String.IsNullOrEmpty(nativePicker.Text))
                 {
-                    // Date property is nullable in .NET 10 - this code works with both .NET 9 and .NET 10
-                    date = ((DateTime?)_datePicker.Date)?.ToUniversalTime();
+                    date = GetDateMAUI(_datePicker)?.ToUniversalTime();
                 }
 #elif MACCATALYST
                 if (_hasValueSwitch?.IsToggled != false)
                 {
-                    // Date property is nullable in .NET 10 - this code works with both .NET 9 and .NET 10
-                    date = ((DateTime?)_datePicker.Date)?.ToUniversalTime();
+                    date = GetDateMAUI(_datePicker)?.ToUniversalTime();
                 }
 #endif
 #elif WINDOWS_XAML
@@ -80,7 +78,12 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
 #else
                 date = _datePicker.SelectedDate?.ToUniversalTime();
 #endif
-                if (date is DateTime newDate && input.IncludeTime && _timePicker?.Time is TimeSpan time
+#if MAUI
+                TimeSpan? timePicked = GetTimeMAUI(_timePicker);
+#else
+                TimeSpan? timePicked = _timePicker?.Time;
+#endif
+                if (date is DateTime newDate && input.IncludeTime && timePicked is TimeSpan time
 #if WINDOWS_XAML
                     && time.Ticks != -1 // TimePicker.SelectedTime is Ticks=-1 when the time is empty
 #endif
@@ -180,12 +183,22 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                 {
 #if MAUI
                     // Min/Max are always converted to local time
-                    _datePicker.MinimumDate = input.Min?.ToLocalTime().Date ?? DateTime.MinValue;
-                    _datePicker.MaximumDate = input.Max?.ToLocalTime().Date ?? DateTime.MaxValue;
+                    if (Environment.Version.Major < 10)
+                    {
+                        SetMinMaxDate_Net9(_datePicker, input.Min, input.Max);
+                    }
+                    else
+                    {
+                        SetMinMaxDate_Net10(_datePicker, input.Min, input.Max);
+                    }
+
 #if WINDOWS
                     if (selectedDate is DateTime date)
                     {
-                        _datePicker.Date = selectedDate.Value;
+                        if (Environment.Version.Major < 10)
+                            SetDate_Net9(_datePicker, selectedDate.Value);
+                        else
+                            SetDate_Net10(_datePicker, selectedDate);
                     }
                     else if (_datePicker.Handler?.PlatformView is Microsoft.UI.Xaml.Controls.CalendarDatePicker winPicker)
                     {
@@ -194,7 +207,10 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
 #elif IOS || ANDROID
                     if (selectedDate is DateTime date)
                     {
-                        _datePicker.Date = date;
+                        if (Environment.Version.Major < 10)
+                            SetDate_Net9(_datePicker, date);
+                        else
+                            SetDate_Net10(_datePicker, date);
                     }
                     else if (_datePicker.Handler?.PlatformView is Microsoft.Maui.Platform.MauiDatePicker nativePicker)
                     {
@@ -203,7 +219,10 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
 #elif MACCATALYST
                     if (selectedDate is DateTime date)
                     {
-                        _datePicker.Date = date;
+                        if (Environment.Version.Major < 10)
+                            SetDate_Net9(_datePicker, date);
+                        else
+                            SetDate(_datePicker, date);
                     }
                     if (_hasValueSwitch != null)
                     {
@@ -225,7 +244,10 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                 {
 #if MAUI
                     _timePicker.IsVisible = input.IncludeTime;
-                    _timePicker.Time = selectedDate?.TimeOfDay ?? TimeSpan.Zero;
+                    if (Environment.Version.Major < 10)
+                        SetTime_Net9(_timePicker, selectedDate?.TimeOfDay ?? TimeSpan.Zero);
+                    else
+                        SetTime_Net10(_timePicker, selectedDate?.TimeOfDay);
 #else
                     _timePicker.Visibility = input.IncludeTime ? Visibility.Visible : Visibility.Collapsed;
 #if WINDOWS_XAML

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FeatureFormElementTemplateSelector.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FeatureFormElementTemplateSelector.cs
@@ -40,7 +40,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui
             {
                 var view = new FieldFormElementView() { Margin = new Thickness(0, 0, 0, 10) };
                 view.SetBinding(FieldFormElementView.ElementProperty, Binding.SelfPath);
-                view.SetBinding(FieldFormElementView.FeatureFormProperty, static (FeatureFormView view) => view.FeatureForm, source: new RelativeBindingSource(RelativeBindingSourceMode.FindAncestor, typeof(FeatureFormView)));
+                view.SetBinding(FieldFormElementView.FeatureFormProperty, static (FeatureFormView? view) => view?.FeatureForm, source: new RelativeBindingSource(RelativeBindingSourceMode.FindAncestor, typeof(FeatureFormView)));
                 return view;
             });
             DefaultGroupElementTemplate = new DataTemplate(() =>


### PR DESCRIPTION
DatePicker and TimePicker changed their properties [to be nullable in .NET MAUI](https://github.com/Esri/arcgis-maps-sdk-dotnet-toolkit/pull/738), which is a breaking binary change.
This is a workaround that avoids the MissingMethodExceptions this change cause.