### PR TITLE
Honor ValidationErrorVisibility in TextFormInputView error state

### DIFF
--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/TextFormInputView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/TextFormInputView.cs
@@ -371,7 +371,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
 
             // Honor the form-level error visibility policy, consistent with
             // FieldFormElementView.UpdateErrorMessages().
-            bool shouldShowError = (FeatureFormView.GetFeatureFormViewParent(this)?.ShouldShowError() ?? false) || _hadFocus;
+            bool shouldShowError = _hadFocus || FeatureFormView.GetFeatureFormViewParent(this)?.ShouldShowError() == true;
 
             if (err != null && err.Any() && Element?.IsEditable == true && shouldShowError)
             {

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/TextFormInputView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/TextFormInputView.cs
@@ -368,7 +368,12 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
         private void UpdateValidationState()
         {
             var err = Element?.ValidationErrors;
-            if (err != null && err.Any() && Element?.IsEditable == true && _hadFocus)
+
+            // Honor the form-level error visibility policy, consistent with
+            // FieldFormElementView.UpdateErrorMessages().
+            bool shouldShowError = (FeatureFormView.GetFeatureFormViewParent(this)?.ShouldShowError() ?? false) || _hadFocus;
+
+            if (err != null && err.Any() && Element?.IsEditable == true && shouldShowError)
             {
 #if MAUI
                 if (GetTemplateChild("ErrorBorder") is Border border)


### PR DESCRIPTION
Issue #761 

TextFormInputView.UpdateValidationState() showed the input error decoration only when _hadFocus was true, ignoring the form-level FeatureFormView.ErrorsVisibility policy. FieldFormElementView already gates on _hadFocus || ShouldShowError(); make TextFormInputView consistent so errors show per the form's policy (default Visible) without requiring the field to be focused first.