### PR TITLE
Remove UITest-specific MauiVersion

### DIFF
--- a/src/Tests/UITests/Directory.Build.props
+++ b/src/Tests/UITests/Directory.Build.props
@@ -3,14 +3,10 @@
 
   <!-- General Settings -->
   <PropertyGroup>
-    <!-- Be sure to delete the obj/ and bin/ folders in both App and Runner projects when updating this parameter -->
+    <!-- Be sure to delete the obj/ and bin/ folders in both App and Runner projects if updating this parameter -->
     <TestAppNetVersion>net10.0</TestAppNetVersion>
 
-    <!-- Maui Version gets set explicitly in the root Directory.build.props file, so if we want to test a newer version it must be set here.
-         Currently this defaults to the latest version of Maui 10 as per floating version syntax: https://learn.microsoft.com/en-us/nuget/concepts/dependency-resolution#floating-versions -->
-    <MauiVersion>10.*</MauiVersion>
-
-    <!-- Other useful general properties (particularly ArcGISRuntimeToolkitPackageVersion, ArcGISRuntimePackageVersion, and UseNugetPackage)
+    <!-- Other useful general properties (particularly ArcGISRuntimeToolkitPackageVersion, ArcGISRuntimePackageVersion, MauiVersion, and UseNugetPackage)
          may be found in the root Directory.build.props file. -->
   </PropertyGroup>
 

--- a/src/Tests/UITests/Directory.Build.props
+++ b/src/Tests/UITests/Directory.Build.props
@@ -6,8 +6,9 @@
     <!-- Be sure to delete the obj/ and bin/ folders in both App and Runner projects when updating this parameter -->
     <TestAppNetVersion>net10.0</TestAppNetVersion>
 
-    <!-- Maui Version gets set explicitly in the root Directory.build.props file, so it must be reset or explicitly specified here. -->
-    <MauiVersion></MauiVersion>
+    <!-- Maui Version gets set explicitly in the root Directory.build.props file, so if we want to test a newer version it must be set here.
+         Currently this defaults to the latest version of Maui 10 as per floating version syntax: https://learn.microsoft.com/en-us/nuget/concepts/dependency-resolution#floating-versions -->
+    <MauiVersion>10.*</MauiVersion>
 
     <!-- Other useful general properties (particularly ArcGISRuntimeToolkitPackageVersion, ArcGISRuntimePackageVersion, and UseNugetPackage)
          may be found in the root Directory.build.props file. -->


### PR DESCRIPTION
When I was writing the tests on main for 300.0.0 we wanted to test on .NET 10 with an appropriate `MauiVersion`, so the `MauiVersion` override was added to support similar workflows. This seems to have broken with the 300.1.0 Maui 10.0.40 requirement. For some reason unsetting `MauiVersion` it seems to have caused it to default to 10.0.20 rather than the actual latest version installed by the current dotnet workload. This branch fixes that while still using the latest` MauiVersion` available within major release 10.