### PR TITLE
UITest maintenance

### DIFF
--- a/src/Esri.ArcGISRuntime.Toolkit.sln
+++ b/src/Esri.ArcGISRuntime.Toolkit.sln
@@ -49,6 +49,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "UITests", "UITests", "{78A5
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Toolkit.UITests.Wpf", "Tests\UITests\Toolkit.UITests.Wpf\Toolkit.UITests.Wpf.csproj", "{3046611A-ABBE-4433-A5A2-CFC98060C709}"
 	ProjectSection(ProjectDependencies) = postProject
+		{0091134B-D36A-89D1-563B-A85047EA0EEA} = {0091134B-D36A-89D1-563B-A85047EA0EEA}
 		{531B2297-2343-4692-8D66-878B0AD158CD} = {531B2297-2343-4692-8D66-878B0AD158CD}
 	EndProjectSection
 EndProject
@@ -64,6 +65,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Toolkit.UITests.Maui.App", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Toolkit.UITests.MauiWinUI", "Tests\UITests\Toolkit.UITests.MauiWinUI\Toolkit.UITests.MauiWinUI.csproj", "{F4979959-EA7D-452E-A673-87767F5F59E6}"
 	ProjectSection(ProjectDependencies) = postProject
+		{0091134B-D36A-89D1-563B-A85047EA0EEA} = {0091134B-D36A-89D1-563B-A85047EA0EEA}
 		{F7F98CE8-5304-460D-83A2-F4F7FE50B370} = {F7F98CE8-5304-460D-83A2-F4F7FE50B370}
 	EndProjectSection
 EndProject

--- a/src/Tests/UITests/Toolkit.UITests.MauiiOS/AppiumSetup.MauiIOS.cs
+++ b/src/Tests/UITests/Toolkit.UITests.MauiiOS/AppiumSetup.MauiIOS.cs
@@ -19,9 +19,9 @@ public static partial class AppiumSetup
         var environmentVariables = Environment.GetEnvironmentVariables();
         foreach (DictionaryEntry variable in environmentVariables)
         {
-            if (variable.Key is string key && key.StartsWith("TKUITEST_PARAM_"))
+            if (variable.Key is string key && key.StartsWith("TKUITEST_PARAM_") && variable.Value is string value)
             {
-                buildSettings[key.Substring(15)] = (string)variable.Value;
+                buildSettings[key.Substring(15)] = value;
             }
         }
 

--- a/src/Tests/UITests/Toolkit.UITests.WinUI.App/Toolkit.UITests.WinUI.App.csproj
+++ b/src/Tests/UITests/Toolkit.UITests.WinUI.App/Toolkit.UITests.WinUI.App.csproj
@@ -15,9 +15,6 @@
     <LangVersion>latest</LangVersion>
     <DefineConstants>$(DefineConstants);WINUI_APP</DefineConstants>
   </PropertyGroup>
-  <ItemGroup>
-    <None Remove="TestPages\ScaleLines.xaml" />
-  </ItemGroup>
 
   <ItemGroup>
     <Content Include="Assets\SplashScreen.scale-200.png" />

--- a/src/Tests/UITests/cibuild/cibuild.cs
+++ b/src/Tests/UITests/cibuild/cibuild.cs
@@ -109,7 +109,7 @@ internal class Program
             var runnerExe = Path.Join(artifactsPath, buildSettings.RunnerName, "TestBuild", buildSettings.RunnerName);
             var appExe = Path.Join(artifactsPath, buildSettings.AppName, "TestBuild", buildSettings.BinaryName);
             Environment.SetEnvironmentVariable("TKUITEST_APP", appExe);
-            RunBinary(runnerExe, $"{string.Join(" ", buildSettings.TestParams)}");
+            RunBinary(runnerExe, $"{string.Join(" ", buildSettings.TestParams)}", throwOnError: false);
         }
         finally {
             OnBuildEnding();

--- a/src/Tests/UITests/cibuild/cibuild.cs
+++ b/src/Tests/UITests/cibuild/cibuild.cs
@@ -74,9 +74,9 @@ internal class Program
             // Platform-specific setup
             BuildSettings buildSettings = testPlatform switch
             {
-                "MauiAndroid" => SetupAndroid(dependencies, nodeWorkspace, toolkitSrc, workspace, apiKey),
-                "MauiMac" => SetupMac(dependencies, workspace, apiKey),
-                "MauiiOS" => SetupiOS(dependencies, workspace, apiKey),
+                "MauiAndroid" => SetupAndroid(dependencies, nodeWorkspace, toolkitSrc, workspace, apiKey, args),
+                "MauiMac" => SetupMac(dependencies, workspace, apiKey, args),
+                "MauiiOS" => SetupiOS(dependencies, workspace, apiKey, args),
                 _ => throw new ArgumentException($"The test platform '{testPlatform}' was not recognized. Aborting tests.")
             };
 
@@ -232,7 +232,7 @@ internal class Program
 #endregion
 
 #region PlatformDependencies
-    private static BuildSettings SetupMac(CommonDependencies dependencies, string workspace, string apiKey)
+    private static BuildSettings SetupMac(CommonDependencies dependencies, string workspace, string apiKey, string[] consoleArgs)
     {
         // Define build settings
         var buildSettings = new BuildSettings("Toolkit.UITests.Maui.App", "Toolkit.UITests.MauiMac");
@@ -243,7 +243,7 @@ internal class Program
         ]);
         var testAppPackage = "Toolkit.UITests.Maui.App.app";
         buildSettings.BinaryName = testAppPackage;
-        AppendPlatformIndependentBuildSettings(buildSettings, workspace, apiKey);
+        AppendPlatformIndependentBuildSettings(buildSettings, workspace, apiKey, consoleArgs);
 
         // Install maui maccatalyst workload
         Console.WriteLine("\nInstalling maui workload...");
@@ -281,7 +281,7 @@ internal class Program
         return buildSettings;
     }
 
-    private static BuildSettings SetupiOS(CommonDependencies dependencies, string workspace, string apiKey)
+    private static BuildSettings SetupiOS(CommonDependencies dependencies, string workspace, string apiKey, string[] consoleArgs)
     {
         // Define build settings
         var buildSettings = new BuildSettings("Toolkit.UITests.Maui.App", "Toolkit.UITests.MauiiOS");
@@ -291,7 +291,7 @@ internal class Program
             "-r ios-arm64"
         ]);
         buildSettings.BinaryName = "Toolkit.UITests.Maui.App.app";
-        AppendPlatformIndependentBuildSettings(buildSettings, workspace, apiKey);
+        AppendPlatformIndependentBuildSettings(buildSettings, workspace, apiKey, consoleArgs);
 
         // This particular setting only applies to the Runner, and is unused by the app
         buildSettings.BuildParamsCommon.Add("-p:BuildApp=false");
@@ -347,7 +347,7 @@ internal class Program
         return buildSettings;
     }
 
-    private static BuildSettings SetupAndroid(CommonDependencies dependencies, string nodeWorkspace, string toolkitSrc, string workspace, string apiKey)
+    private static BuildSettings SetupAndroid(CommonDependencies dependencies, string nodeWorkspace, string toolkitSrc, string workspace, string apiKey, string[] consoleArgs)
     {
         var jdkDirectory = $"{workspace}/jdk";
         var androidSdkDirectory = $"{workspace}/android-sdk";
@@ -362,7 +362,7 @@ internal class Program
             $"-p:AndroidSdkDirectory={androidSdkDirectory}"
         ]);
         buildSettings.BinaryName = "com.esri.toolkit.uitests.maui-Signed.apk";
-        AppendPlatformIndependentBuildSettings(buildSettings, workspace, apiKey);
+        AppendPlatformIndependentBuildSettings(buildSettings, workspace, apiKey, consoleArgs);
 
         // Install maui android
         Console.WriteLine("\nInstalling maui maui workload...");
@@ -397,7 +397,7 @@ internal class Program
 #endregion
 
 #region BuildSettings
-    private static void AppendPlatformIndependentBuildSettings(BuildSettings settings, string workspace, string apiKey)
+    private static void AppendPlatformIndependentBuildSettings(BuildSettings settings, string workspace, string apiKey, string[] consoleArgs)
     {
         // Universal build parameters for the ci builds
         settings.BuildParamsCommon.AddRange([
@@ -421,6 +421,15 @@ internal class Program
         var trxFilename = Environment.GetEnvironmentVariable("TRX_FILENAME");
         if (!string.IsNullOrWhiteSpace(trxFilename)) {
             settings.TestParams.Add($"--report-trx-filename {trxFilename}");
+        }
+
+        // Append filter from console arguments if it exists
+        var filterArgIndex = consoleArgs.IndexOf("--filter");
+        if (filterArgIndex > -1)
+        {
+            if (filterArgIndex + 1 >= consoleArgs.Length)
+                throw new ArgumentException("Recieved '--filter' flag, but no argument was provided.");
+            settings.TestParams.AddRange(["--filter", consoleArgs[filterArgIndex+1]]);
         }
 
         // API key

--- a/src/Tests/UITests/cibuild/cibuild.sh
+++ b/src/Tests/UITests/cibuild/cibuild.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-test_platform=$1
-
 function main {
   if [ -z "${WORKSPACE}" ]; then
     echo "WORKSPACE not set. Aborting dotnet install." 1>&2
@@ -16,7 +14,7 @@ function main {
   install_dotnet "${WORKSPACE}" "${dotnet_version}" "${DOTNET_CACHE_FOLDER}"
 
   export TOOLKIT_SRC=$(realpath "${script_dir}/../../../")
-  "${DOTNET_PATH}" run "${script_dir}/cibuild.cs" -- $1
+  "${DOTNET_PATH}" run "${script_dir}/cibuild.cs" -- $@
 }
 
 function install_dotnet {
@@ -47,4 +45,4 @@ function read_yaml_var {
   grep "^${varname}" "${yml_file}" | sed -E "s/^${varname}: \"(.*)\"/\1/"
 }
 
-main "${test_platform}"
+main "${@}"


### PR DESCRIPTION
A couple quick fixes/improvements:
1. Remove redundant build item in winui test runner (the xaml file it included is already covered by a wildcard item)
2. Add option to pass mstest filter argument to cibuild script for mac/ios/android (not windows for now since the same functionality should be easy to accomplish with the test explorer)
3. No longer throw exception when tests fail since it was showing up in the test results as an error when they did
4. Fixes visual studio not finding the code generator when doing the auto build for WPF/MauiWinUI
5. Address a nullability warning in the iOS runner