### PR TITLE
catalyst: Stabilize compass UI tests

### DIFF
--- a/src/Tests/UITests/Toolkit.UITests.Shared/Tests/Compass/CompassTests.cs
+++ b/src/Tests/UITests/Toolkit.UITests.Shared/Tests/Compass/CompassTests.cs
@@ -14,15 +14,14 @@ public class CompassTests : AppiumTestBase
     [DataRow(CompassType.HeadingBound)]
     public async Task Compass_Rotates(CompassType compassType)
     {
-        OpenSample(CompassMapPage);
+        OpenCompassMapPage();
 
         var rotations = new double[] { 0d, 90d, 180d, 270d };
         var expectedOrientations = new CompassOrientation[] { CompassOrientation.North, CompassOrientation.West, CompassOrientation.South, CompassOrientation.East };
         for (var i = 0; i < rotations.Length; i++)
         {
             SetRotation(rotations[i]);
-            var orientation = await GetCompassOrientationAsync(compassType);
-            Assert.AreEqual(expectedOrientations[i], orientation);
+            await WaitForCompassOrientationAsync(compassType, expectedOrientations[i]);
         }
     }
 
@@ -31,7 +30,7 @@ public class CompassTests : AppiumTestBase
     [DataRow(CompassType.HeadingBound)]
     public async Task Compass_AutoHides(CompassType compassType)
     {
-        OpenSample(CompassMapPage);
+        OpenCompassMapPage();
         var compassElement = GetCompassElement(compassType);
 
         // Check that the compass hides when facing north
@@ -40,45 +39,52 @@ public class CompassTests : AppiumTestBase
         Click(autoHideButton);
 
         var maxTries = 5;
-        var tryCount = 0;
-        while (tryCount < maxTries)
+        var hidden = false;
+        for (var tryCount = 0; tryCount < maxTries; tryCount++)
         {
-            var screenshot = GetScreenshot(compassElement);
+            using var screenshot = GetScreenshot(compassElement);
             // If nothing renders (ie. the screenshot is a uniform color) the compass successfully hid
             if (screenshot.Histogram().Count < 2)
+            {
+                hidden = true;
                 break;
+            }
 
             // Otherwise continue waiting
-            tryCount++;
-            if (tryCount < maxTries)
+            if (tryCount < maxTries - 1)
                 await Task.Delay(500);
         }
-        Assert.IsLessThan(maxTries, tryCount, "Exceeded timeout while waiting for the compass to hide.");
+        Assert.IsTrue(hidden, "Exceeded timeout while waiting for the compass to hide.");
 
         // Check that the compass renders back in when not facing north
         SetRotation(90);
-        var compassDirection = await GetCompassOrientationAsync(compassType);
-        Assert.AreEqual(CompassOrientation.West, compassDirection);
+        await WaitForCompassOrientationAsync(compassType, CompassOrientation.West);
     }
 
     [TestMethod]
     public async Task Compass_ClickToResetMapRotation()
     {
-        OpenSample(CompassMapPage);
+        OpenCompassMapPage();
 
         SetRotation(90d);
 
         var compassElement = GetCompassElement(CompassType.MapBound);
         Click(compassElement);
 
-        var mapRotationElement = FindElement("MapRotationText");
-        var mapRotation = double.Parse(mapRotationElement.Text);
-        Assert.AreEqual(0, mapRotation, 0.001);
+        await WaitForMapRotationAsync(0);
     }
 
-    private AppiumElement GetCompassElement(CompassType compassType)
+    private void OpenCompassMapPage()
     {
-        return FindElement(compassType == CompassType.MapBound ? "MapCompass" : "HeadingCompass");
+        OpenSample(CompassMapPage);
+        FindElement("RotateInput", TimeSpan.FromSeconds(2));
+        GetCompassElement(CompassType.MapBound, TimeSpan.FromSeconds(2));
+        GetCompassElement(CompassType.HeadingBound, TimeSpan.FromSeconds(2));
+    }
+
+    private AppiumElement GetCompassElement(CompassType compassType, TimeSpan? timeout = null)
+    {
+        return FindElement(compassType == CompassType.MapBound ? "MapCompass" : "HeadingCompass", timeout);
     }
 
     private void SetRotation(double rotation)
@@ -90,51 +96,47 @@ public class CompassTests : AppiumTestBase
     }
 
     /// <summary>
-    /// Gets the orientation of the specified compass based on a screenshot analysis. If the compass is hidden or stuck partially
-    /// transparent, the function will raise an Assert.Fail exception.
+    /// Waits for the compass to report the expected orientation based on screenshot analysis.
     /// </summary>
-    private async Task<CompassOrientation> GetCompassOrientationAsync(CompassType compassType)
+    private async Task WaitForCompassOrientationAsync(CompassType compassType, CompassOrientation expectedOrientation)
     {
         var compassElement = GetCompassElement(compassType);
-        MagickImage? compassScreenshot = null;
+        var timeout = TimeSpan.FromSeconds(4);
+        var retryDelay = TimeSpan.FromMilliseconds(200);
+        var endTime = DateTime.UtcNow + timeout;
+        CompassAnalysis? lastAnalysis = null;
 
-        // Wait for the compass to fade in
-        var loaded = false;
-        var tryCount = 0;
-        while (tryCount < 10)
+        do
         {
-            var screenshot = GetScreenshot(compassElement);
+            using var screenshot = GetScreenshot(compassElement);
+            lastAnalysis = AnalyzeCompassOrientation(screenshot);
 
-            foreach (var color in screenshot.GetPixels())
-            {
-                if (color[0] >= 128 && (color[1] + color[2] == 0))
-                {
-                    loaded = true;
-                    compassScreenshot = screenshot;
-                    break;
-                }
-            }
+            if (lastAnalysis.Value.Orientation == expectedOrientation)
+                return;
 
-            if (loaded)
-                break;
-
-            tryCount++;
-            await Task.Delay(200);
+            if (DateTime.UtcNow < endTime)
+                await Task.Delay(retryDelay);
         }
+        while (DateTime.UtcNow < endTime);
 
-        if (!loaded)
-            Assert.Fail("Compass never finished fading in. If the compass is rendering visually, make sure any screen overlays (such as blue light filters) are turned off.");
+        Assert.Fail($"Compass {compassType} did not reach expected orientation {expectedOrientation} within {timeout.TotalSeconds:0.#} seconds. {FormatAnalysis(lastAnalysis)}");
+    }
 
-        // Mask to only red pixels (aka the north arrow)
-        compassScreenshot!.ColorThreshold(new MagickColor(128, 0, 0), new MagickColor(255, 80, 80));
+    private static CompassAnalysis AnalyzeCompassOrientation(MagickImage compassScreenshot)
+    {
+        // Mask to only red pixels (aka the north arrow).
+        compassScreenshot.ColorThreshold(new MagickColor(128, 0, 0), new MagickColor(255, 80, 80));
 
-        // Get the arrow connected component
         var connectedComponents = compassScreenshot.ConnectedComponents(4);
-        var arrowComponent = connectedComponents[1];
-
-        // Determine direction based on the arrow's offset from center
+        var componentCount = Math.Max(0, connectedComponents.Count - 1);
         var imageCenterX = compassScreenshot.Width / 2d;
         var imageCenterY = compassScreenshot.Height / 2d;
+
+        if (componentCount == 0)
+            return new CompassAnalysis(CompassOrientation.Unknown, componentCount, null, null);
+
+        // ConnectedComponents includes the background as the first component. The arrow is the largest remaining blob.
+        var arrowComponent = connectedComponents.Skip(1).OrderByDescending(component => component.Area).First();
         var offset = new PointD(arrowComponent.Centroid.X - imageCenterX, arrowComponent.Centroid.Y - imageCenterY);
 
         var direction = CompassOrientation.Unknown;
@@ -152,7 +154,45 @@ public class CompassTests : AppiumTestBase
             else if (offset.X > 1d)
                 direction = CompassOrientation.East;
         }
-        return direction;
+        return new CompassAnalysis(direction, componentCount, arrowComponent.Centroid, offset);
+    }
+
+    private static string FormatAnalysis(CompassAnalysis? analysis)
+    {
+        if (analysis is null)
+            return "No screenshots were analyzed.";
+
+        return $"Last orientation: {analysis.Value.Orientation}; component count: {analysis.Value.ComponentCount}; centroid: {FormatPoint(analysis.Value.Centroid)}; offset: {FormatPoint(analysis.Value.Offset)}.";
+    }
+
+    private static string FormatPoint(PointD? point)
+    {
+        return point is null ? "none" : $"({point.Value.X:0.##}, {point.Value.Y:0.##})";
+    }
+
+    private async Task WaitForMapRotationAsync(double expectedRotation)
+    {
+        var mapRotationElement = FindElement("MapRotationText");
+        var timeout = TimeSpan.FromSeconds(4);
+        var retryDelay = TimeSpan.FromMilliseconds(200);
+        var endTime = DateTime.UtcNow + timeout;
+        double? lastRotation = null;
+
+        do
+        {
+            if (double.TryParse(GetElementText(mapRotationElement), out var mapRotation))
+            {
+                lastRotation = mapRotation;
+                if (Math.Abs(mapRotation - expectedRotation) <= 0.001)
+                    return;
+            }
+
+            if (DateTime.UtcNow < endTime)
+                await Task.Delay(retryDelay);
+        }
+        while (DateTime.UtcNow < endTime);
+
+        Assert.Fail($"Map rotation did not reach {expectedRotation} within {timeout.TotalSeconds:0.#} seconds. Last rotation: {(lastRotation.HasValue ? lastRotation.Value.ToString("0.###") : "unreadable")}.");
     }
 
     public enum CompassType
@@ -169,4 +209,6 @@ public class CompassTests : AppiumTestBase
         East = 3,
         West = 4
     }
+
+    private readonly record struct CompassAnalysis(CompassOrientation Orientation, int ComponentCount, PointD? Centroid, PointD? Offset);
 }

--- a/src/Tests/UITests/Toolkit.UITests.TestPages.Shared/CompassMap.xaml.cs
+++ b/src/Tests/UITests/Toolkit.UITests.TestPages.Shared/CompassMap.xaml.cs
@@ -36,8 +36,19 @@ public partial class CompassMap : TestPage
     private async void RotateButton_Click(object sender, ClickEventArgs e)
     {
         var heading = double.Parse(RotateInput.Text);
-        Heading = heading;
+        Heading = NormalizeHeadingForCompass(heading);
         await MainMapView.SetViewpointRotationAsync(heading);
+    }
+
+    private static double NormalizeHeadingForCompass(double heading)
+    {
+        var normalized = heading % 360;
+        if (normalized <= -180)
+            normalized += 360;
+        else if (normalized > 180)
+            normalized -= 360;
+
+        return normalized;
     }
 
     private void ToggleAutoHideButton_Click(object sender, ClickEventArgs e)


### PR DESCRIPTION
Wait for Compass_Rotates to observe the expected orientation instead of sampling the first screenshot that contains red pixels. This gives Catalyst and mac2 time to reflect visual rotation changes before assertions run.

Normalize the standalone heading bound to the test compass so equivalent angles avoid the raw 270 -> -270 visual rotation path that has been unreliable on Catalyst. The map still receives the original rotation value.

Fix the Compass_AutoHides timeout assertion and wait for the reset test's map rotation label through the platform-specific text accessor.