### PR TITLE
UITests ScaleLine updates

### DIFF
--- a/src/Tests/UITests/Toolkit.UITests.Maui.App/TestPages/ScaleLine/ScaleLines.xaml
+++ b/src/Tests/UITests/Toolkit.UITests.Maui.App/TestPages/ScaleLine/ScaleLines.xaml
@@ -14,17 +14,18 @@
                 Background="{StaticResource CalciteBackground1Brush}"
                 Stroke="{StaticResource CalciteBorder1Brush}">
             <StackLayout Margin="5">
-                <StackLayout Orientation="Horizontal" Margin="0,0,0,5">
-                    <Label Text="Scale: 1 / " Margin="1,1,0,1" VerticalOptions="Center"/>
-                    <Entry x:Name="ScaleTextBox" AutomationId="ScaleTextBox" Text="50000000" MinimumWidthRequest="60" FontSize="14"/>
-                </StackLayout>
-
-                <StackLayout Orientation="Horizontal" Margin="0,0,0,5">
-                    <Label Text="Latitude: " Margin="1,1,3,1" VerticalOptions="Center"/>
-                    <Entry x:Name="LatitudeTextBox" AutomationId="LatitudeTextBox" Text="0" MinimumWidthRequest="60" FontSize="14"/>
-                </StackLayout>
-
-                <Button x:Name="UpdateViewpoint" AutomationId="UpdateViewpoint" Text="Update Viewpoint" Clicked="UpdateViewpoint_Click" />
+                <Button x:Name="WorldEquatorViewpoint"
+                        AutomationId="WorldEquatorViewpoint"
+                        Text="World / Equator"
+                        Clicked="WorldEquatorViewpoint_Click" />
+                <Button x:Name="EquatorDetailViewpoint"
+                        AutomationId="EquatorDetailViewpoint"
+                        Text="Detail / Equator"
+                        Clicked="EquatorDetailViewpoint_Click" />
+                <Button x:Name="HighLatitudeDetailViewpoint"
+                        AutomationId="HighLatitudeDetailViewpoint"
+                        Text="Detail / Latitude 60"
+                        Clicked="HighLatitudeDetailViewpoint_Click" />
             </StackLayout>
         </Border>
 

--- a/src/Tests/UITests/Toolkit.UITests.Shared/Tests/ScaleLine/ScaleLineTests.cs
+++ b/src/Tests/UITests/Toolkit.UITests.Shared/Tests/ScaleLine/ScaleLineTests.cs
@@ -118,9 +118,9 @@ public class ScaleLineTests : AppiumTestBase
     private AppiumElement GetScaleElement(ScaleLineType type)
     {
         if (type == ScaleLineType.Advanced)
-            return FindElement("AdvancedScaleLine");
+            return FindElement("AdvancedScaleLine", TimeSpan.FromSeconds(5));
         else if (type == ScaleLineType.Simple)
-            return FindElement("SimpleScaleLine");
+            return FindElement("SimpleScaleLine", TimeSpan.FromSeconds(5));
         else
             throw new ArgumentOutOfRangeException(nameof(type), type, "Invalid scale line type.");
     }

--- a/src/Tests/UITests/Toolkit.UITests.Shared/Tests/ScaleLine/ScaleLineTests.cs
+++ b/src/Tests/UITests/Toolkit.UITests.Shared/Tests/ScaleLine/ScaleLineTests.cs
@@ -6,6 +6,7 @@ namespace Toolkit.UITest.Shared.ScaleLine;
 public class ScaleLineTests : AppiumTestBase
 {
     private const string ScaleLinePage = "ScaleLines";
+    private readonly TimeSpan _defaultTimeout = TimeSpan.FromSeconds(5);
 
     [TestMethod]
     [DataRow(ScaleLineType.Advanced)]
@@ -118,9 +119,9 @@ public class ScaleLineTests : AppiumTestBase
     private AppiumElement GetScaleElement(ScaleLineType type)
     {
         if (type == ScaleLineType.Advanced)
-            return FindElement("AdvancedScaleLine", TimeSpan.FromSeconds(5));
+            return FindElement("AdvancedScaleLine", _defaultTimeout);
         else if (type == ScaleLineType.Simple)
-            return FindElement("SimpleScaleLine", TimeSpan.FromSeconds(5));
+            return FindElement("SimpleScaleLine", _defaultTimeout);
         else
             throw new ArgumentOutOfRangeException(nameof(type), type, "Invalid scale line type.");
     }
@@ -132,7 +133,7 @@ public class ScaleLineTests : AppiumTestBase
             ViewpointPreset.WorldEquator => "WorldEquatorViewpoint",
             ViewpointPreset.DetailEquator => "EquatorDetailViewpoint",
             ViewpointPreset.DetailHighLatitude => "HighLatitudeDetailViewpoint",
-            _ => throw new ArgumentOutOfRangeException(nameof(preset), preset, "Invalid viewpoint preset.")
+            _ => throw new ArgumentOutOfRangeException(nameof(preset), "Invalid viewpoint preset.")
         };
 
         var button = FindElement(buttonAutomationId);

--- a/src/Tests/UITests/Toolkit.UITests.Shared/Tests/ScaleLine/ScaleLineTests.cs
+++ b/src/Tests/UITests/Toolkit.UITests.Shared/Tests/ScaleLine/ScaleLineTests.cs
@@ -13,7 +13,7 @@ public class ScaleLineTests : AppiumTestBase
     public async Task ScaleLine_Renders(ScaleLineType scaleLineType)
     {
         OpenSample(ScaleLinePage);
-        UpdateViewpoint(50000000, 0);
+        SelectViewpoint(ViewpointPreset.WorldEquator);
 
         // Check initial render
         var scaleLineInfo = GetScaleLineInfo(scaleLineType);
@@ -36,10 +36,10 @@ public class ScaleLineTests : AppiumTestBase
     {
         OpenSample(ScaleLinePage);
 
-        UpdateViewpoint(50000000, 0);
+        SelectViewpoint(ViewpointPreset.WorldEquator);
         var initialScaleLineInfo = GetScaleLineInfo(scaleLineType);
 
-        UpdateViewpoint(5000000, 0);
+        SelectViewpoint(ViewpointPreset.DetailEquator);
         var finalScaleLineInfo = GetScaleLineInfo(scaleLineType);
 
         var scaleRatioMetric = finalScaleLineInfo.MetricScale / initialScaleLineInfo.MetricScale;
@@ -58,10 +58,10 @@ public class ScaleLineTests : AppiumTestBase
     {
         OpenSample(ScaleLinePage);
 
-        UpdateViewpoint(5000000, 0);
+        SelectViewpoint(ViewpointPreset.DetailEquator);
         var initialInfo = GetScaleLineInfo(scaleLineType);
 
-        UpdateViewpoint(5000000, 60);
+        SelectViewpoint(ViewpointPreset.DetailHighLatitude);
         var finalInfo = GetScaleLineInfo(scaleLineType);
 
         if (scaleLineType == ScaleLineType.Advanced)
@@ -125,16 +125,25 @@ public class ScaleLineTests : AppiumTestBase
             throw new ArgumentOutOfRangeException(nameof(type), type, "Invalid scale line type.");
     }
 
-    private void UpdateViewpoint(int scale, int latitude)
+    private void SelectViewpoint(ViewpointPreset preset)
     {
-        var scaleInputElement = FindElement("ScaleTextBox");
-        SubmitText(scaleInputElement, scale.ToString());
+        var buttonAutomationId = preset switch
+        {
+            ViewpointPreset.WorldEquator => "WorldEquatorViewpoint",
+            ViewpointPreset.DetailEquator => "EquatorDetailViewpoint",
+            ViewpointPreset.DetailHighLatitude => "HighLatitudeDetailViewpoint",
+            _ => throw new ArgumentOutOfRangeException(nameof(preset), preset, "Invalid viewpoint preset.")
+        };
 
-        var latitudeInputElement = FindElement("LatitudeTextBox");
-        SubmitText(latitudeInputElement, latitude.ToString());
+        var button = FindElement(buttonAutomationId);
+        Click(button);
+    }
 
-        var updateButtonElement = FindElement("UpdateViewpoint");
-        Click(updateButtonElement);
+    private enum ViewpointPreset
+    {
+        WorldEquator,
+        DetailEquator,
+        DetailHighLatitude
     }
 
     public enum ScaleLineType

--- a/src/Tests/UITests/Toolkit.UITests.TestPages.Shared/ScaleLine/ScaleLines.xaml.cs
+++ b/src/Tests/UITests/Toolkit.UITests.TestPages.Shared/ScaleLine/ScaleLines.xaml.cs
@@ -14,6 +14,9 @@ namespace Toolkit.UITests.App.TestPages;
 
 public partial class ScaleLines : TestPage
 {
+    private const double WorldScale = 50000000;
+    private const double DetailScale = 5000000;
+
     public ScaleLines()
     {
         InitializeComponent();
@@ -23,11 +26,23 @@ public partial class ScaleLines : TestPage
         MainMapView.Map = map;
     }
 
-    private void UpdateViewpoint_Click(object sender, ClickEventArgs e)
+    private void WorldEquatorViewpoint_Click(object sender, ClickEventArgs e)
     {
-        var scale = double.Parse(ScaleTextBox.Text);
-        var latitude = double.Parse(LatitudeTextBox.Text);
+        SetViewpoint(WorldScale, 0);
+    }
 
+    private void EquatorDetailViewpoint_Click(object sender, ClickEventArgs e)
+    {
+        SetViewpoint(DetailScale, 0);
+    }
+
+    private void HighLatitudeDetailViewpoint_Click(object sender, ClickEventArgs e)
+    {
+        SetViewpoint(DetailScale, 60);
+    }
+
+    private void SetViewpoint(double scale, double latitude)
+    {
         var center = new MapPoint(0, latitude, SpatialReferences.Wgs84);
         MainMapView.SetViewpoint(new Viewpoint(center, scale));
     }

--- a/src/Tests/UITests/Toolkit.UITests.WinUI.App/TestPages/ScaleLine/ScaleLines.xaml
+++ b/src/Tests/UITests/Toolkit.UITests.WinUI.App/TestPages/ScaleLine/ScaleLines.xaml
@@ -19,17 +19,18 @@
                 BorderBrush="{ThemeResource CalciteBorder1Color}"
                 BorderThickness="1">
             <StackPanel Margin="5">
-                <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
-                    <TextBlock Text="Scale: 1 / " Margin="1,1,0,1" VerticalAlignment="Center"/>
-                    <TextBox x:Name="ScaleTextBox" Text="50000000" MinWidth="60" FontSize="14"/>
-                </StackPanel>
-
-                <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
-                    <TextBlock Text="Latitude: " Margin="1,1,3,1" VerticalAlignment="Center"/>
-                    <TextBox x:Name="LatitudeTextBox" Text="0" MinWidth="60" FontSize="14"/>
-                </StackPanel>
-
-                <Button x:Name="UpdateViewpoint" Content="Update Viewpoint" Click="UpdateViewpoint_Click" />
+                <Button x:Name="WorldEquatorViewpoint"
+                        AutomationProperties.AutomationId="WorldEquatorViewpoint"
+                        Content="World / Equator"
+                        Click="WorldEquatorViewpoint_Click" />
+                <Button x:Name="EquatorDetailViewpoint"
+                        AutomationProperties.AutomationId="EquatorDetailViewpoint"
+                        Content="Detail / Equator"
+                        Click="EquatorDetailViewpoint_Click" />
+                <Button x:Name="HighLatitudeDetailViewpoint"
+                        AutomationProperties.AutomationId="HighLatitudeDetailViewpoint"
+                        Content="Detail / Latitude 60"
+                        Click="HighLatitudeDetailViewpoint_Click" />
             </StackPanel>
         </Border>
 

--- a/src/Tests/UITests/Toolkit.UITests.Wpf.App/TestPages/ScaleLine/ScaleLines.xaml
+++ b/src/Tests/UITests/Toolkit.UITests.Wpf.App/TestPages/ScaleLine/ScaleLines.xaml
@@ -13,17 +13,18 @@
 
         <Border Background="White" BorderBrush="Black" BorderThickness="1" HorizontalAlignment="Left" VerticalAlignment="Top">
             <StackPanel Margin="5">
-                <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
-                    <TextBlock Text="Scale: 1 / " Margin="1,1,0,1" VerticalAlignment="Center"/>
-                    <TextBox x:Name="ScaleTextBox" Text="50000000" MinWidth="60" Padding="1"/>
-                </StackPanel>
-                
-                <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
-                    <TextBlock Text="Latitude: " Margin="1,1,3,1" VerticalAlignment="Center"/>
-                    <TextBox x:Name="LatitudeTextBox" Text="0" MinWidth="60" Padding="1"/>
-                </StackPanel>
-                    
-                <Button x:Name="UpdateViewpoint" Content="Update Viewpoint" Padding="1" Click="UpdateViewpoint_Click"/>
+                <Button x:Name="WorldEquatorViewpoint"
+                        AutomationProperties.AutomationId="WorldEquatorViewpoint"
+                        Content="World / Equator"
+                        Click="WorldEquatorViewpoint_Click"/>
+                <Button x:Name="EquatorDetailViewpoint"
+                        AutomationProperties.AutomationId="EquatorDetailViewpoint"
+                        Content="Detail / Equator"
+                        Click="EquatorDetailViewpoint_Click"/>
+                <Button x:Name="HighLatitudeDetailViewpoint"
+                        AutomationProperties.AutomationId="HighLatitudeDetailViewpoint"
+                        Content="Detail / Latitude 60"
+                        Click="HighLatitudeDetailViewpoint_Click"/>
             </StackPanel>
         </Border>
 


### PR DESCRIPTION
This PR does has two parts:
1. Adds a timeout for finding the scale line elements which should help with the occasional flakiness in the ci tests
2. Uses buttons instead of entries for updating the viewpoint since there are only 3 viewpoints and it is quicker for appium to find and press buttons than multiple entries