### PR TITLE
Fix local builds of WinUI toolkit and samples

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -47,6 +47,7 @@
     <NetiOSTargetFramework Condition="'$(NetiOSTargetFramework)'==''">$(NETMauiTarget)-ios26.0</NetiOSTargetFramework>  
     <MauiVersion Condition="'$(MauiVersion)'==''">10.0.40</MauiVersion>
     <WinUIVersion Condition="'$(WinUIVersion)'==''">1.8.250906003</WinUIVersion>
+    <WinAppSDKVersion Condition="'$(WinAppSDKVersion)'==''">1.8.251003001</WinAppSDKVersion>
   </PropertyGroup>
   <PropertyGroup>
     <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -46,7 +46,7 @@
     <NetCatalystTargetFramework Condition="'$(NetCatalystTargetFramework)'==''">$(NETMauiTarget)-maccatalyst26.0</NetCatalystTargetFramework>
     <NetiOSTargetFramework Condition="'$(NetiOSTargetFramework)'==''">$(NETMauiTarget)-ios26.0</NetiOSTargetFramework>  
     <MauiVersion Condition="'$(MauiVersion)'==''">10.0.40</MauiVersion>
-    <WinAppSDKVersion Condition="'$(WinAppSDKVersion)'==''">1.8.250916003</WinAppSDKVersion>
+    <WinUIVersion Condition="'$(WinUIVersion)'==''">1.8.250906003</WinUIVersion>
   </PropertyGroup>
   <PropertyGroup>
     <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>

--- a/src/Samples/Toolkit.SampleApp.WinUI/Toolkit.SampleApp.WinUI.csproj
+++ b/src/Samples/Toolkit.SampleApp.WinUI/Toolkit.SampleApp.WinUI.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" Version="8.1.240916" />
     <PackageReference Include="CommunityToolkit.WinUI.Helpers" Version="8.1.240916" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260416003" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="$(WinAppSDKVersion)" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.4654" />
     <PackageReference Include="Esri.Calcite.WinUI" Version="1.0.0-rc.1" />

--- a/src/Samples/Toolkit.SampleApp.WinUI/Toolkit.SampleApp.WinUI.csproj
+++ b/src/Samples/Toolkit.SampleApp.WinUI/Toolkit.SampleApp.WinUI.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" Version="8.1.240916" />
     <PackageReference Include="CommunityToolkit.WinUI.Helpers" Version="8.1.240916" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="$(WinAppSDKVersion)" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260416003" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.4654" />
     <PackageReference Include="Esri.Calcite.WinUI" Version="1.0.0-rc.1" />


### PR DESCRIPTION
During cert I was unable to build WinUI locally unless I changed some of the version numbers. Formalizing the changes here