### PR TITLE
Update CommunityToolkit.Maui version in Maui Samples

### DIFF
--- a/src/Samples/Toolkit.SampleApp.Maui/Toolkit.SampleApp.Maui.csproj
+++ b/src/Samples/Toolkit.SampleApp.Maui/Toolkit.SampleApp.Maui.csproj
@@ -61,7 +61,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.Maui" Version="7.0.0" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
   </ItemGroup>
 

--- a/src/Samples/Toolkit.SampleApp.Maui/Toolkit.SampleApp.Maui.csproj
+++ b/src/Samples/Toolkit.SampleApp.Maui/Toolkit.SampleApp.Maui.csproj
@@ -61,6 +61,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="CommunityToolkit.Maui" Version="14.1.0" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
   </ItemGroup>
 

--- a/src/Samples/Toolkit.SampleApp.Maui/Toolkit.SampleApp.Maui.csproj
+++ b/src/Samples/Toolkit.SampleApp.Maui/Toolkit.SampleApp.Maui.csproj
@@ -61,7 +61,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.Maui" Version="14.1.0" />
+    <PackageReference Include="CommunityToolkit.Maui" Version="14.0.0" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
   </ItemGroup>
 


### PR DESCRIPTION
When debugging the Maui samples on Windows an unhandled error is thrown that crashes the app. This did not happen in release mode, but does interrupt debugging.

```
System.TypeLoadException
  HResult=0x80131522
  Message=Method 'OnParentResourcesChanged' on type 'CommunityToolkit.Maui.Views.Popup' from assembly 'CommunityToolkit.Maui, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null' is overriding a method that is not visible from that assembly.
  Source=CommunityToolkit.Maui
  StackTrace:
   at CommunityToolkit.Maui.AppBuilderExtensions.UseMauiCommunityToolkit(MauiAppBuilder builder, Action`1 options)
   at CommunityToolkit.Maui.AppBuilderExtensions.UseMauiCommunityToolkit(MauiAppBuilder builder, Action`1 options)
   at Toolkit.SampleApp.Maui.MauiProgram.CreateMauiApp() in C:\Repos\arcgis-maps-sdk-dotnet-toolkit\src\Samples\Toolkit.SampleApp.Maui\MauiProgram.cs:line 13
   at Toolkit.SampleApp.Maui.WinUI.App.CreateMauiApp() in C:\Repos\arcgis-maps-sdk-dotnet-toolkit\src\Samples\Toolkit.SampleApp.Maui\Platforms\Windows\App.xaml.cs:line 22
   at Microsoft.Maui.MauiWinUIApplication.OnLaunched(LaunchActivatedEventArgs args)
   at Microsoft.UI.Xaml.Application.Microsoft.UI.Xaml.IApplicationOverrides.OnLaunched(LaunchActivatedEventArgs args)
   at ABI.Microsoft.UI.Xaml.IApplicationOverrides.Do_Abi_OnLaunched_0(IntPtr thisPtr, IntPtr args)
```
Upgrading CommunityToolkit.Maui to 14.0 resolves the problem.