### PR TITLE
Update test packages and configure dependabot for UITest projects

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,5 +8,10 @@ updates:
       - "/src/Tests/UITests/Toolkit.UITests.Wpf.App/"
       - "/src/Tests/UITests/Toolkit.UITests.WinUI.App/"
       - "/src/Tests/UITests/Toolkit.UITests.Maui.App/"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    cooldown:
+      - default-days: 2
     schedule:
       interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,6 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
     cooldown:
-      - default-days: 2
+      default-days: 2
     schedule:
       interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,8 @@ version: 2
 updates:
   - package-ecosystem: "nuget" # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#package-ecosystem-
     directories:
-      - "/src/Tests/**"
+      - "/src/Tests/Toolkit.Tests/*"
+      - "/src/Tests/UITests/*"
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,10 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# Documentation: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
 updates:
   - package-ecosystem: "nuget" # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#package-ecosystem-
     directories:
-      - "/src/Tests/UITests/Toolkit.UITests.Wpf/" # Location of UITests Directory.Build.props
-      - "/src/Tests/UITests/Toolkit.UITests.Maui.App/" # Location of UITests Directory.Build.props
+      - "/src/Tests/UITests/Toolkit.UITests.Wpf/"
+      - "/src/Tests/UITests/Toolkit.UITests.Maui.App/"
     schedule:
-      interval: "daily"
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ version: 2
 updates:
   - package-ecosystem: "nuget" # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#package-ecosystem-
     directories:
-      - "/src/Tests/Toolkit.Tests/*"
+      - "/src/Tests/Toolkit.Tests"
       - "/src/Tests/UITests/*"
     ignore:
       - dependency-name: "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
   - package-ecosystem: "nuget" # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#package-ecosystem-
     directories:
       - "/src/Tests/UITests/Toolkit.UITests.Wpf/"
+      - "/src/Tests/UITests/Toolkit.UITests.Wpf.App/"
+      - "/src/Tests/UITests/Toolkit.UITests.WinUI.App/"
       - "/src/Tests/UITests/Toolkit.UITests.Maui.App/"
     schedule:
       interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "nuget" # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#package-ecosystem-
+    directories:
+      - "/src/Tests/UITests/Toolkit.UITests.Wpf/" # Location of UITests Directory.Build.props
+      - "/src/Tests/UITests/Toolkit.UITests.Maui.App/" # Location of UITests Directory.Build.props
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,7 @@ version: 2
 updates:
   - package-ecosystem: "nuget" # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#package-ecosystem-
     directories:
-      - "/src/Tests/UITests/Toolkit.UITests.Wpf/"
-      - "/src/Tests/UITests/Toolkit.UITests.Wpf.App/"
-      - "/src/Tests/UITests/Toolkit.UITests.WinUI.App/"
-      - "/src/Tests/UITests/Toolkit.UITests.Maui.App/"
+      - "/src/Tests/**"
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]

--- a/global.json
+++ b/global.json
@@ -1,8 +1,8 @@
 {
-    "msbuild-sdks": {
-        "MSTest.Sdk": "4.0.2"
-    },
-    "test": {
-      "runner": "Microsoft.Testing.Platform"
-    }
+  "msbuild-sdks": {
+    "MSTest.Sdk": "4.2.3"
+  },
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
 }

--- a/src/Tests/UITests/Directory.Build.props
+++ b/src/Tests/UITests/Directory.Build.props
@@ -46,6 +46,6 @@
   <PropertyGroup>
     <TestRunnerNetVersion>net10.0</TestRunnerNetVersion>
     <AppiumWebDriverVersion>8.2.0</AppiumWebDriverVersion>
-    <MagickNetVersion>14.12.0</MagickNetVersion>
+    <MagickNetVersion>14.13.1</MagickNetVersion>
   </PropertyGroup>
 </Project>

--- a/src/Tests/UITests/Directory.Build.props
+++ b/src/Tests/UITests/Directory.Build.props
@@ -46,6 +46,6 @@
   <PropertyGroup>
     <TestRunnerNetVersion>net10.0</TestRunnerNetVersion>
     <AppiumWebDriverVersion>8.2.0</AppiumWebDriverVersion>
-    <MagickNetVersion>14.13.1</MagickNetVersion>
+    <MagickNetVersion>14.14.0</MagickNetVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Tested on a separate fork. We will need to activate dependabot following the steps here: https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/dependabot-quickstart-guide#enabling-dependabot-for-your-repository