### PR TITLE
UITests: Suppress mstest error code 2 in ci builds

### DIFF
--- a/src/Tests/UITests/cibuild/cibuild.cs
+++ b/src/Tests/UITests/cibuild/cibuild.cs
@@ -423,6 +423,10 @@ internal class Program
             settings.TestParams.Add($"--report-trx-filename {trxFilename}");
         }
 
+        // Ignore exit code 2 in test results since it just means that one or more tests failed
+        // https://learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-troubleshooting
+        settings.TestParams.Add("--ignore-exit-code 2");
+
         // Append filter from console arguments if it exists
         var filterArgIndex = consoleArgs.IndexOf("--filter");
         if (filterArgIndex > -1)

--- a/src/Tests/UITests/cibuild/utils.psm1
+++ b/src/Tests/UITests/cibuild/utils.psm1
@@ -150,6 +150,10 @@ function Invoke-WindowsUITests {
         $test_run_params += @('--report-trx-filename', $trx_filename)
       }
 
+      # Ignore exit code 2 in test results since it just means that one or more tests failed
+      # https://learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-troubleshooting
+      $test_run_params += @('--ignore-exit-code 2')
+
       $env:TKUITEST_APP = Join-Path $PSScriptRoot "..\artifacts\bin\${app_name}\TestBuild\${app_name}.exe"
       & $dotnet_exe test --project $runner_project @build_parameters @test_run_params
     }

--- a/src/Tests/UITests/cibuild/utils.psm1
+++ b/src/Tests/UITests/cibuild/utils.psm1
@@ -152,7 +152,7 @@ function Invoke-WindowsUITests {
 
       # Ignore exit code 2 in test results since it just means that one or more tests failed
       # https://learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-troubleshooting
-      $test_run_params += @('--ignore-exit-code 2')
+      $test_run_params += @('--ignore-exit-code', '2')
 
       $env:TKUITEST_APP = Join-Path $PSScriptRoot "..\artifacts\bin\${app_name}\TestBuild\${app_name}.exe"
       & $dotnet_exe test --project $runner_project @build_parameters @test_run_params


### PR DESCRIPTION
The mstest [exit code](https://learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes) 2 is returned if any tests fail, which meant we were seeing test-wide "Errors" any time even a single test did not complete. This was embedded in the trx file itself so could not be fixed easily jenkins-side.