### PR TITLE
[WinUI] Fix for suggestions not showing when multiple geocoders are connected

### DIFF
--- a/src/Toolkit/Toolkit.WinUI/UI/Controls/SearchView/SearchView.Theme.xaml
+++ b/src/Toolkit/Toolkit.WinUI/UI/Controls/SearchView/SearchView.Theme.xaml
@@ -550,7 +550,7 @@
                     <CollectionViewSource
                         x:Key="GroupedSuggestionsEx"
                         IsSourceGrouped="True"
-                        Source="{TemplateBinding GroupedSuggestions}" />
+                        Source="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=GroupedSuggestions, Mode=TwoWay}" />
                 </Popup.Resources>
                 <Border
                     Width="{TemplateBinding Width}"

--- a/src/Toolkit/Toolkit.WinUI/UI/Controls/SearchView/SearchView.Theme.xaml
+++ b/src/Toolkit/Toolkit.WinUI/UI/Controls/SearchView/SearchView.Theme.xaml
@@ -558,7 +558,7 @@
                     <CollectionViewSource
                         x:Key="GroupedSuggestionsEx"
                         IsSourceGrouped="True"
-                        Source="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=GroupedSuggestions, Mode=TwoWay}" />
+                        Source="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=GroupedSuggestions, Mode=OneWay}" />
                 </Popup.Resources>
                 <Border
                     Width="{TemplateBinding Width}"

--- a/src/Toolkit/Toolkit.WinUI/UI/Controls/SearchView/SearchView.Theme.xaml
+++ b/src/Toolkit/Toolkit.WinUI/UI/Controls/SearchView/SearchView.Theme.xaml
@@ -558,7 +558,7 @@
                     <CollectionViewSource
                         x:Key="GroupedSuggestionsEx"
                         IsSourceGrouped="True"
-                        Source="{TemplateBinding GroupedSuggestions}" />
+                        Source="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=GroupedSuggestions, Mode=TwoWay}" />
                 </Popup.Resources>
                 <Border
                     Width="{TemplateBinding Width}"


### PR DESCRIPTION
Same concept as https://github.com/Esri/arcgis-maps-sdk-dotnet-toolkit/pull/723

~~If this seems low risk enough I will cherry pick it into lts.next~~ lts.next is probably too risky in case this has aot implications