### PR TITLE
Simplify FeatureForm DateTimePicker for .NET 10 nullable MAUI pickers

### DIFF
--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/DateTimePickerFormInputView.Maui.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/DateTimePickerFormInputView.Maui.cs
@@ -17,6 +17,8 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
         private Button? _clearButton;
 #elif MACCATALYST
         private Switch? _hasValueSwitch;
+#elif WINDOWS
+        private Microsoft.UI.Xaml.Controls.CalendarDatePicker? _winDatePicker;
 #endif
 
         static DateTimePickerFormInputView()
@@ -127,12 +129,20 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
         // and listen for native date changes (the MAUI DateSelected event alone is unreliable here).
         private void DatePicker_HandlerChanged(object? sender, EventArgs e)
         {
-            if (_datePicker is not null && _datePicker.Handler?.PlatformView is Microsoft.UI.Xaml.Controls.CalendarDatePicker winPicker)
+            if (_winDatePicker is not null)
+            {
+                _winDatePicker.DateChanged -= WinDatePicker_DateChanged;
+                _winDatePicker = null;
+            }
+            if (_datePicker?.Handler?.PlatformView is Microsoft.UI.Xaml.Controls.CalendarDatePicker winPicker)
             {
                 winPicker.HorizontalAlignment = Microsoft.UI.Xaml.HorizontalAlignment.Stretch;
-                winPicker.DateChanged += (s, e) => UpdateValue();
+                winPicker.DateChanged += WinDatePicker_DateChanged;
+                _winDatePicker = winPicker;
             }
         }
+
+        private void WinDatePicker_DateChanged(Microsoft.UI.Xaml.Controls.CalendarDatePicker sender, Microsoft.UI.Xaml.Controls.CalendarDatePickerDateChangedEventArgs args) => UpdateValue();
 #endif
 
         private void TimePicker_PropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/DateTimePickerFormInputView.Maui.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/DateTimePickerFormInputView.Maui.cs
@@ -4,9 +4,7 @@ using Esri.ArcGISRuntime.Toolkit.Internal;
 using Esri.ArcGISRuntime.Toolkit.Maui.Internal;
 using Microsoft.Maui;
 using Microsoft.Maui.Controls.Internals;
-using Microsoft.Maui.Platform;
 using System.ComponentModel;
-using System.Runtime.CompilerServices;
 
 namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
 {
@@ -68,7 +66,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
             var hasValueSwitch = new Switch();
             container.Children.Add(hasValueSwitch);
             nameScope.RegisterName("HasValueSwitch", hasValueSwitch);
-            
+
             container.AddColumnDefinition(new ColumnDefinition { Width = GridLength.Auto });
             container.AddColumnDefinition(new ColumnDefinition { Width = GridLength.Star });
             Grid.SetColumn(datePicker, 1);
@@ -102,7 +100,9 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
             if (_datePicker is not null)
             {
                 _datePicker.DateSelected += DatePicker_DateSelected;
+#if WINDOWS
                 _datePicker.HandlerChanged += DatePicker_HandlerChanged;
+#endif
             }
             if (_timePicker is not null)
             {
@@ -122,29 +122,18 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
         }
 #endif
 
+#if WINDOWS
+        // The MAUI DatePicker on Windows wraps a CalendarDatePicker. Stretch it to fill the row,
+        // and listen for native date changes (the MAUI DateSelected event alone is unreliable here).
         private void DatePicker_HandlerChanged(object? sender, EventArgs e)
         {
-            // Platform-specific workarounds are needed to allow selecting "no date",
-            // because MAUI's own DatePicker does not support empty values.
-            // See https://github.com/dotnet/maui/issues/1100
-#if WINDOWS
             if (_datePicker is not null && _datePicker.Handler?.PlatformView is Microsoft.UI.Xaml.Controls.CalendarDatePicker winPicker)
             {
                 winPicker.HorizontalAlignment = Microsoft.UI.Xaml.HorizontalAlignment.Stretch;
                 winPicker.DateChanged += (s, e) => UpdateValue();
-                if (Element?.Value is null)
-                    winPicker.Date = null;
             }
-#elif IOS || ANDROID
-            if (_datePicker is not null && _datePicker.Handler?.PlatformView is Microsoft.Maui.Platform.MauiDatePicker nativePicker)
-            {
-                if (Element?.Value is null)
-                {
-                    nativePicker.Text = null;
-                }
-            }
-#endif
         }
+#endif
 
         private void TimePicker_PropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
@@ -153,60 +142,6 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
         }
 
         private void DatePicker_DateSelected(object? sender, DateChangedEventArgs e) => UpdateValue();
-
-
-#if MAUI && !NET10_0_OR_GREATER // Work around for breaking change in .NET MAUI 10.0
-        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_MinimumDate")]
-        extern static void SetMinimumDate(DatePicker p, DateTime? value);
-        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_MaximumDate")]
-        extern static void SetMaximumDate(DatePicker p, DateTime? value);
-        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_Date")]
-        extern static void SetDate(DatePicker p, DateTime? value);
-        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "get_Date")]
-        extern static DateTime? GetDate(DatePicker p);
-        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_Time")]
-        extern static void SetTime(TimePicker p, TimeSpan? value);
-        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "get_Time")]
-        extern static TimeSpan? GetTime(TimePicker p);
-
-        private static void SetMinMaxDate_Net9(DatePicker _datePicker, DateTime? minValue, DateTime? maxValue)
-        {
-            _datePicker.MinimumDate = minValue?.ToLocalTime().Date ?? DateTime.MinValue;
-            _datePicker.MaximumDate = maxValue?.ToLocalTime().Date ?? DateTime.MaxValue;
-        }
-        private static void SetMinMaxDate_Net10(DatePicker _datePicker, DateTime? minValue, DateTime? maxValue)
-        {
-#if WINDOWS
-            SetMinimumDate(_datePicker, minValue?.ToLocalTime().Date ?? DateTime.MinValue);
-            SetMaximumDate(_datePicker, maxValue?.ToLocalTime().Date ?? DateTime.MaxValue);
-#else
-            SetMinimumDate(_datePicker, minValue?.ToLocalTime().Date);
-            SetMaximumDate(_datePicker, maxValue?.ToLocalTime().Date);
-#endif
-        }
-        private static void SetDate_Net9(DatePicker datePicker, DateTime value) => datePicker.Date = value;
-        private static void SetDate_Net10(DatePicker datePicker, DateTime? value) => SetDate(datePicker, value);
-        private static DateTime? GetDateMAUI(DatePicker datePicker)
-        {
-            if (Environment.Version.Major < 10)
-                return GetDate_Net9(datePicker);
-            else
-                return GetDate_Net10(datePicker);
-        }
-        private static DateTime? GetDate_Net9(DatePicker datePicker) => datePicker.Date;
-        private static DateTime? GetDate_Net10(DatePicker datePicker) => GetDate(datePicker);
-        private static void SetTime_Net9(TimePicker timePicker, TimeSpan value) => timePicker.Time = value;
-        private static void SetTime_Net10(TimePicker timePicker, TimeSpan? value) => SetTime(timePicker, value);
-        private static TimeSpan? GetTimeMAUI(TimePicker timePicker)
-        {
-            if (Environment.Version.Major < 10)
-                return GetTime_Net9(timePicker);
-            else
-                return GetTime_Net10(timePicker);
-        }
-        private static TimeSpan? GetTime_Net9(TimePicker timePicker) => timePicker.Time;
-        private static TimeSpan? GetTime_Net10(TimePicker timePicker) => GetTime(timePicker);
-#endif
 
         }
     }

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/DateTimePickerFormInputView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/DateTimePickerFormInputView.cs
@@ -54,22 +54,16 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                 // We display dates in local time but store them in UTC.
                 DateTime? date = null;
 #if MAUI
-                // MAUI's DatePicker does not have a way to determine if it's empty. Check the platform control instead.
-#if WINDOWS
-                if (_datePicker.Handler?.PlatformView is Microsoft.UI.Xaml.Controls.CalendarDatePicker winPicker)
-                {
-                    date = winPicker.Date?.UtcDateTime;
-                }
-#elif IOS || ANDROID
-                if (_datePicker.Handler?.PlatformView is not Microsoft.Maui.Platform.MauiDatePicker nativePicker || !String.IsNullOrEmpty(nativePicker.Text))
-                {
-                    date = _datePicker.Date?.ToUniversalTime();
-                }
-#elif MACCATALYST
+#if MACCATALYST
+                // On Mac, MAUI's DatePicker always reports a value (no empty state); the
+                // has-value switch determines whether the field is considered set.
                 if (_hasValueSwitch?.IsToggled != false)
                 {
                     date = _datePicker.Date?.ToUniversalTime();
                 }
+#else
+                // DatePicker.Date is nullable (.NET 10+); null means no date is selected.
+                date = _datePicker.Date?.ToUniversalTime();
 #endif
 #elif WINDOWS_XAML
                 var doffset = _datePicker.SelectedDate?.Date;
@@ -182,25 +176,9 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                     _datePicker.MinimumDate = input.Min?.ToLocalTime();
                     _datePicker.MaximumDate = input.Max?.ToLocalTime();
 
-#if WINDOWS
-                    if (selectedDate is DateTime date)
-                    {
-                       _datePicker.Date = selectedDate.Value;
-                    }
-                    else if (_datePicker.Handler?.PlatformView is Microsoft.UI.Xaml.Controls.CalendarDatePicker winPicker)
-                    {
-                        winPicker.Date = selectedDate;
-                    }
-#elif IOS || ANDROID
-                    if (selectedDate is DateTime date)
-                    {
-                        _datePicker.Date = date;
-                    }
-                    else if (_datePicker.Handler?.PlatformView is Microsoft.Maui.Platform.MauiDatePicker nativePicker)
-                    {
-                        nativePicker.Text = null;
-                    }
-#elif MACCATALYST
+#if MACCATALYST
+                    // On Mac the DatePicker can't show an empty value, so only push a real date and
+                    // use the has-value switch to represent the null/empty state.
                     if (selectedDate is DateTime date)
                     {
                         _datePicker.Date = date;
@@ -209,6 +187,9 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                     {
                         _hasValueSwitch.IsToggled = (selectedDate != null);
                     }
+#else
+                    // DatePicker.Date is nullable (.NET 10+); null renders as an unset picker.
+                    _datePicker.Date = selectedDate;
 #endif
 #else
                     _datePicker.SelectedDate = selectedDate;

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/DateTimePickerFormInputView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/DateTimePickerFormInputView.cs
@@ -32,6 +32,12 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
     {
         private WeakEventListener<DateTimePickerFormInputView, INotifyPropertyChanged, object?, PropertyChangedEventArgs>? _elementPropertyChangedListener;
 
+#if MAUI && WINDOWS
+        // Works around dotnet/maui#35785: a null MaximumDate makes the WinUI handler overflow DateTimeOffset
+        // west of UTC. A Utc-kind MaxValue casts to CalendarDatePicker.MaxDate at offset 0, staying in range.
+        private static readonly DateTime s_winMaxDate = DateTime.SpecifyKind(DateTime.MaxValue, DateTimeKind.Utc);
+#endif
+
         /// <summary>
         /// Initializes an instance of the <see cref="DateTimePickerFormInputView"/> class.
         /// </summary>
@@ -174,7 +180,13 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
 #if MAUI
                     // Min/Max are always converted to local time
                     _datePicker.MinimumDate = input.Min?.ToLocalTime();
+#if WINDOWS
+                    // Never pass a null MaximumDate on WinUI: it triggers dotnet/maui#35785 west of UTC (see
+                    // s_winMaxDate). Min has no such issue (the symmetric case was fixed by #30973). Remove when fixed.
+                    _datePicker.MaximumDate = input.Max?.ToLocalTime() ?? s_winMaxDate;
+#else
                     _datePicker.MaximumDate = input.Max?.ToLocalTime();
+#endif
 
 #if MACCATALYST
                     // On Mac the DatePicker can't show an empty value, so only push a real date and

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/DateTimePickerFormInputView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/DateTimePickerFormInputView.cs
@@ -32,12 +32,6 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
     {
         private WeakEventListener<DateTimePickerFormInputView, INotifyPropertyChanged, object?, PropertyChangedEventArgs>? _elementPropertyChangedListener;
 
-#if MAUI && WINDOWS
-        // Works around dotnet/maui#35785: a null MaximumDate makes the WinUI handler overflow DateTimeOffset
-        // west of UTC. A Utc-kind MaxValue casts to CalendarDatePicker.MaxDate at offset 0, staying in range.
-        private static readonly DateTime s_winMaxDate = DateTime.SpecifyKind(DateTime.MaxValue, DateTimeKind.Utc);
-#endif
-
         /// <summary>
         /// Initializes an instance of the <see cref="DateTimePickerFormInputView"/> class.
         /// </summary>
@@ -181,9 +175,9 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                     // Min/Max are always converted to local time
                     _datePicker.MinimumDate = input.Min?.ToLocalTime();
 #if WINDOWS
-                    // Never pass a null MaximumDate on WinUI: it triggers dotnet/maui#35785 west of UTC (see
-                    // s_winMaxDate). Min has no such issue (the symmetric case was fixed by #30973). Remove when fixed.
-                    _datePicker.MaximumDate = input.Max?.ToLocalTime() ?? s_winMaxDate;
+                    // Works around dotnet/maui#35785: a null MaximumDate makes the WinUI handler overflow DateTimeOffset west of UTC.
+                    // A Utc-kind MaxValue casts to CalendarDatePicker.MaxDate at offset 0, staying in range.
+                    _datePicker.MaximumDate = input.Max?.ToLocalTime() ?? DateTime.SpecifyKind(DateTime.MaxValue, DateTimeKind.Utc);
 #else
                     _datePicker.MaximumDate = input.Max?.ToLocalTime();
 #endif


### PR DESCRIPTION
For dotnet-api issue 14390

MAUI 10 made DatePicker.Date/TimePicker.Time nullable and the toolkit now targets .NET 10+, so read/write the value directly instead of reaching into platform handler views:

- UpdateValue/ConfigurePickers use the nullable _datePicker.Date directly on Windows/iOS/Android; drop the CalendarDatePicker / MauiDatePicker.Text poking.
- Remove the dead `#if !NET10_0_OR_GREATER` UnsafeAccessor block and now-unused Microsoft.Maui.Platform / System.Runtime.CompilerServices usings.
- Trim DatePicker_HandlerChanged to the Windows-only CalendarDatePicker hook.

MacCatalyst keeps its has-value switch: its native picker has no empty state, so the nullable API alone can't represent "no value" there.