### PR TITLE
Collapse source-select dropdown when typing in SearchView

### DIFF
--- a/src/Toolkit/Toolkit.Maui/SearchView/SearchView.cs
+++ b/src/Toolkit/Toolkit.Maui/SearchView/SearchView.cs
@@ -313,6 +313,9 @@ public partial class SearchView : TemplatedView, INotifyPropertyChanged
     {
         if (SearchViewModel != null)
         {
+            // Collapse the source-select dropdown when the user starts typing.
+            _sourceSelectToggled = false;
+            UpdateVisibility();
             SearchViewModel.CurrentQuery = e.NewTextValue;
         }
     }


### PR DESCRIPTION
When the search-source dropdown is open and the user starts typing in the search entry, dismiss it so it no longer obscures the suggestions list. Uses the same _sourceSelectToggled/UpdateVisibility() pattern already used by the source-select handler.

This is a clean PR for issue #686 

I am closing the #691 
