### PR TITLE
[IOS] [Bug fix]: Fixes Display of floor visibility in the control, When zoomed into a building

### DIFF
--- a/src/Toolkit/Toolkit.Maui/FloorFilter/FloorFilter.cs
+++ b/src/Toolkit/Toolkit.Maui/FloorFilter/FloorFilter.cs
@@ -638,7 +638,7 @@ public partial class FloorFilter : TemplatedView
 
             const int maxHeight = 320;
             var desiredHeight = (_displayLevels?.Count ?? 0) * 48;
-#if _IOS__ || __MACCATALYST__
+#if __IOS__ || __MACCATALYST__
             var limitedHeight = Math.Min(maxHeight, desiredHeight);
             PART_LevelListView.VerticalOptions = LayoutOptions.End;
             PART_LevelListView.HeightRequest = limitedHeight;


### PR DESCRIPTION
Issue:  What is expected is that when I zoom in the floor filter control should expand vertically to show the floors in the current building (1, 2, 3, etc). When I zoom in and out there is a very subtle change in the height of the control like it's trying to do something, but no floors are actually shown. Otherwise the navigate site button and zoom to building button work as intended.
Fix: There is a typo in pre-processor statement for ios. So fixed that