### PR TITLE
UITests: Small tweak to viewpoint on one of the SearchView tests

### DIFF
--- a/src/Tests/UITests/Toolkit.UITests.TestPages.Shared/SearchView/SearchViewControlMap.xaml.cs
+++ b/src/Tests/UITests/Toolkit.UITests.TestPages.Shared/SearchView/SearchViewControlMap.xaml.cs
@@ -25,7 +25,7 @@ public partial class SearchViewControlMap : TestPage
 
     private void UpdateViewpointExtentToUSA_Click(object sender, ClickEventArgs e)
     {
-        UpdateViewpoint_Click(50000000, -95, 37);
+        UpdateViewpoint_Click(50000000, -115, 37);
     }
 
     private void UpdateViewpointExtentToOntario_Click(object sender, ClickEventArgs e)


### PR DESCRIPTION
The `SearchViewControl_SearchSuggestions` test used the `UpdateViewpointExtentToUSA` to take the map to a viewpoint that was expected to cover ontario international airport. The existing viewpoint was a bit too close to the center of the US and did not include ontario as the CI test device is very narrow, which caused the test to fail. This PR just shifts the viewpoint west.