### PR TITLE
UIToolkit: Use floating version for MagickNet

### DIFF
--- a/src/Tests/UITests/Directory.Build.props
+++ b/src/Tests/UITests/Directory.Build.props
@@ -46,6 +46,6 @@
   <PropertyGroup>
     <TestRunnerNetVersion>net10.0</TestRunnerNetVersion>
     <AppiumWebDriverVersion>8.2.0</AppiumWebDriverVersion>
-    <MagickNetVersion>14.12.0</MagickNetVersion>
+    <MagickNetVersion>14.*</MagickNetVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
MagickNet seems to constantly get new security updates which can lead to sometimes hundreds of warnings when all the test runners are built together. Setting it to a floating version off the current major version should make this less of a problem.