### PR TITLE
UITests: Windows CI Build

### DIFF
--- a/src/Tests/UITests/README.md
+++ b/src/Tests/UITests/README.md
@@ -96,6 +96,17 @@ The `.Wpf`, `.MauiWinUI`, and `.MauiiOS` test runners will automatically build t
 
 Please be sure to consult the `MauiiOS` section below as it requires additional configuration before tests can run.
 
+### Configuration
+**Directory.Build.props**
+The [`UITests/Directory.Build.props`](./Directory.Build.props) file includes several configuration options, primarily targeted at the `MauiAndroid` and `MauiiOS` test runners.
+
+**Environment Variables**
+Configuration can also be done at runtime by setting certain environment variables. The current list of environment variables is as follows:
+
+| Variable | Description | Affected Tests |
+|---|---|---|
+| UITEST_APP_PATH | Defines the path or application identifier of the target `.App` program. | WPF, WinUI, MauiWinUI |
+
 ### General Notes
 Running the MacCatalyst test or any of the Windows tests will take over your machine. Moving the mouse is still possible but may interfere with the tests. Tests will abort if the test app gets closed (pressing the close button or `Alt+F4` are both options).
 

--- a/src/Tests/UITests/README.md
+++ b/src/Tests/UITests/README.md
@@ -105,7 +105,7 @@ Configuration can also be done at runtime by setting certain environment variabl
 
 | Variable | Description | Affected Tests |
 |---|---|---|
-| UITEST_APP_PATH | Defines the path or application identifier of the target `.App` program. | WPF, WinUI, MauiWinUI |
+| TKUITEST_APP | Defines the path to or package identifier of the target `.App` program. | WPF, WinUI, MauiWinUI |
 
 ### General Notes
 Running the MacCatalyst test or any of the Windows tests will take over your machine. Moving the mouse is still possible but may interfere with the tests. Tests will abort if the test app gets closed (pressing the close button or `Alt+F4` are both options).

--- a/src/Tests/UITests/Toolkit.UITests.MauiWinUI/AppiumSetup.MauiWinUI.cs
+++ b/src/Tests/UITests/Toolkit.UITests.MauiWinUI/AppiumSetup.MauiWinUI.cs
@@ -8,7 +8,7 @@ public static partial class AppiumSetup
     [AssemblyInitialize]
     public static void AssemblyInitialize(TestContext testContext)
     {
-        var envAppPath = Environment.GetEnvironmentVariable("UITEST_APP_PATH");
+        var envAppPath = Environment.GetEnvironmentVariable("TKUITEST_APP");
         var testApp = String.IsNullOrWhiteSpace(envAppPath) ? GetBuildSettings()["app"] : envAppPath;
 
         driver = MakeWindowsDriver(testApp);

--- a/src/Tests/UITests/Toolkit.UITests.MauiWinUI/AppiumSetup.MauiWinUI.cs
+++ b/src/Tests/UITests/Toolkit.UITests.MauiWinUI/AppiumSetup.MauiWinUI.cs
@@ -8,9 +8,10 @@ public static partial class AppiumSetup
     [AssemblyInitialize]
     public static void AssemblyInitialize(TestContext testContext)
     {
-        var mauiSamplesApp = GetBuildSettings()["app"];
+        var envAppPath = Environment.GetEnvironmentVariable("UITEST_APP_PATH");
+        var testApp = String.IsNullOrWhiteSpace(envAppPath) ? GetBuildSettings()["app"] : envAppPath;
 
-        driver = MakeWindowsDriver(mauiSamplesApp);
+        driver = MakeWindowsDriver(testApp);
 
         driver.Manage().Window.Maximize();
 

--- a/src/Tests/UITests/Toolkit.UITests.WinUI/AppiumSetup.WinUI.cs
+++ b/src/Tests/UITests/Toolkit.UITests.WinUI/AppiumSetup.WinUI.cs
@@ -7,9 +7,11 @@ public static partial class AppiumSetup
     [AssemblyInitialize]
     public static void AssemblyInitialize(TestContext testContext)
     {
-        var WinUISamplesApp = @"d733bdd1-d63f-45f9-b119-555748d3b3e4_6b5psgtf36ad0!App";
+        var WinUIAppPackageId = @"d733bdd1-d63f-45f9-b119-555748d3b3e4_6b5psgtf36ad0!App";
+        var envAppPath = Environment.GetEnvironmentVariable("UITEST_APP_PATH");
+        var testApp = String.IsNullOrWhiteSpace(envAppPath) ? WinUIAppPackageId : envAppPath;
 
-        driver = MakeWindowsDriver(WinUISamplesApp);
+        driver = MakeWindowsDriver(testApp);
 
         driver.Manage().Window.Maximize();
 

--- a/src/Tests/UITests/Toolkit.UITests.WinUI/AppiumSetup.WinUI.cs
+++ b/src/Tests/UITests/Toolkit.UITests.WinUI/AppiumSetup.WinUI.cs
@@ -8,7 +8,7 @@ public static partial class AppiumSetup
     public static void AssemblyInitialize(TestContext testContext)
     {
         var WinUIAppPackageId = @"d733bdd1-d63f-45f9-b119-555748d3b3e4_6b5psgtf36ad0!App";
-        var envAppPath = Environment.GetEnvironmentVariable("UITEST_APP_PATH");
+        var envAppPath = Environment.GetEnvironmentVariable("TKUITEST_APP");
         var testApp = String.IsNullOrWhiteSpace(envAppPath) ? WinUIAppPackageId : envAppPath;
 
         driver = MakeWindowsDriver(testApp);

--- a/src/Tests/UITests/Toolkit.UITests.Wpf/AppiumSetup.Wpf.cs
+++ b/src/Tests/UITests/Toolkit.UITests.Wpf/AppiumSetup.Wpf.cs
@@ -9,7 +9,7 @@ public static partial class AppiumSetup
     [AssemblyInitialize]
     public static void AssemblyInitialize(TestContext testContext)
     {
-        var envAppPath = Environment.GetEnvironmentVariable("UITEST_APP_PATH");
+        var envAppPath = Environment.GetEnvironmentVariable("TKUITEST_APP");
         var testApp = String.IsNullOrWhiteSpace(envAppPath) ? GetBuildSettings()["app"] : envAppPath;
 
         driver = MakeWindowsDriver(testApp);

--- a/src/Tests/UITests/Toolkit.UITests.Wpf/AppiumSetup.Wpf.cs
+++ b/src/Tests/UITests/Toolkit.UITests.Wpf/AppiumSetup.Wpf.cs
@@ -9,9 +9,10 @@ public static partial class AppiumSetup
     [AssemblyInitialize]
     public static void AssemblyInitialize(TestContext testContext)
     {
-        var wpfSamplesApp = GetBuildSettings()["app"];
+        var envAppPath = Environment.GetEnvironmentVariable("UITEST_APP_PATH");
+        var testApp = String.IsNullOrWhiteSpace(envAppPath) ? GetBuildSettings()["app"] : envAppPath;
 
-        driver = MakeWindowsDriver(wpfSamplesApp);
+        driver = MakeWindowsDriver(testApp);
 
         driver.Manage().Window.Maximize();
 

--- a/src/Tests/UITests/cibuild/cibuild-mauiwinui.ps1
+++ b/src/Tests/UITests/cibuild/cibuild-mauiwinui.ps1
@@ -9,15 +9,20 @@ if (-not $?) {
   exit 1
 }
 
-# Define build parameters
+# Define common build parameters
 $config_file = Join-Path $PSScriptRoot "variables.yml"
 $build_params = @('-c', 'Release', '-r', 'win-x64', '-p:UseMonoRuntime=false')
 if (![string]::IsNullOrWhiteSpace($env:RELEASE_VERSION)) {
   $build_params += "-p:UseNugetPackage=$env:RELEASE_VERSION"
 }
 
-$framework = "$(Get-YamlValue $config_file 'maui-dotnet-framework')-windows$(Get-YamlValue $config_file 'windows-sdk-version')"
-$build_params_app = @('-f', $framework)
+# Define app build parameters, including setting MauiVersion to the latest available
+$dotnet_version = Get-YamlValue $config_file 'dotnet-version'
+$dotnet_major_version = $(Select-String -InputObject $dotnet_version -Pattern '\d+\.\d+(?=\.)')[0].Matches[0].Value
+$build_params_app = @("-p:MauiVersion=${dotnet_major_version}*")
+
+$framework = "net${dotnet_major_version}-windows$(Get-YamlValue $config_file 'windows-sdk-version')"
+$build_params_app += @('-f', $framework)
 
 # Run tests
 $runner_name = 'Toolkit.UITests.MauiWinUI'

--- a/src/Tests/UITests/cibuild/cibuild-mauiwinui.ps1
+++ b/src/Tests/UITests/cibuild/cibuild-mauiwinui.ps1
@@ -22,7 +22,7 @@ $dotnet_major_version = $(Select-String -InputObject $dotnet_version -Pattern '\
 $build_params_app = @("-p:MauiVersion=${dotnet_major_version}*")
 
 $framework = "net${dotnet_major_version}-windows$(Get-YamlValue $config_file 'windows-sdk-version')"
-$build_params_app += @('-f', $framework)
+$build_params_app += @('-f', $framework, "-p:TargetFrameworks=${framework}")
 
 # Run tests
 $runner_name = 'Toolkit.UITests.MauiWinUI'

--- a/src/Tests/UITests/cibuild/cibuild-mauiwinui.ps1
+++ b/src/Tests/UITests/cibuild/cibuild-mauiwinui.ps1
@@ -1,0 +1,25 @@
+if ([string]::IsNullOrWhiteSpace($env:WORKSPACE)) {
+  Write-Error 'WORKSPACE environment variable is not set. Please set it to the root of your workspace.'
+  exit 1
+}
+
+# Import utils module
+Import-Module $(Join-Path $PSScriptRoot 'utils.psm1') -Force
+if (-not $?) {
+  exit 1
+}
+
+# Define build parameters
+$config_file = Join-Path $PSScriptRoot "variables.yml"
+$build_params = @('-c', 'Release', '-r', 'win-x64', '-p:UseMonoRuntime=false')
+if (![string]::IsNullOrWhiteSpace($env:RELEASE_VERSION)) {
+  $build_params += "-p:UseNugetPackage=$env:RELEASE_VERSION"
+}
+
+$framework = "$(Get-YamlValue $config_file 'maui-dotnet-framework')-windows$(Get-YamlValue $config_file 'windows-sdk-version')"
+$build_params_app = @('-f', $framework)
+
+# Run tests
+$runner_name = 'Toolkit.UITests.MauiWinUI'
+$app_name = 'Toolkit.UITests.Maui.App'
+Invoke-WindowsUITests $env:WORKSPACE $runner_name $app_name $build_params $true $env:NUGET_REPO $env:TRX_FILENAME $build_params_app

--- a/src/Tests/UITests/cibuild/cibuild-winui.ps1
+++ b/src/Tests/UITests/cibuild/cibuild-winui.ps1
@@ -10,12 +10,14 @@ if (-not $?) {
 }
 
 # Define build parameters
-$build_params = @('-c', 'Release')
+$build_params = @('-c', 'Release', '-r', 'win-x64', '-p:SelfContained=true', '-p:PublishProfile=win-x64.pubxml', '-p:WindowsAppSDKSelfContained=true')
 if (![string]::IsNullOrWhiteSpace($env:RELEASE_VERSION)) {
   $build_params += "-p:UseNugetPackage=$env:RELEASE_VERSION"
 }
 
 # Run tests
-$runner_project = Join-Path $PSScriptRoot '..\Toolkit.UITests.WPF\Toolkit.UITests.WPF.csproj'
-$app_project = Join-Path $PSScriptRoot '..\Toolkit.UITests.WPF.App\Toolkit.UITests.WPF.App.csproj'
+$runner_project = Join-Path $PSScriptRoot '..\Toolkit.UITests.WinUI\Toolkit.UITests.WinUI.csproj'
+$app_project = Join-Path $PSScriptRoot '..\Toolkit.UITests.WinUI.App\Toolkit.UITests.WinUI.App.csproj'
+
+$env:UITEST_APP_PATH = Join-Path $PSScriptRoot '..\Toolkit.UITests.WinUI.App\bin\Release\net10.0-windows10.0.19041.0\win-x64\Toolkit.UITests.WinUI.App.exe'
 Invoke-WindowsUITests $env:WORKSPACE $runner_project $app_project $build_params $env:NUGET_REPO $env:TRX_FILENAME

--- a/src/Tests/UITests/cibuild/cibuild-winui.ps1
+++ b/src/Tests/UITests/cibuild/cibuild-winui.ps1
@@ -24,4 +24,4 @@ if (![string]::IsNullOrWhiteSpace($env:RELEASE_VERSION)) {
 # Run tests
 $runner_name = 'Toolkit.UITests.WinUI'
 $app_name = 'Toolkit.UITests.WinUI.App'
-Invoke-WindowsUITests $env:WORKSPACE $runner_name $app_name $build_params $env:NUGET_REPO $env:TRX_FILENAME
+Invoke-WindowsUITests $env:WORKSPACE $runner_name $app_name $build_params $false $env:NUGET_REPO $env:TRX_FILENAME

--- a/src/Tests/UITests/cibuild/cibuild-winui.ps1
+++ b/src/Tests/UITests/cibuild/cibuild-winui.ps1
@@ -10,14 +10,18 @@ if (-not $?) {
 }
 
 # Define build parameters
-$build_params = @('-c', 'Release', '-r', 'win-x64', '-p:SelfContained=true', '-p:PublishProfile=win-x64.pubxml', '-p:WindowsAppSDKSelfContained=true')
+$build_params = @(
+  '-c', 'Release',
+  '-r', 'win-x64',
+  '-p:SelfContained=true',
+  '-p:PublishProfile=win-x64.pubxml',
+  '-p:WindowsAppSDKSelfContained=true'
+)
 if (![string]::IsNullOrWhiteSpace($env:RELEASE_VERSION)) {
   $build_params += "-p:UseNugetPackage=$env:RELEASE_VERSION"
 }
 
 # Run tests
-$runner_project = Join-Path $PSScriptRoot '..\Toolkit.UITests.WinUI\Toolkit.UITests.WinUI.csproj'
-$app_project = Join-Path $PSScriptRoot '..\Toolkit.UITests.WinUI.App\Toolkit.UITests.WinUI.App.csproj'
-
-$env:UITEST_APP_PATH = Join-Path $PSScriptRoot '..\Toolkit.UITests.WinUI.App\bin\Release\net10.0-windows10.0.19041.0\win-x64\Toolkit.UITests.WinUI.App.exe'
-Invoke-WindowsUITests $env:WORKSPACE $runner_project $app_project $build_params $env:NUGET_REPO $env:TRX_FILENAME
+$runner_name = 'Toolkit.UITests.WinUI'
+$app_name = 'Toolkit.UITests.WinUI.App'
+Invoke-WindowsUITests $env:WORKSPACE $runner_name $app_name $build_params $env:NUGET_REPO $env:TRX_FILENAME

--- a/src/Tests/UITests/cibuild/cibuild-wpf.ps1
+++ b/src/Tests/UITests/cibuild/cibuild-wpf.ps1
@@ -40,13 +40,14 @@ if (![string]::IsNullOrWhiteSpace($env:NUGET_REPO)) {
 
 # Build the test app and test runner projects
 if (![string]::IsNullOrWhiteSpace($env:RELEASE_VERSION)) {
-  $property_UseNugetPackage = "-p:UseNugetPackage=$($env:RELEASE_VERSION)"
+  $property_UseNugetPackage = "-p:UseNugetPackage=$env:RELEASE_VERSION"
 }
+$common_build_params = "-c Release $property_UseNugetPackage"
 
 $wpf_project = Join-Path $PSScriptRoot '..\Toolkit.UITests.WPF\Toolkit.UITests.WPF.csproj'
 $wpf_app_project = Join-Path $PSScriptRoot '..\Toolkit.UITests.WPF.App\Toolkit.UITests.WPF.App.csproj'
-& $dotnet_exe build $wpf_app_project -c Release $property_UseNugetPackage
-& $dotnet_exe build $wpf_project -c Release $property_UseNugetPackage
+Invoke-Expression "$dotnet_exe build $wpf_app_project $common_build_params"
+Invoke-Expression "$dotnet_exe build $wpf_project $common_build_params"
 if (!$?) {
   exit 1
 }
@@ -62,11 +63,11 @@ if (!$?) {
 $results_dir = Join-Path $env:WORKSPACE 'TestResults'
 $toolkit_src_root = Join-Path $PSScriptRoot '..\..\..'
 if (![string]::IsNullOrWhiteSpace($env:TRX_FILENAME)) {
-  $parameter_trxfilename = "--report-trx-filename $($env:TRX_FILENAME)"
+  $parameter_trxfilename = "--report-trx-filename $env:TRX_FILENAME"
 }
 
 Set-Location -Path $toolkit_src_root
-Invoke-Expression "$dotnet_exe test $wpf_project -c Release $property_UseNugetPackage --results-directory $results_dir --report-trx $parameter_trxfilename"
+Invoke-Expression "$dotnet_exe test $wpf_project $common_build_params --results-directory $results_dir --report-trx $parameter_trxfilename"
 
 # Kill the appium server process and build server
 Stop-Process -InputObject $appium_server_process

--- a/src/Tests/UITests/cibuild/cibuild-wpf.ps1
+++ b/src/Tests/UITests/cibuild/cibuild-wpf.ps1
@@ -66,7 +66,7 @@ if (![string]::IsNullOrWhiteSpace($env:TRX_FILENAME)) {
 }
 
 Set-Location -Path $toolkit_src_root
-& $dotnet_exe test $wpf_project $property_UseNugetPackage --results-directory $results_dir --report-trx $parameter_trxfilename
+Invoke-Expression "$dotnet_exe test $wpf_project $property_UseNugetPackage --results-directory $results_dir --report-trx $parameter_trxfilename"
 
 # Kill the appium server process and build server
 Stop-Process -InputObject $appium_server_process

--- a/src/Tests/UITests/cibuild/cibuild-wpf.ps1
+++ b/src/Tests/UITests/cibuild/cibuild-wpf.ps1
@@ -43,11 +43,10 @@ if (![string]::IsNullOrWhiteSpace($env:RELEASE_VERSION)) {
   $property_UseNugetPackage = "-p:UseNugetPackage=$($env:RELEASE_VERSION)"
 }
 
-$output_dir = Join-Path $env:WORKSPACE 'wpf-cibuild-output'
 $wpf_project = Join-Path $PSScriptRoot '..\Toolkit.UITests.WPF\Toolkit.UITests.WPF.csproj'
 $wpf_app_project = Join-Path $PSScriptRoot '..\Toolkit.UITests.WPF.App\Toolkit.UITests.WPF.App.csproj'
 & $dotnet_exe build $wpf_app_project -c Release $property_UseNugetPackage
-& $dotnet_exe build $wpf_project -o $output_dir -c Release $property_UseNugetPackage
+& $dotnet_exe build $wpf_project -c Release $property_UseNugetPackage
 if (!$?) {
   exit 1
 }

--- a/src/Tests/UITests/cibuild/cibuild-wpf.ps1
+++ b/src/Tests/UITests/cibuild/cibuild-wpf.ps1
@@ -29,6 +29,15 @@ if ($LASTEXITCODE -ne 0) {
 
 & $node_exe $appium_entry driver install windows
 
+# Set nuget source if provided
+if (![string]::IsNullOrWhiteSpace($env:NUGET_REPO)) {
+  $toolkit_src_dir = Join-Path $PSScriptRoot '..\..\..'
+  Set-NugetSource $toolkit_src_dir $dotnet_exe $env:NUGET_REPO
+  if (!$?) {
+    exit 1
+  }
+}
+
 # Build both projects manually since it is easier to see build errors when they are built separately
 $output_dir = Join-Path $env:WORKSPACE 'wpf-cibuild-output'
 $wpf_project = Join-Path $PSScriptRoot '..\Toolkit.UITests.WPF\Toolkit.UITests.WPF.csproj'

--- a/src/Tests/UITests/cibuild/cibuild-wpf.ps1
+++ b/src/Tests/UITests/cibuild/cibuild-wpf.ps1
@@ -29,10 +29,35 @@ if ($LASTEXITCODE -ne 0) {
 
 & $node_exe $appium_entry driver install windows
 
+# Build both projects manually since it is easier to see build errors when they are built separately
+$output_dir = Join-Path $env:WORKSPACE 'wpf-cibuild-output'
+$wpf_project = Join-Path $PSScriptRoot '..\Toolkit.UITests.WPF\Toolkit.UITests.WPF.csproj'
+$wpf_app_project = Join-Path $PSScriptRoot '..\Toolkit.UITests.WPF.App\Toolkit.UITests.WPF.App.csproj'
+& $dotnet_exe build $wpf_app_project
+& $dotnet_exe build $wpf_project -o $output_dir
+if (!$?) {
+  exit 1
+}
+
+# Kill the dotnet build server as it is no longer needed
+& $dotnet_exe build-server shutdown
+
 # Start appium
 $appium_server_process = Start-Process -FilePath $node_exe -ArgumentList @($appium_entry) -PassThru
+if (!$?) {
+  exit 1
+}
 
-Read-Host -Prompt "Press enter to kill appium"
+# Run tests
+$test_exe = Join-Path $output_dir 'Toolkit.UITests.WPF.exe'
+$results_dir = Join-Path $env:WORKSPACE 'TestResults'
+Write-Host $trx_file
+if ([string]::IsNullOrWhiteSpace($env:TRX_FILENAME)) {
+  & $test_exe --results-directory $results_dir --report-trx
+}
+else {
+  & $test_exe --results-directory $results_dir --report-trx --report-trx-filename $env:TRX_FILENAME
+}
 
 # Kill the appium server process
 Stop-Process -InputObject $appium_server_process

--- a/src/Tests/UITests/cibuild/cibuild-wpf.ps1
+++ b/src/Tests/UITests/cibuild/cibuild-wpf.ps1
@@ -15,14 +15,14 @@ $dotnet_exe = Install-Dotnet $env:WORKSPACE $dotnet_version $env:DOTNET_CACHE_FO
 
 # Install Node.js
 $node_version = '24.15.0'
-$node_exe, $npm_exe = Install-Nodejs $env:WORKSPACE $node_version
-$node_prefix = Join-Path $env:WORKSPACE '.node'
+$node_workspace = Join-Path $env:WORKSPACE '.node'
+$node_exe, $npm_exe = Install-Nodejs $node_workspace $node_version
 
 # Install appium and driver
-$appium_entry = Join-Path $node_prefix 'node_modules\appium\index.js'
+$appium_entry = Join-Path $node_workspace 'node_modules\appium\index.js'
 $env:APPIUM_HOME = Join-Path $env:WORKSPACE '.appium'
 
-& $npm_exe install appium --prefix $node_prefix
+& $npm_exe install appium --prefix $node_workspace
 if ($LASTEXITCODE -ne 0) {
   exit $LASTEXITCODE
 }

--- a/src/Tests/UITests/cibuild/cibuild-wpf.ps1
+++ b/src/Tests/UITests/cibuild/cibuild-wpf.ps1
@@ -45,7 +45,7 @@ if (![string]::IsNullOrWhiteSpace($env:RELEASE_VERSION)) {
 
 $wpf_project = Join-Path $PSScriptRoot '..\Toolkit.UITests.WPF\Toolkit.UITests.WPF.csproj'
 $wpf_app_project = Join-Path $PSScriptRoot '..\Toolkit.UITests.WPF.App\Toolkit.UITests.WPF.App.csproj'
-& $dotnet_exe build $wpf_app_project -c Release $property_UseNugetPackage -p:SelfContained=true
+& $dotnet_exe build $wpf_app_project -c Release $property_UseNugetPackage
 & $dotnet_exe build $wpf_project -c Release $property_UseNugetPackage
 if (!$?) {
   exit 1

--- a/src/Tests/UITests/cibuild/cibuild-wpf.ps1
+++ b/src/Tests/UITests/cibuild/cibuild-wpf.ps1
@@ -51,8 +51,6 @@ if (!$?) {
   exit 1
 }
 
-# Kill the dotnet build server as it is no longer needed
-
 # Start appium
 $appium_server_process = Start-Process -FilePath $node_exe -ArgumentList @($appium_entry) -PassThru
 if (!$?) {
@@ -61,16 +59,14 @@ if (!$?) {
 }
 
 # Run tests
-$toolkit_src_root = Join-Path $PSScriptRoot '..\..\..'
-Set-Location -Path $toolkit_src_root
-
 $results_dir = Join-Path $env:WORKSPACE 'TestResults'
+$toolkit_src_root = Join-Path $PSScriptRoot '..\..\..'
 if ([string]::IsNullOrWhiteSpace($env:TRX_FILENAME)) {
-  & $dotnet_exe test $wpf_project --results-directory $results_dir --report-trx
+  $parameter_trxfilename = "--report-trx-filename $($env:TRX_FILENAME)"
 }
-else {
-  & $dotnet_exe test $wpf_project --results-directory $results_dir --report-trx --report-trx-filename $env:TRX_FILENAME
-}
+
+Set-Location -Path $toolkit_src_root
+& $dotnet_exe test $wpf_project $property_UseNugetPackage --results-directory $results_dir --report-trx $parameter_trxfilename
 
 # Kill the appium server process and build server
 Stop-Process -InputObject $appium_server_process

--- a/src/Tests/UITests/cibuild/cibuild-wpf.ps1
+++ b/src/Tests/UITests/cibuild/cibuild-wpf.ps1
@@ -18,4 +18,4 @@ if (![string]::IsNullOrWhiteSpace($env:RELEASE_VERSION)) {
 # Run tests
 $runner_name = 'Toolkit.UITests.WPF'
 $app_name = 'Toolkit.UITests.WPF.App'
-Invoke-WindowsUITests $env:WORKSPACE $runner_name $app_name $build_params $env:NUGET_REPO $env:TRX_FILENAME
+Invoke-WindowsUITests $env:WORKSPACE $runner_name $app_name $build_params $false $env:NUGET_REPO $env:TRX_FILENAME

--- a/src/Tests/UITests/cibuild/cibuild-wpf.ps1
+++ b/src/Tests/UITests/cibuild/cibuild-wpf.ps1
@@ -16,6 +16,6 @@ if (![string]::IsNullOrWhiteSpace($env:RELEASE_VERSION)) {
 }
 
 # Run tests
-$runner_project = Join-Path $PSScriptRoot '..\Toolkit.UITests.WPF\Toolkit.UITests.WPF.csproj'
-$app_project = Join-Path $PSScriptRoot '..\Toolkit.UITests.WPF.App\Toolkit.UITests.WPF.App.csproj'
-Invoke-WindowsUITests $env:WORKSPACE $runner_project $app_project $build_params $env:NUGET_REPO $env:TRX_FILENAME
+$runner_name = 'Toolkit.UITests.WPF'
+$app_name = 'Toolkit.UITests.WPF.App'
+Invoke-WindowsUITests $env:WORKSPACE $runner_name $app_name $build_params $env:NUGET_REPO $env:TRX_FILENAME

--- a/src/Tests/UITests/cibuild/cibuild-wpf.ps1
+++ b/src/Tests/UITests/cibuild/cibuild-wpf.ps1
@@ -53,11 +53,11 @@ if (!$?) {
 }
 
 # Kill the dotnet build server as it is no longer needed
-& $dotnet_exe build-server shutdown
 
 # Start appium
 $appium_server_process = Start-Process -FilePath $node_exe -ArgumentList @($appium_entry) -PassThru
 if (!$?) {
+  & $dotnet_exe build-server shutdown
   exit 1
 }
 
@@ -73,5 +73,6 @@ else {
   & $dotnet_exe test $wpf_project --results-directory $results_dir --report-trx --report-trx-filename $env:TRX_FILENAME
 }
 
-# Kill the appium server process
+# Kill the appium server process and build server
 Stop-Process -InputObject $appium_server_process
+& $dotnet_exe build-server shutdown

--- a/src/Tests/UITests/cibuild/cibuild-wpf.ps1
+++ b/src/Tests/UITests/cibuild/cibuild-wpf.ps1
@@ -38,12 +38,16 @@ if (![string]::IsNullOrWhiteSpace($env:NUGET_REPO)) {
   }
 }
 
-# Build both projects manually since it is easier to see build errors when they are built separately
+# Build the test app and test runner projects
+if (![string]::IsNullOrWhiteSpace($env:RELEASE_VERSION)) {
+  $property_UseNugetPackage = "-p:UseNugetPackage=$($env:RELEASE_VERSION)"
+}
+
 $output_dir = Join-Path $env:WORKSPACE 'wpf-cibuild-output'
 $wpf_project = Join-Path $PSScriptRoot '..\Toolkit.UITests.WPF\Toolkit.UITests.WPF.csproj'
 $wpf_app_project = Join-Path $PSScriptRoot '..\Toolkit.UITests.WPF.App\Toolkit.UITests.WPF.App.csproj'
-& $dotnet_exe build $wpf_app_project
-& $dotnet_exe build $wpf_project -o $output_dir
+& $dotnet_exe build $wpf_app_project -c Release $property_UseNugetPackage
+& $dotnet_exe build $wpf_project -o $output_dir -c Release $property_UseNugetPackage
 if (!$?) {
   exit 1
 }

--- a/src/Tests/UITests/cibuild/cibuild-wpf.ps1
+++ b/src/Tests/UITests/cibuild/cibuild-wpf.ps1
@@ -61,7 +61,7 @@ if (!$?) {
 # Run tests
 $results_dir = Join-Path $env:WORKSPACE 'TestResults'
 $toolkit_src_root = Join-Path $PSScriptRoot '..\..\..'
-if ([string]::IsNullOrWhiteSpace($env:TRX_FILENAME)) {
+if (![string]::IsNullOrWhiteSpace($env:TRX_FILENAME)) {
   $parameter_trxfilename = "--report-trx-filename $($env:TRX_FILENAME)"
 }
 

--- a/src/Tests/UITests/cibuild/cibuild-wpf.ps1
+++ b/src/Tests/UITests/cibuild/cibuild-wpf.ps1
@@ -3,10 +3,16 @@ if ([string]::IsNullOrWhiteSpace($env:WORKSPACE)) {
   exit 1
 }
 
+# Import utils module
 Import-Module $(Join-Path $PSScriptRoot 'utils.psm1') -Force
 if (-not $?) {
   exit 1
 }
 
+# Install dotnet
 $dotnet_version = "10.0.300"
 $dotnet_exe = Install-Dotnet $env:WORKSPACE $dotnet_version $env:DOTNET_CACHE_FOLDER
+
+# Install Node.js
+$node_version = '24.15.0'
+$node_exe, $npm_exe = Install-Nodejs $env:WORKSPACE $node_version

--- a/src/Tests/UITests/cibuild/cibuild-wpf.ps1
+++ b/src/Tests/UITests/cibuild/cibuild-wpf.ps1
@@ -62,14 +62,15 @@ if (!$?) {
 }
 
 # Run tests
-$test_exe = Join-Path $output_dir 'Toolkit.UITests.WPF.exe'
+$toolkit_src_root = Join-Path $PSScriptRoot '..\..\..'
+Set-Location -Path $toolkit_src_root
+
 $results_dir = Join-Path $env:WORKSPACE 'TestResults'
-Write-Host $trx_file
 if ([string]::IsNullOrWhiteSpace($env:TRX_FILENAME)) {
-  & $test_exe --results-directory $results_dir --report-trx
+  & $dotnet_exe test $wpf_project --results-directory $results_dir --report-trx
 }
 else {
-  & $test_exe --results-directory $results_dir --report-trx --report-trx-filename $env:TRX_FILENAME
+  & $dotnet_exe test $wpf_project --results-directory $results_dir --report-trx --report-trx-filename $env:TRX_FILENAME
 }
 
 # Kill the appium server process

--- a/src/Tests/UITests/cibuild/cibuild-wpf.ps1
+++ b/src/Tests/UITests/cibuild/cibuild-wpf.ps1
@@ -1,0 +1,12 @@
+if ([string]::IsNullOrWhiteSpace($env:WORKSPACE)) {
+  Write-Error 'WORKSPACE environment variable is not set. Please set it to the root of your workspace.'
+  exit 1
+}
+
+Import-Module $(Join-Path $PSScriptRoot 'utils.psm1') -Force
+if (-not $?) {
+  exit 1
+}
+
+$dotnet_version = "10.0.300"
+$dotnet_exe = Install-Dotnet $env:WORKSPACE $dotnet_version $env:DOTNET_CACHE_FOLDER

--- a/src/Tests/UITests/cibuild/cibuild-wpf.ps1
+++ b/src/Tests/UITests/cibuild/cibuild-wpf.ps1
@@ -9,12 +9,14 @@ if (-not $?) {
   exit 1
 }
 
+$config_file = Join-Path $PSScriptRoot "variables.yml"
+
 # Install dotnet
-$dotnet_version = "10.0.300"
+$dotnet_version = Get-YamlValue $config_file 'dotnet-version'
 $dotnet_exe = Install-Dotnet $env:WORKSPACE $dotnet_version $env:DOTNET_CACHE_FOLDER
 
 # Install Node.js
-$node_version = '24.15.0'
+$node_version = Get-YamlValue $config_file 'node-version'
 $node_workspace = Join-Path $env:WORKSPACE '.node'
 $node_exe, $npm_exe = Install-Nodejs $node_workspace $node_version
 

--- a/src/Tests/UITests/cibuild/cibuild-wpf.ps1
+++ b/src/Tests/UITests/cibuild/cibuild-wpf.ps1
@@ -16,3 +16,23 @@ $dotnet_exe = Install-Dotnet $env:WORKSPACE $dotnet_version $env:DOTNET_CACHE_FO
 # Install Node.js
 $node_version = '24.15.0'
 $node_exe, $npm_exe = Install-Nodejs $env:WORKSPACE $node_version
+$node_prefix = Join-Path $env:WORKSPACE '.node'
+
+# Install appium and driver
+$appium_entry = Join-Path $node_prefix 'node_modules\appium\index.js'
+$env:APPIUM_HOME = Join-Path $env:WORKSPACE '.appium'
+
+& $npm_exe install appium --prefix $node_prefix
+if ($LASTEXITCODE -ne 0) {
+  exit $LASTEXITCODE
+}
+
+& $node_exe $appium_entry driver install windows
+
+# Start appium
+$appium_server_process = Start-Process -FilePath $node_exe -ArgumentList @($appium_entry) -PassThru
+
+Read-Host -Prompt "Press enter to kill appium"
+
+# Kill the appium server process
+Stop-Process -InputObject $appium_server_process

--- a/src/Tests/UITests/cibuild/cibuild-wpf.ps1
+++ b/src/Tests/UITests/cibuild/cibuild-wpf.ps1
@@ -45,7 +45,7 @@ if (![string]::IsNullOrWhiteSpace($env:RELEASE_VERSION)) {
 
 $wpf_project = Join-Path $PSScriptRoot '..\Toolkit.UITests.WPF\Toolkit.UITests.WPF.csproj'
 $wpf_app_project = Join-Path $PSScriptRoot '..\Toolkit.UITests.WPF.App\Toolkit.UITests.WPF.App.csproj'
-& $dotnet_exe build $wpf_app_project -c Release $property_UseNugetPackage
+& $dotnet_exe build $wpf_app_project -c Release $property_UseNugetPackage -p:SelfContained=true
 & $dotnet_exe build $wpf_project -c Release $property_UseNugetPackage
 if (!$?) {
   exit 1
@@ -66,7 +66,7 @@ if (![string]::IsNullOrWhiteSpace($env:TRX_FILENAME)) {
 }
 
 Set-Location -Path $toolkit_src_root
-Invoke-Expression "$dotnet_exe test $wpf_project $property_UseNugetPackage --results-directory $results_dir --report-trx $parameter_trxfilename"
+Invoke-Expression "$dotnet_exe test $wpf_project -c Release $property_UseNugetPackage --results-directory $results_dir --report-trx $parameter_trxfilename"
 
 # Kill the appium server process and build server
 Stop-Process -InputObject $appium_server_process

--- a/src/Tests/UITests/cibuild/utils.psm1
+++ b/src/Tests/UITests/cibuild/utils.psm1
@@ -23,7 +23,7 @@ function Install-Dotnet {
 
   if ([string]::IsNullOrWhiteSpace($dotnet_cache_folder) -or !(Test-Path -Path $dotnet_exe)) {
     $installerPath = Join-Path $workspace 'dotnet-install.ps1'
-    curl -L https://dot.net/v1/dotnet-install.ps1 -o $installerPath
+    & curl.exe -L https://dot.net/v1/dotnet-install.ps1 -o $installerPath
     & $installerPath -Version $dotnet_version -InstallDir $dotnet_install_folder -NoPath
     if ($LASTEXITCODE -ne 0) {
      exit 1
@@ -56,7 +56,7 @@ function Install-Nodejs {
     $node_url = "https://nodejs.org/dist/v$($node_version)/node-v$($node_version)-win-x64.zip"
     $node_zip = Join-Path $env:WORKSPACE "node.zip"
 
-    curl $node_url -o $node_zip
+    & curl.exe -L $node_url -o $node_zip
     Expand-Archive -Path $node_zip -Destination $env:WORKSPACE
 
     if (!($?) -or ($LASTEXITCODE -ne 0)) {

--- a/src/Tests/UITests/cibuild/utils.psm1
+++ b/src/Tests/UITests/cibuild/utils.psm1
@@ -8,11 +8,11 @@ function Invoke-WindowsUITests {
 
     [Parameter(Mandatory)]
     [ValidateNotNullOrEmpty()]
-    [string]$runner_project,
+    [string]$runner_name,
 
     [Parameter(Mandatory)]
     [ValidateNotNullOrEmpty()]
-    [string]$app_project,
+    [string]$app_name,
 
     [Parameter(Mandatory)]
     [string[]]$build_parameters,
@@ -25,6 +25,8 @@ function Invoke-WindowsUITests {
   )
 
   $config_file = Join-Path $PSScriptRoot "variables.yml"
+  $runner_project = Join-Path $PSScriptRoot "..\${runner_name}\${runner_name}.csproj"
+  $app_project = Join-Path $PSScriptRoot "..\${app_name}\${app_name}.csproj"
 
   # Install dotnet
   $dotnet_version = Get-YamlValue $config_file 'dotnet-version'
@@ -66,6 +68,10 @@ function Invoke-WindowsUITests {
     }
   }
 
+  # Ensure predictable artifacts output layout for setting env:UITEST_APP_PATH later
+  $build_params_artifacts = @('-p:ArtifactsPivots=TestBuild', '-p:UseArtifactsOutput=true')
+  $build_parameters += $build_params_artifacts
+
   # Build app and runner projects
   & $dotnet_exe build $app_project @build_parameters
   if ($LASTEXITCODE -ne 0) {
@@ -96,6 +102,7 @@ function Invoke-WindowsUITests {
   }
 
   Set-Location -Path $toolkit_src_root
+  $env:UITEST_APP_PATH = Join-Path $PSScriptRoot "..\artifacts\bin\${app_name}\TestBuild\${app_name}.exe"
   & $dotnet_exe test $runner_project @build_parameters --results-directory $results_dir --report-trx $parameter_trxfilename
 
   # Kill the appium server process and build server

--- a/src/Tests/UITests/cibuild/utils.psm1
+++ b/src/Tests/UITests/cibuild/utils.psm1
@@ -1,3 +1,108 @@
+function Invoke-WindowsUITests {
+
+  [CmdletBinding()]
+  param (
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string]$workspace,
+
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string]$runner_project,
+
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string]$app_project,
+
+    [Parameter(Mandatory)]
+    [string[]]$build_parameters,
+
+    [Parameter()]
+    [string]$nuget_repo,
+
+    [Parameter()]
+    [string]$trx_filename
+  )
+
+  $config_file = Join-Path $PSScriptRoot "variables.yml"
+
+  # Install dotnet
+  $dotnet_version = Get-YamlValue $config_file 'dotnet-version'
+  $dotnet_exe = Install-Dotnet $workspace $dotnet_version $env:DOTNET_CACHE_FOLDER
+
+  # Install Node.js
+  $node_version = Get-YamlValue $config_file 'node-version'
+  $node_workspace = Join-Path $workspace '.node'
+  $node_exe, $npm_exe = Install-Nodejs $node_workspace $node_version
+
+  # Install appium and driver
+  $appium_entry = Join-Path $node_workspace 'node_modules\appium\index.js'
+  $env:APPIUM_HOME = Join-Path $workspace '.appium'
+
+  & $npm_exe install appium --prefix $node_workspace
+  if ($LASTEXITCODE -ne 0) {
+    exit $LASTEXITCODE
+  }
+
+  & $node_exe $appium_entry driver install windows
+
+  # Extract and configure WindowsAppDriver for appium
+  $env:APPIUM_WAD_PATH = Join-Path $env:APPIUM_HOME 'WinAppDriver1.2.1\WinAppDriver.exe'
+  if (!(Test-Path $env:APPIUM_WAD_PATH)) {
+    $wap_zip = Join-Path $PSScriptRoot 'WinAppDriver1.2.1.zip'
+    Expand-Archive -Path $wap_zip -Destination $env:APPIUM_HOME
+    if (!$?) {
+      Write-Error 'Failed to extract WinAppDriver zip'
+      exit 1
+    }
+  }
+
+  # Set nuget source if provided
+  if (![string]::IsNullOrWhiteSpace($nuget_repo)) {
+    $toolkit_src_dir = Join-Path $PSScriptRoot '..\..\..'
+    Set-NugetSource $toolkit_src_dir $dotnet_exe $nuget_repo
+    if (!$?) {
+      exit 1
+    }
+  }
+
+  # Build app and runner projects
+  & $dotnet_exe build $app_project @build_parameters
+  if ($LASTEXITCODE -ne 0) {
+    echo "App build failed. Aborting."
+    & $dotnet_exe build-server shutdown
+    exit $LASTEXITCODE
+  }
+
+  & $dotnet_exe build $runner_project @build_parameters
+  if ($LASTEXITCODE -ne 0) {
+    echo "Runner build failed. Aborting."
+    & $dotnet_exe build-server shutdown
+    exit $LASTEXITCODE
+  }
+
+  # Start appium
+  $appium_server_process = Start-Process -FilePath $node_exe -ArgumentList @($appium_entry) -PassThru
+  if (!$?) {
+    & $dotnet_exe build-server shutdown
+    exit 1
+  }
+
+  # Run tests
+  $results_dir = Join-Path $workspace 'TestResults'
+  $toolkit_src_root = Join-Path $PSScriptRoot '..\..\..'
+  if (![string]::IsNullOrWhiteSpace($trx_filename)) {
+    $parameter_trxfilename = @('--report-trx-filename', $trx_filename)
+  }
+
+  Set-Location -Path $toolkit_src_root
+  & $dotnet_exe test $runner_project @build_parameters --results-directory $results_dir --report-trx $parameter_trxfilename
+
+  # Kill the appium server process and build server
+  Stop-Process -InputObject $appium_server_process
+  & $dotnet_exe build-server shutdown
+}
+
 function Get-YamlValue {
 
   [CmdletBinding()]

--- a/src/Tests/UITests/cibuild/utils.psm1
+++ b/src/Tests/UITests/cibuild/utils.psm1
@@ -57,7 +57,16 @@ function Invoke-WindowsUITests {
     exit $LASTEXITCODE
   }
 
-  & $node_exe $appium_entry driver install windows
+  $driver_install_output = & $node_exe $appium_entry driver install windows 2>&1
+  $driver_already_installed = $driver_install_output | Select-String -Pattern "A driver named "".*"" is already installed" -Quiet
+  Write-Output $driver_install_output
+  if ($driver_already_installed) {
+    Write-Output "Appium driver already installed. Continuing build...`n"
+  }
+  elseif ($LASTEXITCODE -ne 0) {
+    Write-Output "Error installing appium driver. See logs."
+    exit $LASTEXITCODE
+  }
 
   # Extract and configure WindowsAppDriver for appium
   $wad_installer = Join-Path $workspace 'WinAppDriver.msi'

--- a/src/Tests/UITests/cibuild/utils.psm1
+++ b/src/Tests/UITests/cibuild/utils.psm1
@@ -195,7 +195,7 @@ function Install-Dotnet {
     & curl.exe -sSL https://dot.net/v1/dotnet-install.ps1 -o $installerPath
     & $installerPath -Version $dotnet_version -InstallDir $dotnet_install_folder -NoPath
     if ($LASTEXITCODE -ne 0) {
-     exit 1
+      exit 1
     }
 
     Write-Host "Dotnet installed at $dotnet_exe`n"

--- a/src/Tests/UITests/cibuild/utils.psm1
+++ b/src/Tests/UITests/cibuild/utils.psm1
@@ -25,7 +25,7 @@ function Install-Dotnet {
 
   if ([string]::IsNullOrWhiteSpace($dotnet_cache_folder) -or !(Test-Path -Path $dotnet_exe)) {
     $installerPath = Join-Path $workspace 'dotnet-install.ps1'
-    & curl.exe -L https://dot.net/v1/dotnet-install.ps1 -o $installerPath
+    & curl.exe -sSL https://dot.net/v1/dotnet-install.ps1 -o $installerPath
     & $installerPath -Version $dotnet_version -InstallDir $dotnet_install_folder -NoPath
     if ($LASTEXITCODE -ne 0) {
      exit 1
@@ -63,7 +63,7 @@ function Install-Nodejs {
     $node_url = "https://nodejs.org/dist/v${node_version}/node-v${node_version}-win-x64.zip"
     $node_zip = Join-Path $workspace "node.zip"
 
-    & curl.exe -L $node_url -o $node_zip --create-dirs
+    & curl.exe -sSL $node_url -o $node_zip --create-dirs
     if ($LASTEXITCODE -ne 0) {
       Write-Error 'Failed to download Node.js zip'
       exit 1

--- a/src/Tests/UITests/cibuild/utils.psm1
+++ b/src/Tests/UITests/cibuild/utils.psm1
@@ -140,12 +140,13 @@ function Invoke-WindowsUITests {
   }
 
   $toolkit_src_root = Join-Path $PSScriptRoot '..\..\..'
-  Set-Location -Path $toolkit_src_root
+  Push-Location -Path $toolkit_src_root
 
   $env:TKUITEST_APP = Join-Path $PSScriptRoot "..\artifacts\bin\${app_name}\TestBuild\${app_name}.exe"
   & $dotnet_exe test $runner_project @build_parameters @test_run_params
 
-  # Kill the appium server process and build server
+  # Kill the appium server process and build server, and return to original location
+  Pop-Location
   Stop-Process -InputObject $appium_server_process
   & $dotnet_exe build-server shutdown
 }

--- a/src/Tests/UITests/cibuild/utils.psm1
+++ b/src/Tests/UITests/cibuild/utils.psm1
@@ -79,6 +79,13 @@ function Invoke-WindowsUITests {
     }
   }
 
+  # Start appium before build so it has time to initialize in the background
+  $appium_server_process = Start-Process -FilePath $node_exe -ArgumentList @($appium_entry) -PassThru
+  if (!$?) {
+    & $dotnet_exe build-server shutdown
+    exit 1
+  }
+
   # Ensure predictable artifacts output layout for setting env:TKUITEST_APP later
   $build_params_artifacts = @('-p:ArtifactsPivots=TestBuild', '-p:UseArtifactsOutput=true')
   $build_parameters += $build_params_artifacts
@@ -96,13 +103,6 @@ function Invoke-WindowsUITests {
     echo "Runner build failed. Aborting."
     & $dotnet_exe build-server shutdown
     exit $LASTEXITCODE
-  }
-
-  # Start appium
-  $appium_server_process = Start-Process -FilePath $node_exe -ArgumentList @($appium_entry) -PassThru
-  if (!$?) {
-    & $dotnet_exe build-server shutdown
-    exit 1
   }
 
   # Run tests

--- a/src/Tests/UITests/cibuild/utils.psm1
+++ b/src/Tests/UITests/cibuild/utils.psm1
@@ -41,6 +41,7 @@ function Invoke-WindowsUITests {
   # Install maui workload if required
   if ($install_maui) {
     & $dotnet_exe workload install maui-windows
+    if ($LASTEXITCODE -ne 0) { Write-Error 'maui workload install failed.'; exit $LASTEXITCODE }
   }
 
   # Install Node.js

--- a/src/Tests/UITests/cibuild/utils.psm1
+++ b/src/Tests/UITests/cibuild/utils.psm1
@@ -189,6 +189,12 @@ function Install-Dotnet {
     [string]$dotnet_cache_folder=$env:DOTNET_CACHE_FOLDER
   )
 
+  if (![string]::IsNullOrWhiteSpace($env:DOTNET_EXE)) {
+    Write-Host 'DOTNET_EXE provided as an environment variable. Skipping install.'
+    $env:DOTNET_ROOT = [System.IO.Path]::GetDirectoryName($env:DOTNET_EXE)
+    return $env:DOTNET_EXE
+  }
+
   Write-Host 'Starting dotnet install...'
 
   # Install the requested dotnet version if it is not already present.

--- a/src/Tests/UITests/cibuild/utils.psm1
+++ b/src/Tests/UITests/cibuild/utils.psm1
@@ -140,7 +140,7 @@ function Invoke-WindowsUITests {
         $test_run_params += @('--report-trx-filename', $trx_filename)
       }
 
-      $env:TKUITEST_APP = Join-Path $PSScriptRoot "..\artifacts1\bin\${app_name}\TestBuild\${app_name}.exe"
+      $env:TKUITEST_APP = Join-Path $PSScriptRoot "..\artifacts\bin\${app_name}\TestBuild\${app_name}.exe"
       & $dotnet_exe test $runner_project @build_parameters @test_run_params
     }
     finally {

--- a/src/Tests/UITests/cibuild/utils.psm1
+++ b/src/Tests/UITests/cibuild/utils.psm1
@@ -79,7 +79,7 @@ function Invoke-WindowsUITests {
     }
   }
 
-  # Ensure predictable artifacts output layout for setting env:UITEST_APP_PATH later
+  # Ensure predictable artifacts output layout for setting env:TKUITEST_APP later
   $build_params_artifacts = @('-p:ArtifactsPivots=TestBuild', '-p:UseArtifactsOutput=true')
   $build_parameters += $build_params_artifacts
 
@@ -115,7 +115,7 @@ function Invoke-WindowsUITests {
   $toolkit_src_root = Join-Path $PSScriptRoot '..\..\..'
   Set-Location -Path $toolkit_src_root
 
-  $env:UITEST_APP_PATH = Join-Path $PSScriptRoot "..\artifacts\bin\${app_name}\TestBuild\${app_name}.exe"
+  $env:TKUITEST_APP = Join-Path $PSScriptRoot "..\artifacts\bin\${app_name}\TestBuild\${app_name}.exe"
   & $dotnet_exe test $runner_project @build_parameters @test_run_params
 
   # Kill the appium server process and build server

--- a/src/Tests/UITests/cibuild/utils.psm1
+++ b/src/Tests/UITests/cibuild/utils.psm1
@@ -1,3 +1,17 @@
+function Get-YamlValue {
+
+  [CmdletBinding()]
+  param (
+    [Parameter(Mandatory)]
+    [string]$path,
+
+    [Parameter(Mandatory)]
+    [string]$value_name
+  )
+
+  return $(Select-String -Path $path -Pattern "${value_name}: ""(.*)""")[0].Matches[0].Groups[1].Value
+}
+
 function Install-Dotnet {
 
   [CmdletBinding()]

--- a/src/Tests/UITests/cibuild/utils.psm1
+++ b/src/Tests/UITests/cibuild/utils.psm1
@@ -1,0 +1,39 @@
+function Install-Dotnet {
+
+  [CmdletBinding()]
+  param (
+    [Parameter(Mandatory)]
+    [string]$workspace,
+
+    [Parameter(Mandatory)]
+    [string]$dotnet_version,
+
+    [string]$dotnet_cache_folder=$env:DOTNET_CACHE_FOLDER
+  )
+
+  # Install the requested dotnet version if it is not already present.
+  if ([string]::IsNullOrWhiteSpace($dotnet_cache_folder)) {
+    $dotnet_install_folder = Join-Path $workspace '.dotnet'
+  }
+  else {
+    $dotnet_install_folder = Join-Path $dotnet_cache_folder $dotnet_version
+  }
+
+  $dotnet_exe = Join-Path $dotnet_install_folder 'dotnet.exe'
+
+  if ([string]::IsNullOrWhiteSpace($dotnet_cache_folder) -or !(Test-Path -Path $dotnet_exe)) {
+    $installerPath = Join-Path $workspace 'dotnet-install.ps1'
+    curl -L https://dot.net/v1/dotnet-install.ps1 -o $installerPath
+    & $installerPath -Version $dotnet_version -InstallDir $dotnet_install_folder -NoPath
+    if ($LASTEXITCODE -ne 0) {
+     exit 1
+    }
+
+    Write-Host "Dotnet installed at $dotnet_exe"
+  }
+  else {
+    Write-Host "Found cached dotnet at $dotnet_exe"
+  }
+
+  return $dotnet_exe
+}

--- a/src/Tests/UITests/cibuild/utils.psm1
+++ b/src/Tests/UITests/cibuild/utils.psm1
@@ -57,14 +57,15 @@ function Invoke-WindowsUITests {
     exit $LASTEXITCODE
   }
 
-  $driver_install_output = & $node_exe $appium_entry driver install windows 2>&1
-  $driver_already_installed = $driver_install_output | Select-String -Pattern "A driver named "".*"" is already installed" -Quiet
-  Write-Host $driver_install_output
-  if ($driver_already_installed) {
-    Write-Host "Appium driver already installed. Continuing build...`n"
+  $drivers_installed = & $node_exe $appium_entry driver list --installed 2>&1
+  if (!(Select-String -InputObject $drivers_installed -Pattern "windows" -Quiet)) {
+    & $node_exe $appium_entry driver install windows
   }
-  elseif ($LASTEXITCODE -ne 0) {
-    Write-Error "Error installing appium driver. See logs."
+  else {
+    & $node_exe $appium_entry driver update windows
+  }
+  if ($LASTEXITCODE -ne 0) {
+    Write-Error "Error installing or updating appium driver. See logs."
     exit $LASTEXITCODE
   }
 

--- a/src/Tests/UITests/cibuild/utils.psm1
+++ b/src/Tests/UITests/cibuild/utils.psm1
@@ -148,7 +148,7 @@ function Invoke-WindowsUITests {
       }
 
       $env:TKUITEST_APP = Join-Path $PSScriptRoot "..\artifacts\bin\${app_name}\TestBuild\${app_name}.exe"
-      & $dotnet_exe test $runner_project @build_parameters @test_run_params
+      & $dotnet_exe test --project $runner_project @build_parameters @test_run_params
     }
     finally {
       # Kill appium and return to original location

--- a/src/Tests/UITests/cibuild/utils.psm1
+++ b/src/Tests/UITests/cibuild/utils.psm1
@@ -17,11 +17,17 @@ function Invoke-WindowsUITests {
     [Parameter(Mandatory)]
     [string[]]$build_parameters,
 
+    [Parameter(Mandatory)]
+    [bool]$install_maui,
+
     [Parameter()]
     [string]$nuget_repo,
 
     [Parameter()]
-    [string]$trx_filename
+    [string]$trx_filename,
+
+    [Parameter()]
+    [string[]]$build_parameters_app
   )
 
   $config_file = Join-Path $PSScriptRoot "variables.yml"
@@ -31,6 +37,11 @@ function Invoke-WindowsUITests {
   # Install dotnet
   $dotnet_version = Get-YamlValue $config_file 'dotnet-version'
   $dotnet_exe = Install-Dotnet $workspace $dotnet_version $env:DOTNET_CACHE_FOLDER
+
+  # Install maui workload if required
+  if ($install_maui) {
+    & $dotnet_exe workload install maui
+  }
 
   # Install Node.js
   $node_version = Get-YamlValue $config_file 'node-version'
@@ -73,7 +84,7 @@ function Invoke-WindowsUITests {
   $build_parameters += $build_params_artifacts
 
   # Build app and runner projects
-  & $dotnet_exe build $app_project @build_parameters
+  & $dotnet_exe build $app_project @build_parameters @build_parameters_app
   if ($LASTEXITCODE -ne 0) {
     echo "App build failed. Aborting."
     & $dotnet_exe build-server shutdown

--- a/src/Tests/UITests/cibuild/utils.psm1
+++ b/src/Tests/UITests/cibuild/utils.psm1
@@ -37,6 +37,9 @@ function Install-Dotnet {
     Write-Host "Found cached dotnet at $($dotnet_exe)`n"
   }
 
+  # Set dotnet location for apps that rely on .NET runtime: https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables#dotnet_host_path
+  $env:DOTNET_ROOT = $dotnet_install_folder
+
   return $dotnet_exe
 }
 

--- a/src/Tests/UITests/cibuild/utils.psm1
+++ b/src/Tests/UITests/cibuild/utils.psm1
@@ -133,13 +133,15 @@ function Invoke-WindowsUITests {
         exit 1
       }
 
+      $ready = $false
       $deadline = (Get-Date).AddSeconds(60)
       while ((Get-Date) -lt $deadline) {
           try {
               $r = Invoke-RestMethod -Uri 'http://127.0.0.1:4723/status' -TimeoutSec 2
-              if ($r.value.ready) { break }
+              if ($r.value.ready) { $ready = $true; break }
           } catch { Start-Sleep -Milliseconds 500 }
       }
+      if (-not $ready) { Write-Error 'Appium did not become ready within 60s.'; exit 1 }
 
       # Run tests
       $results_dir = Join-Path $workspace 'TestResults'

--- a/src/Tests/UITests/cibuild/utils.psm1
+++ b/src/Tests/UITests/cibuild/utils.psm1
@@ -11,6 +11,8 @@ function Install-Dotnet {
     [string]$dotnet_cache_folder=$env:DOTNET_CACHE_FOLDER
   )
 
+  Write-Host 'Starting dotnet install...'
+
   # Install the requested dotnet version if it is not already present.
   if ([string]::IsNullOrWhiteSpace($dotnet_cache_folder)) {
     $dotnet_install_folder = Join-Path $workspace '.dotnet'
@@ -29,10 +31,10 @@ function Install-Dotnet {
      exit 1
     }
 
-    Write-Host "Dotnet installed at $dotnet_exe"
+    Write-Host "Dotnet installed at $($dotnet_exe)`n"
   }
   else {
-    Write-Host "Found cached dotnet at $dotnet_exe"
+    Write-Host "Found cached dotnet at $($dotnet_exe)`n"
   }
 
   return $dotnet_exe
@@ -49,24 +51,31 @@ function Install-Nodejs {
     [string]$node_version
   )
 
-  $node_dir = Join-Path $env:WORKSPACE "node-v$($node_version)-win-x64"
+  Write-Host "Starting Node.js install..."
+
+  $node_dir = Join-Path $workspace "node-v$($node_version)-win-x64"
   $node_exe = Join-Path $node_dir 'node.exe'
   $npm_exe = Join-Path $node_dir 'npm.cmd'
   if (!(Test-Path $node_exe)) {
     $node_url = "https://nodejs.org/dist/v$($node_version)/node-v$($node_version)-win-x64.zip"
-    $node_zip = Join-Path $env:WORKSPACE "node.zip"
+    $node_zip = Join-Path $workspace "node.zip"
 
-    & curl.exe -L $node_url -o $node_zip
-    Expand-Archive -Path $node_zip -Destination $env:WORKSPACE
-
-    if (!($?) -or ($LASTEXITCODE -ne 0)) {
+    & curl.exe -L $node_url -o $node_zip --create-dirs
+    if ($LASTEXITCODE -ne 0) {
+      Write-Error 'Failed to download Node.js zip'
       exit 1
     }
 
-    Write-Host "Node.js installed at $($node_exe)"
+    Expand-Archive -Path $node_zip -Destination $workspace
+    if (!$?) {
+      Write-Error 'Failed to extract Node.js zip'
+      exit 1
+    }
+
+    Write-Host "Node.js installed at $($node_exe)`n"
   }
   else {
-    Write-Host "Found cached Node.js at $($node_exe)"
+    Write-Host "Found cached Node.js at $($node_exe)`n"
   }
 
   return $node_exe, $npm_exe

--- a/src/Tests/UITests/cibuild/utils.psm1
+++ b/src/Tests/UITests/cibuild/utils.psm1
@@ -79,7 +79,7 @@ function Invoke-WindowsUITests {
 
   # Extract and configure WindowsAppDriver for appium
   $wad_installer = Join-Path $workspace 'WinAppDriver.msi'
-  & curl.exe -sSL https://github.com/microsoft/WinAppDriver/releases/download/v1.2.1/WindowsApplicationDriver_1.2.1.msi -o $wad_installer
+  & curl.exe -fsSL https://github.com/microsoft/WinAppDriver/releases/download/v1.2.1/WindowsApplicationDriver_1.2.1.msi -o $wad_installer
   if ($LASTEXITCODE -ne 0) {
     Write-Error "Failed to download Windows App Driver installer."
     & $dotnet_exe build-server shutdown
@@ -212,7 +212,7 @@ function Install-Dotnet {
 
   if ([string]::IsNullOrWhiteSpace($dotnet_cache_folder) -or !(Test-Path -Path $dotnet_exe)) {
     $installerPath = Join-Path $workspace 'dotnet-install.ps1'
-    & curl.exe -sSL https://dot.net/v1/dotnet-install.ps1 -o $installerPath
+    & curl.exe -fsSL https://dot.net/v1/dotnet-install.ps1 -o $installerPath
     & $installerPath -Version $dotnet_version -InstallDir $dotnet_install_folder -NoPath
     if ($LASTEXITCODE -ne 0) {
       exit 1
@@ -250,7 +250,7 @@ function Install-Nodejs {
     $node_url = "https://nodejs.org/dist/v${node_version}/node-v${node_version}-win-x64.zip"
     $node_zip = Join-Path $workspace "node.zip"
 
-    & curl.exe -sSL $node_url -o $node_zip --create-dirs
+    & curl.exe -fsSL $node_url -o $node_zip --create-dirs
     if ($LASTEXITCODE -ne 0) {
       Write-Error 'Failed to download Node.js zip'
       exit 1

--- a/src/Tests/UITests/cibuild/utils.psm1
+++ b/src/Tests/UITests/cibuild/utils.psm1
@@ -100,56 +100,62 @@ function Invoke-WindowsUITests {
   $build_params_artifacts = @('-p:ArtifactsPivots=TestBuild', '-p:UseArtifactsOutput=true')
   $build_parameters += $build_params_artifacts
 
-  # Build app and runner projects
-  & $dotnet_exe build $app_project @build_parameters @build_parameters_app
-  if ($LASTEXITCODE -ne 0) {
-    Write-Error "App build failed. Aborting."
+  try {
+    # Build app and runner projects
+    & $dotnet_exe build $app_project @build_parameters @build_parameters_app
+    if ($LASTEXITCODE -ne 0) {
+      Write-Error "App build failed. Aborting."
+      exit $LASTEXITCODE
+    }
+
+    & $dotnet_exe build $runner_project @build_parameters
+    if ($LASTEXITCODE -ne 0) {
+      Write-Error "Runner build failed. Aborting."
+      exit $LASTEXITCODE
+    }
+
+    # The tests seem to need to be run from the toolkit source root
+    $toolkit_src_root = Join-Path $PSScriptRoot '..\..\..'
+    Push-Location -Path $toolkit_src_root
+
+    try {
+      # Start appium server and wait for it to report as ready
+      $appium_server_process = Start-Process -FilePath $node_exe -ArgumentList @($appium_entry) -PassThru
+      if (!$?) {
+        exit 1
+      }
+
+      $deadline = (Get-Date).AddSeconds(60)
+      while ((Get-Date) -lt $deadline) {
+          try {
+              $r = Invoke-RestMethod -Uri 'http://127.0.0.1:4723/status' -TimeoutSec 2
+              Write-Host $r
+              Write-Host $r.value
+              Write-Host $r.value.ready
+              if ($r.value.ready) { break }
+          } catch { Start-Sleep -Milliseconds 500 }
+      }
+
+      # Run tests
+      $results_dir = Join-Path $workspace 'TestResults'
+      $test_run_params = @('--no-build', '--report-trx', '--results-directory', $results_dir)
+      if (![string]::IsNullOrWhiteSpace($trx_filename)) {
+        $test_run_params += @('--report-trx-filename', $trx_filename)
+      }
+
+      $env:TKUITEST_APP = Join-Path $PSScriptRoot "..\artifacts1\bin\${app_name}\TestBuild\${app_name}.exe"
+      & $dotnet_exe test $runner_project @build_parameters @test_run_params
+    }
+    finally {
+      # Kill appium and return to original location
+      Stop-Process -InputObject $appium_server_process
+      Pop-Location
+    }
+  }
+  finally {
+    # Kill dotnet build server
     & $dotnet_exe build-server shutdown
-    exit $LASTEXITCODE
   }
-
-  & $dotnet_exe build $runner_project @build_parameters
-  if ($LASTEXITCODE -ne 0) {
-    Write-Error "Runner build failed. Aborting."
-    & $dotnet_exe build-server shutdown
-    exit $LASTEXITCODE
-  }
-
-  # Start appium server and wait for it to report as ready
-  $appium_server_process = Start-Process -FilePath $node_exe -ArgumentList @($appium_entry) -PassThru
-  if (!$?) {
-    & $dotnet_exe build-server shutdown
-    exit 1
-  }
-
-  $deadline = (Get-Date).AddSeconds(60)
-  while ((Get-Date) -lt $deadline) {
-      try {
-          $r = Invoke-RestMethod -Uri 'http://127.0.0.1:4723/status' -TimeoutSec 2
-          Write-Host $r
-          Write-Host $r.value
-          Write-Host $r.value.ready
-          if ($r.value.ready) { break }
-      } catch { Start-Sleep -Milliseconds 500 }
-  }
-
-  # Run tests
-  $results_dir = Join-Path $workspace 'TestResults'
-  $test_run_params = @('--no-build', '--report-trx', '--results-directory', $results_dir)
-  if (![string]::IsNullOrWhiteSpace($trx_filename)) {
-    $test_run_params += @('--report-trx-filename', $trx_filename)
-  }
-
-  $toolkit_src_root = Join-Path $PSScriptRoot '..\..\..'
-  Push-Location -Path $toolkit_src_root
-
-  $env:TKUITEST_APP = Join-Path $PSScriptRoot "..\artifacts\bin\${app_name}\TestBuild\${app_name}.exe"
-  & $dotnet_exe test $runner_project @build_parameters @test_run_params
-
-  # Kill the appium server process and build server, and return to original location
-  Pop-Location
-  Stop-Process -InputObject $appium_server_process
-  & $dotnet_exe build-server shutdown
 }
 
 function Get-YamlValue {

--- a/src/Tests/UITests/cibuild/utils.psm1
+++ b/src/Tests/UITests/cibuild/utils.psm1
@@ -80,3 +80,42 @@ function Install-Nodejs {
 
   return $node_exe, $npm_exe
 }
+
+function Set-NugetSource {
+
+  [CmdletBinding()]
+  param (
+    [Parameter(Mandatory)]
+    [string]$workspace,
+
+    [Parameter(Mandatory)]
+    [string]$dotnet_exe,
+
+    [Parameter(Mandatory)]
+    [string]$nuget_repo
+  )
+
+  Write-Host "Configuring nuget..."
+
+  $LASTEXITCODE = 0
+  & $dotnet_exe new nugetconfig --force -o $workspace
+  if ($LASTEXITCODE -ne 0) {
+    exit $LASTEXITCODE
+  }
+
+  $configfile = Join-Path $workspace 'nuget.config'
+  & $dotnet_exe nuget add source $nuget_repo --configfile $configfile
+  if ($LASTEXITCODE -ne 0) {
+    exit $LASTEXITCODE
+  }
+
+  $nuget_dir = Join-Path $workspace '.nuget'
+  $env:NUGET_PACKAGES = Join-Path $nuget_dir 'packages'
+  $env:NUGET_HTTP_CACHE_PATH = Join-Path $nuget_dir 'cache'
+  if (!$?) {
+    Write-Error "Failed to set nuget environment variables."
+    exit 1
+  }
+
+  Write-Host "Done configuring nuget.`n"
+}

--- a/src/Tests/UITests/cibuild/utils.psm1
+++ b/src/Tests/UITests/cibuild/utils.psm1
@@ -129,9 +129,6 @@ function Invoke-WindowsUITests {
       while ((Get-Date) -lt $deadline) {
           try {
               $r = Invoke-RestMethod -Uri 'http://127.0.0.1:4723/status' -TimeoutSec 2
-              Write-Host $r
-              Write-Host $r.value
-              Write-Host $r.value.ready
               if ($r.value.ready) { break }
           } catch { Start-Sleep -Milliseconds 500 }
       }

--- a/src/Tests/UITests/cibuild/utils.psm1
+++ b/src/Tests/UITests/cibuild/utils.psm1
@@ -60,14 +60,21 @@ function Invoke-WindowsUITests {
   & $node_exe $appium_entry driver install windows
 
   # Extract and configure WindowsAppDriver for appium
-  $env:APPIUM_WAD_PATH = Join-Path $env:APPIUM_HOME 'WinAppDriver1.2.1\WinAppDriver.exe'
-  if (!(Test-Path $env:APPIUM_WAD_PATH)) {
-    $wap_zip = Join-Path $PSScriptRoot 'WinAppDriver1.2.1.zip'
-    Expand-Archive -Path $wap_zip -Destination $env:APPIUM_HOME
-    if (!$?) {
-      Write-Error 'Failed to extract WinAppDriver zip'
-      exit 1
-    }
+  $wad_installer = Join-Path $workspace 'WinAppDriver.msi'
+  & curl.exe -sSL https://github.com/microsoft/WinAppDriver/releases/download/v1.2.1/WindowsApplicationDriver_1.2.1.msi -o $wad_installer
+  if ($LASTEXITCODE -ne 0) {
+    Write-Output "Failed to download Windows App Driver installer."
+    & $dotnet_exe build-server shutdown
+    exit $LASTEXITCODE
+  }
+
+  $wad_install_dir = Join-Path $workspace '.WAD'
+  $env:APPIUM_WAD_PATH = Join-Path $wad_install_dir 'Windows Application Driver\WinAppDriver.exe'
+  & msiexec.exe /a $wad_installer TARGETDIR=$wad_install_dir /qn
+  if ($LASTEXITCODE -ne 0) {
+    Write-Output "Failed to install Windows App Driver."
+    & $dotnet_exe build-server shutdown
+    exit $LASTEXITCODE
   }
 
   # Set nuget source if provided

--- a/src/Tests/UITests/cibuild/utils.psm1
+++ b/src/Tests/UITests/cibuild/utils.psm1
@@ -69,6 +69,13 @@ function Invoke-WindowsUITests {
     exit $LASTEXITCODE
   }
 
+  # Install koffi
+  & $npm_exe install koffi --prefix $node_workspace
+  if ($LASTEXITCODE -ne 0) {
+    Write-Error "Error installing koffi node module. Koffi is necessary to avoid reliance on node-ffi, which in turn requires a Visual Studio install."
+    exit $LASTEXITCODE
+  }
+
   # Extract and configure WindowsAppDriver for appium
   $wad_installer = Join-Path $workspace 'WinAppDriver.msi'
   & curl.exe -sSL https://github.com/microsoft/WinAppDriver/releases/download/v1.2.1/WindowsApplicationDriver_1.2.1.msi -o $wad_installer

--- a/src/Tests/UITests/cibuild/utils.psm1
+++ b/src/Tests/UITests/cibuild/utils.psm1
@@ -95,13 +95,6 @@ function Invoke-WindowsUITests {
     }
   }
 
-  # Start appium before build so it has time to initialize in the background
-  $appium_server_process = Start-Process -FilePath $node_exe -ArgumentList @($appium_entry) -PassThru
-  if (!$?) {
-    & $dotnet_exe build-server shutdown
-    exit 1
-  }
-
   # Ensure predictable artifacts output layout for setting env:TKUITEST_APP later
   $build_params_artifacts = @('-p:ArtifactsPivots=TestBuild', '-p:UseArtifactsOutput=true')
   $build_parameters += $build_params_artifacts
@@ -119,6 +112,24 @@ function Invoke-WindowsUITests {
     Write-Error "Runner build failed. Aborting."
     & $dotnet_exe build-server shutdown
     exit $LASTEXITCODE
+  }
+
+  # Start appium server and wait for it to report as ready
+  $appium_server_process = Start-Process -FilePath $node_exe -ArgumentList @($appium_entry) -PassThru
+  if (!$?) {
+    & $dotnet_exe build-server shutdown
+    exit 1
+  }
+
+  $deadline = (Get-Date).AddSeconds(60)
+  while ((Get-Date) -lt $deadline) {
+      try {
+          $r = Invoke-RestMethod -Uri 'http://127.0.0.1:4723/status' -TimeoutSec 2
+          Write-Host $r
+          Write-Host $r.value
+          Write-Host $r.value.ready
+          if ($r.value.ready) { break }
+      } catch { Start-Sleep -Milliseconds 500 }
   }
 
   # Run tests

--- a/src/Tests/UITests/cibuild/utils.psm1
+++ b/src/Tests/UITests/cibuild/utils.psm1
@@ -31,10 +31,10 @@ function Install-Dotnet {
      exit 1
     }
 
-    Write-Host "Dotnet installed at $($dotnet_exe)`n"
+    Write-Host "Dotnet installed at $dotnet_exe`n"
   }
   else {
-    Write-Host "Found cached dotnet at $($dotnet_exe)`n"
+    Write-Host "Found cached dotnet at $dotnet_exe`n"
   }
 
   # Set dotnet location for apps that rely on .NET runtime: https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables#dotnet_host_path
@@ -56,11 +56,11 @@ function Install-Nodejs {
 
   Write-Host "Starting Node.js install..."
 
-  $node_dir = Join-Path $workspace "node-v$($node_version)-win-x64"
+  $node_dir = Join-Path $workspace "node-v${node_version}-win-x64"
   $node_exe = Join-Path $node_dir 'node.exe'
   $npm_exe = Join-Path $node_dir 'npm.cmd'
   if (!(Test-Path $node_exe)) {
-    $node_url = "https://nodejs.org/dist/v$($node_version)/node-v$($node_version)-win-x64.zip"
+    $node_url = "https://nodejs.org/dist/v${node_version}/node-v${node_version}-win-x64.zip"
     $node_zip = Join-Path $workspace "node.zip"
 
     & curl.exe -L $node_url -o $node_zip --create-dirs
@@ -75,14 +75,14 @@ function Install-Nodejs {
       exit 1
     }
 
-    Write-Host "Node.js installed at $($node_exe)`n"
+    Write-Host "Node.js installed at $node_exe`n"
   }
   else {
-    Write-Host "Found cached Node.js at $($node_exe)`n"
+    Write-Host "Found cached Node.js at $node_exe`n"
   }
 
   # Node sometimes calls itself base on path internally, so we cannot rely on returning the local variables
-  $env:PATH = "$($node_dir);$($env:PATH)"
+  $env:PATH = "${node_dir};${env:PATH}"
 
   return $node_exe, $npm_exe
 }

--- a/src/Tests/UITests/cibuild/utils.psm1
+++ b/src/Tests/UITests/cibuild/utils.psm1
@@ -59,12 +59,12 @@ function Invoke-WindowsUITests {
 
   $driver_install_output = & $node_exe $appium_entry driver install windows 2>&1
   $driver_already_installed = $driver_install_output | Select-String -Pattern "A driver named "".*"" is already installed" -Quiet
-  Write-Output $driver_install_output
+  Write-Host $driver_install_output
   if ($driver_already_installed) {
-    Write-Output "Appium driver already installed. Continuing build...`n"
+    Write-Host "Appium driver already installed. Continuing build...`n"
   }
   elseif ($LASTEXITCODE -ne 0) {
-    Write-Output "Error installing appium driver. See logs."
+    Write-Error "Error installing appium driver. See logs."
     exit $LASTEXITCODE
   }
 
@@ -72,7 +72,7 @@ function Invoke-WindowsUITests {
   $wad_installer = Join-Path $workspace 'WinAppDriver.msi'
   & curl.exe -sSL https://github.com/microsoft/WinAppDriver/releases/download/v1.2.1/WindowsApplicationDriver_1.2.1.msi -o $wad_installer
   if ($LASTEXITCODE -ne 0) {
-    Write-Output "Failed to download Windows App Driver installer."
+    Write-Error "Failed to download Windows App Driver installer."
     & $dotnet_exe build-server shutdown
     exit $LASTEXITCODE
   }
@@ -81,7 +81,7 @@ function Invoke-WindowsUITests {
   $env:APPIUM_WAD_PATH = Join-Path $wad_install_dir 'Windows Application Driver\WinAppDriver.exe'
   & msiexec.exe /a $wad_installer TARGETDIR=$wad_install_dir /qn
   if ($LASTEXITCODE -ne 0) {
-    Write-Output "Failed to install Windows App Driver."
+    Write-Error "Failed to install Windows App Driver."
     & $dotnet_exe build-server shutdown
     exit $LASTEXITCODE
   }
@@ -109,14 +109,14 @@ function Invoke-WindowsUITests {
   # Build app and runner projects
   & $dotnet_exe build $app_project @build_parameters @build_parameters_app
   if ($LASTEXITCODE -ne 0) {
-    echo "App build failed. Aborting."
+    Write-Error "App build failed. Aborting."
     & $dotnet_exe build-server shutdown
     exit $LASTEXITCODE
   }
 
   & $dotnet_exe build $runner_project @build_parameters
   if ($LASTEXITCODE -ne 0) {
-    echo "Runner build failed. Aborting."
+    Write-Error "Runner build failed. Aborting."
     & $dotnet_exe build-server shutdown
     exit $LASTEXITCODE
   }

--- a/src/Tests/UITests/cibuild/utils.psm1
+++ b/src/Tests/UITests/cibuild/utils.psm1
@@ -153,8 +153,10 @@ function Invoke-WindowsUITests {
     }
     finally {
       # Kill appium and return to original location
-      Stop-Process -InputObject $appium_server_process
-      Pop-Location
+      if ($appium_server_process) {
+        & taskkill /T /F /PID $($appium_server_process.Id)
+        Pop-Location
+      }
     }
   }
   finally {

--- a/src/Tests/UITests/cibuild/utils.psm1
+++ b/src/Tests/UITests/cibuild/utils.psm1
@@ -37,3 +37,37 @@ function Install-Dotnet {
 
   return $dotnet_exe
 }
+
+function Install-Nodejs {
+
+  [CmdletBinding()]
+  param (
+    [Parameter(Mandatory)]
+    [string]$workspace,
+
+    [Parameter(Mandatory)]
+    [string]$node_version
+  )
+
+  $node_dir = Join-Path $env:WORKSPACE "node-v$($node_version)-win-x64"
+  $node_exe = Join-Path $node_dir 'node.exe'
+  $npm_exe = Join-Path $node_dir 'npm.cmd'
+  if (!(Test-Path $node_exe)) {
+    $node_url = "https://nodejs.org/dist/v$($node_version)/node-v$($node_version)-win-x64.zip"
+    $node_zip = Join-Path $env:WORKSPACE "node.zip"
+
+    curl $node_url -o $node_zip
+    Expand-Archive -Path $node_zip -Destination $env:WORKSPACE
+
+    if (!($?) -or ($LASTEXITCODE -ne 0)) {
+      exit 1
+    }
+
+    Write-Host "Node.js installed at $($node_exe)"
+  }
+  else {
+    Write-Host "Found cached Node.js at $($node_exe)"
+  }
+
+  return $node_exe, $npm_exe
+}

--- a/src/Tests/UITests/cibuild/utils.psm1
+++ b/src/Tests/UITests/cibuild/utils.psm1
@@ -78,6 +78,9 @@ function Install-Nodejs {
     Write-Host "Found cached Node.js at $($node_exe)`n"
   }
 
+  # Node sometimes calls itself base on path internally, so we cannot rely on returning the local variables
+  $env:PATH = "$($node_dir);$($env:PATH)"
+
   return $node_exe, $npm_exe
 }
 

--- a/src/Tests/UITests/cibuild/utils.psm1
+++ b/src/Tests/UITests/cibuild/utils.psm1
@@ -96,14 +96,16 @@ function Invoke-WindowsUITests {
 
   # Run tests
   $results_dir = Join-Path $workspace 'TestResults'
-  $toolkit_src_root = Join-Path $PSScriptRoot '..\..\..'
+  $test_run_params = @('--no-build', '--report-trx', '--results-directory', $results_dir)
   if (![string]::IsNullOrWhiteSpace($trx_filename)) {
-    $parameter_trxfilename = @('--report-trx-filename', $trx_filename)
+    $test_run_params += @('--report-trx-filename', $trx_filename)
   }
 
+  $toolkit_src_root = Join-Path $PSScriptRoot '..\..\..'
   Set-Location -Path $toolkit_src_root
+
   $env:UITEST_APP_PATH = Join-Path $PSScriptRoot "..\artifacts\bin\${app_name}\TestBuild\${app_name}.exe"
-  & $dotnet_exe test $runner_project @build_parameters --results-directory $results_dir --report-trx $parameter_trxfilename
+  & $dotnet_exe test $runner_project @build_parameters @test_run_params
 
   # Kill the appium server process and build server
   Stop-Process -InputObject $appium_server_process

--- a/src/Tests/UITests/cibuild/utils.psm1
+++ b/src/Tests/UITests/cibuild/utils.psm1
@@ -40,7 +40,7 @@ function Invoke-WindowsUITests {
 
   # Install maui workload if required
   if ($install_maui) {
-    & $dotnet_exe workload install maui
+    & $dotnet_exe workload install maui-windows
   }
 
   # Install Node.js

--- a/src/Tests/UITests/cibuild/variables.yml
+++ b/src/Tests/UITests/cibuild/variables.yml
@@ -1,2 +1,4 @@
 dotnet-version: "10.0.300"
 node-version: "24.15.0"
+maui-dotnet-framework: "net10.0"
+windows-sdk-version: "10.0.19041.0"

--- a/src/Tests/UITests/cibuild/variables.yml
+++ b/src/Tests/UITests/cibuild/variables.yml
@@ -1,0 +1,2 @@
+dotnet-version: "10.0.300"
+node-version: "24.15.0"

--- a/src/Tests/UITests/cibuild/variables.yml
+++ b/src/Tests/UITests/cibuild/variables.yml
@@ -1,4 +1,3 @@
 dotnet-version: "10.0.300"
 node-version: "24.15.0"
-maui-dotnet-framework: "net10.0"
 windows-sdk-version: "10.0.19041.0"


### PR DESCRIPTION
The commit history got corrupted in the [last PR](https://github.com/Esri/arcgis-maps-sdk-dotnet-toolkit/pull/755), hence this copy. Changes are exactly the same.

Scripts for running CI tests for windows. All of the scripts are running on the Jenkins VMs when RDP is connected. Because of this tests are expected to fail until we get a physical machine to test on.

## Notes for reviewers
**Structure**
Most of the logic is stored in the `utils.psm1` module. The 3 platform-specific scripts just call `Invoke-WindowsUITests` with different parameters.

**Changes to test runners**
To simplify the ci logic I added the ability to configure app paths for the runner projects at runtime using environment variables. This has been documented in the UITest readme.

## Testing Locally
To test locally run the following commands in powershell. The NUGET_REPO directory should contain the nuget package from a daily build or a release, otherwise leave it unset.
```powershell
mkdir C:\uitest-workspace\
cd C:\uitest-workspace\
git clone https://github.com/Esri/arcgis-maps-sdk-dotnet-toolkit.git -b ian/uitests-cibuild-wpf-clean
$env:WORKSPACE = 'C:\uitest-workspace\'
$env:RELEASE_VERSION = '300.1.0' # This may need to change if NUGET_REPO used packages from a different version
$env:NUGET_REPO = 'C:\uitest-workspace\nuget-source' # This requires first copying nuget files to the given folder
& C:\uitest-workspace\arcgis-maps-sdk-dotnet-toolkit\src\Tests\UITests\cibuild\cibuild-wpf.ps1 
```