### PR TITLE
Fix SearchView source race when default geocoder config reruns

### DIFF
--- a/src/Toolkit/Toolkit/UI/Controls/SearchView/SearchViewModel.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/SearchView/SearchViewModel.cs
@@ -56,9 +56,11 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
 
         private bool _searchInProgress;
         private bool _suggestInProgress;
+        private LocatorSearchSource? _defaultWorldGeocoderSource;
 
         private CancellationTokenSource? _activeSearchCancellation;
         private CancellationTokenSource? _activeSuggestCancellation;
+        private readonly object _defaultSourceConfigurationSync = new();
 
         /// <summary>
         /// Gets or sets the active search source, if one is selected. If there is no selection, all sources will be used for the search.
@@ -546,8 +548,32 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         /// <param name="token">Token used for cancellation.</param>
         public async Task ConfigureDefaultWorldGeocoder(CancellationToken token = default)
         {
-            Sources.Clear();
-            Sources.Add(await LocatorSearchSource.CreateDefaultSourceAsync(token));
+            LocatorSearchSource? source;
+
+            lock (_defaultSourceConfigurationSync)
+            {
+                source = _defaultWorldGeocoderSource;
+            }
+
+            if (source == null)
+            {
+                source = await LocatorSearchSource.CreateDefaultSourceAsync(token);
+                token.ThrowIfCancellationRequested();
+
+                lock (_defaultSourceConfigurationSync)
+                {
+                    _defaultWorldGeocoderSource ??= source;
+                    source = _defaultWorldGeocoderSource;
+                }
+            }
+
+            lock (_defaultSourceConfigurationSync)
+            {
+                if (!Sources.Contains(source))
+                {
+                    Sources.Add(source);
+                }
+            }
         }
 
         private List<ISearchSource> SourcesToSearch()


### PR DESCRIPTION
Fixes a SearchView race where custom search sources could be removed when default world geocoder configuration reran (for example after binding/GeoView changes).
ConfigureDefaultWorldGeocoder is now non-destructive and only ensures the default source exists, preserving custom sources.

- Caches the default world geocoder source in SearchViewModel
- Adds the default source only if it is missing.
- Synchronizes access to avoid race conditions during concurrent/lifecycle-triggered configuration.
