### PR TITLE
utilnet: favor display of FunctionName

### DIFF
--- a/src/Toolkit/Toolkit.Maui/UtilityNetworkTraceTool/UtilityNetworkTraceTool.Appearance.cs
+++ b/src/Toolkit/Toolkit.Maui/UtilityNetworkTraceTool/UtilityNetworkTraceTool.Appearance.cs
@@ -67,6 +67,7 @@ public partial class UtilityNetworkTraceTool
     [DynamicDependency(nameof(Esri.ArcGISRuntime.UtilityNetworks.UtilityNetworkAttribute.Name), "Esri.ArcGISRuntime.UtilityNetworks.UtilityNetworkAttribute", "Esri.ArcGISRuntime")]
     [DynamicDependency(nameof(Esri.ArcGISRuntime.UtilityNetworks.UtilityTraceFunction.FunctionType), "Esri.ArcGISRuntime.UtilityNetworks.UtilityTraceFunction", "Esri.ArcGISRuntime")]
     [DynamicDependency(nameof(Esri.ArcGISRuntime.UtilityNetworks.UtilityTraceFunction.NetworkAttribute), "Esri.ArcGISRuntime.UtilityNetworks.UtilityTraceFunction", "Esri.ArcGISRuntime")]
+    [DynamicDependency(nameof(Esri.ArcGISRuntime.UtilityNetworks.UtilityTraceFunction.FunctionName), "Esri.ArcGISRuntime.UtilityNetworks.UtilityTraceFunction", "Esri.ArcGISRuntime")]
     static UtilityNetworkTraceTool()
     {
         const string backgroundColor = "{AppThemeBinding Dark=#353535, Light=#F8F8F8}";
@@ -188,9 +189,37 @@ xmlns:esriTK=""clr-namespace:Esri.ArcGISRuntime.Toolkit.Maui;assembly=Esri.ArcGI
                                             <RowDefinition Height=""Auto"" />
                                             <RowDefinition Height=""Auto"" />
                                         </Grid.RowDefinitions>
-                                        <Label Text=""{{Binding Function.NetworkAttribute.Name}}"" FontAttributes=""Bold"" TextColor=""{foregroundColor}""  />
+                                        <Label Text=""{{Binding Function.NetworkAttribute.Name}}"" FontAttributes=""Bold"" TextColor=""{foregroundColor}"" IsVisible=""False"">
+                                            <Label.Triggers>
+                                                <DataTrigger TargetType=""Label"" Binding=""{{Binding Function.FunctionName}}"" Value="""">
+                                                    <Setter Property=""IsVisible"" Value=""True"" />
+                                                </DataTrigger>
+                                                <DataTrigger TargetType=""Label"" Binding=""{{Binding Function.FunctionName}}"" Value=""{{x:Null}}"">
+                                                    <Setter Property=""IsVisible"" Value=""True"" />
+                                                </DataTrigger>
+                                            </Label.Triggers>
+                                        </Label>
                                         <Label Text=""{{Binding Result}}"" Grid.Column=""1"" TextColor=""{foregroundColor}""  />
-                                        <Label Text=""{{Binding Function.FunctionType}}"" Grid.Row=""1"" Grid.ColumnSpan=""2"" TextColor=""{foregroundColor}""  />
+                                        <Label Text=""{{Binding Function.FunctionType}}"" Grid.Row=""1"" Grid.ColumnSpan=""2"" TextColor=""{foregroundColor}"" IsVisible=""False"">
+                                            <Label.Triggers>
+                                                <DataTrigger TargetType=""Label"" Binding=""{{Binding Function.FunctionName}}"" Value="""">
+                                                    <Setter Property=""IsVisible"" Value=""True"" />
+                                                </DataTrigger>
+                                                <DataTrigger TargetType=""Label"" Binding=""{{Binding Function.FunctionName}}"" Value=""{{x:Null}}"">
+                                                    <Setter Property=""IsVisible"" Value=""True"" />
+                                                </DataTrigger>
+                                            </Label.Triggers>
+                                        </Label>
+                                        <Label Text=""{{Binding Function.FunctionName}}"" Grid.RowSpan=""2"" FontAttributes=""Bold"" TextColor=""{foregroundColor}"" IsVisible=""True"">
+                                            <Label.Triggers>
+                                                <DataTrigger TargetType=""Label"" Binding=""{{Binding Function.FunctionName}}"" Value="""">
+                                                    <Setter Property=""IsVisible"" Value=""False"" />
+                                                </DataTrigger>
+                                                <DataTrigger TargetType=""Label"" Binding=""{{Binding Function.FunctionName}}"" Value=""{{x:Null}}"">
+                                                    <Setter Property=""IsVisible"" Value=""False"" />
+                                                </DataTrigger>
+                                            </Label.Triggers>
+                                        </Label>
                                     </Grid>
                                 </DataTemplate>
                             </BindableLayout.ItemTemplate>

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/UtilityNetworkTraceTool/UtilityNetworkTraceTool.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/UtilityNetworkTraceTool/UtilityNetworkTraceTool.Theme.xaml
@@ -9,6 +9,7 @@
     <internal:VisibilityConverter x:Key="VisibilityConverter" />
     <internal:ListSizeVisibilityConverter x:Key="ListSizeVisibilityConverter" />
     <internal:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />
+    <internal:EmptyStringToVisibilityConverter x:Key="PlaceholderVisibilityConverter" />
 
     <Style x:Key="UNTraceIcon32Danger" TargetType="Path">
         <Setter Property="Width" Value="32" />
@@ -242,12 +243,21 @@
                                                         Grid.Column="0"
                                                         Margin="2"
                                                         Text="{Binding Function.FunctionType, Mode=OneTime}"
-                                                        TextWrapping="WrapWithOverflow" />
+                                                        TextWrapping="WrapWithOverflow"
+                                                        Visibility="{Binding Function.FunctionName, Converter={StaticResource PlaceholderVisibilityConverter}}" />
                                                     <TextBlock
                                                         Margin="2"
                                                         FontWeight="Bold"
                                                         Text="{Binding Function.NetworkAttribute.Name}"
-                                                        TextWrapping="WrapWithOverflow" />
+                                                        TextWrapping="WrapWithOverflow"
+                                                        Visibility="{Binding Function.FunctionName, Converter={StaticResource PlaceholderVisibilityConverter}}" />
+                                                    <TextBlock
+                                                        Margin="2"
+                                                        FontWeight="Bold"
+                                                        Grid.RowSpan="2"
+                                                        Text="{Binding Function.FunctionName}"
+                                                        TextWrapping="WrapWithOverflow"
+                                                        Visibility="{Binding Function.FunctionName, Converter={StaticResource PlaceholderVisibilityConverter}, ConverterParameter='NotEmpty'}" />
                                                     <TextBlock
                                                         Grid.RowSpan="2"
                                                         Grid.Column="1"

--- a/src/Toolkit/Toolkit.WinUI/UI/Controls/UtilityNetworkTraceTool/UtilityNetworkTraceTool.Theme.xaml
+++ b/src/Toolkit/Toolkit.WinUI/UI/Controls/UtilityNetworkTraceTool/UtilityNetworkTraceTool.Theme.xaml
@@ -12,6 +12,7 @@
     <internal:VisibilityConverter x:Key="VisibilityConverter" />
     <internal:ListSizeVisibilityConverter x:Key="ListSizeVisibilityConverter" />
     <internal:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />
+    <internal:EmptyStringToVisibilityConverter x:Key="PlaceholderVisibilityConverter" />
 
     <Style x:Key="UNTraceIcon32Info" TargetType="Path">
         <Setter Property="Fill" Value="{StaticResource UNTraceTintNormal}" />
@@ -214,11 +215,19 @@
                                                         Grid.Column="0"
                                                         Margin="2"
                                                         Style="{StaticResource UNTraceBasicText}"
-                                                        Text="{Binding Function.FunctionType, Mode=OneTime}" />
+                                                        Text="{Binding Function.FunctionType, Mode=OneTime}"
+                                                        Visibility="{Binding Function.FunctionName, Converter={StaticResource PlaceholderVisibilityConverter}}" />
                                                     <TextBlock
                                                         Margin="2"
                                                         Style="{StaticResource UNTraceBoldText}"
-                                                        Text="{Binding Function.NetworkAttribute.Name}" />
+                                                        Text="{Binding Function.NetworkAttribute.Name}"
+                                                        Visibility="{Binding Function.FunctionName, Converter={StaticResource PlaceholderVisibilityConverter}}" />
+                                                    <TextBlock
+                                                        Margin="2"
+                                                        Grid.RowSpan="2"
+                                                        Style="{StaticResource UNTraceBoldText}"
+                                                        Text="{Binding Function.FunctionName}"
+                                                        Visibility="{Binding Function.FunctionName, Converter={StaticResource PlaceholderVisibilityConverter}, ConverterParameter='NotEmpty'}" />
                                                     <TextBlock
                                                         Grid.RowSpan="2"
                                                         Grid.Column="1"


### PR DESCRIPTION
favor display of `FunctionName` when available; otherwise, fallback to `NetworkAttribute.Name` and `FunctionType`