### PR TITLE
Add OrientedImageryView (WPF only)

### DIFF
--- a/docs/oriented-imagery-view.md
+++ b/docs/oriented-imagery-view.md
@@ -1,0 +1,155 @@
+# OrientedImageryView
+
+`OrientedImageryView` displays oriented imagery with a built-in toolbar for image navigation, footprint visibility, camera location markers, and image markers. It works with an `OrientedImageryLayer` and `GeoView`. The control manages footprints and marker overlays, while your app remains responsible for searching for images and choosing which image is selected.
+
+![Example Image](images/oriented-imagery.png)
+
+## Minimal implementation
+
+The following WPF example places a `MapView` next to an `OrientedImageryView`. Set `GeoView` so the control can display its managed marker overlay on the map, and set `OrientedImageryLayer` so the view model can manage footprints and image-to-map calculations.
+
+```xml
+<Grid xmlns:esri="http://schemas.esri.com/arcgis/runtime/2013">
+    <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="*" />
+        <ColumnDefinition Width="400" />
+    </Grid.ColumnDefinitions>
+
+    <esri:MapView x:Name="MainMapView" />
+    <esri:OrientedImageryView x:Name="MainOrientedImageryView"
+                              Grid.Column="1"
+                              GeoView="{Binding ElementName=MainMapView}" />
+</Grid>
+```
+
+Create the map and oriented imagery layer. Search for oriented images when the map is tapped.
+
+```cs
+private const string OrientedImageryLayerUrl = "https://example.com/arcgis/rest/services/OrientedImagery/FeatureServer";
+
+private OrientedImageryLayer? _orientedImageryLayer;
+
+private async Task InitializeAsync()
+{
+    MainMapView.Map = new Map(BasemapStyle.ArcGISImageryStandard);
+
+    _orientedImageryLayer = new OrientedImageryLayer(new Uri(OrientedImageryLayerUrl));
+    MainMapView.Map.OperationalLayers.Add(_orientedImageryLayer);
+
+    MainOrientedImageryView.OrientedImageryLayer = _orientedImageryLayer;
+
+    await _orientedImageryLayer.LoadAsync();
+
+    if (_orientedImageryLayer.FullExtent is not null)
+    {
+        await MainMapView.SetViewpointGeometryAsync(_orientedImageryLayer.FullExtent);
+    }
+
+    MainMapView.GeoViewTapped += MainMapView_GeoViewTapped;
+}
+
+private async void MainMapView_GeoViewTapped(object? sender, GeoViewInputEventArgs e)
+{
+    if (_orientedImageryLayer is null || e.Location is null)
+    {
+        return;
+    }
+
+    // Add a marker if the `OrientedImageryViewModel.AllowAddingMarkers` is enabled.
+    if (MainOrientedImageryView.ViewModel.AllowAddingMarkers)
+    {
+        MainOrientedImageryView.ViewModel.AddMarkerLocation(e.Location);
+        return;
+    }
+
+    // Otherwise search for images that view the clicked location.
+    var parameters = new OrientedImageSearchParameters { MaxResults = -1 };
+    var images = await _orientedImageryLayer.SearchImagesAsync(e.Location, parameters) ?? new List<OrientedImage>();
+
+    MainOrientedImageryView.ViewModel.SetImages(images, e.Location);
+    MainOrientedImageryView.ViewModel.SelectedImage = images.FirstOrDefault();
+}
+```
+
+See the `OrientedImageryView` sample for a full example implementation.
+
+## Customizing the toolbar
+
+`OrientedImageryView` is structured as an `ItemsControl` whose toolbar items are defined by its `ItemsSource` property. The default toolbar items are defined by `OrientedImageryView.GetDefaultToolbarItems()`, which includes controls for auto-updating the footprint, showing selected and unselected footprints, cycling camera marker display modes, enabling marker creation, selecting the marker symbol, and clearing markers.
+
+Toolbar items are styled using the `OrientedImageryViewTemplateSelector` which maps object types to data templates. Custom toolbar items can be any type, but users may choose to derive from `OrientedImageryViewToolbarViewModelBase` to automatically gain access to the current `OrientedImageryViewModel` via the `OrientedImageryViewToolbarViewModelBase.MainViewModel` property.
+
+### Example
+
+Define a toolbar item class deriving from `OrientedImageryViewToolbarViewModelBase`.
+
+```cs
+internal sealed class ShowImageDetailsToolbarItem : OrientedImageryViewToolbarViewModelBase { }
+```
+
+Define a data template for the custom toolbar item and create a new `OrientedImageyViewTemplateSelector` item to map it to the `ShowImageDetailsToolbarItem` type.
+
+```xml
+<UserControl.Resources>
+    <DataTemplate x:Key="ShowImageDetailsToolbarTemplate"
+                  DataType="{x:Type local:ShowImageDetailsToolbarItem}">
+        <Button Content="Info"
+                MinWidth="48"
+                Padding="8,4"
+                ToolTip="Show selected image details"
+                Click="ShowImageDetails_Click">
+            <Button.Style>
+                <Style TargetType="{x:Type Button}">
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding MainViewModel.SelectedImage}" Value="{x:Null}">
+                            <Setter Property="IsEnabled" Value="False" />
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </Button.Style>
+        </Button>
+    </DataTemplate>
+
+    <esri:OrientedImageryViewTemplateSelectorItem x:Key="ShowImageDetailsToolbarSelectorItem"
+                                                  Type="{x:Type local:ShowImageDetailsToolbarItem}"
+                                                  Template="{StaticResource ShowImageDetailsToolbarTemplate}" />
+</UserControl.Resources>
+```
+
+Add the custom item to the toolbar collection and register its template after the control has loaded.
+
+```cs
+public OrientedImagerySample()
+{
+    InitializeComponent();
+    MainOrientedImageryView.Loaded += (_, _) => ConfigureToolbar();
+}
+
+private void ConfigureToolbar()
+{
+    // Register the selector item.
+    if (MainOrientedImageryView.ItemTemplateSelector is OrientedImageryViewTemplateSelector selector &&
+        TryFindResource("ShowImageDetailsToolbarSelectorItem") is OrientedImageryViewTemplateSelectorItem selectorItem)
+    {
+        selector.TypeTemplatePairs.Add(selectorItem);
+    }
+
+    // Reuse the default toolbar items (optional).
+    var toolbarItems = OrientedImageryView.GetDefaultToolbarItems();
+
+    // Add the custom item to the list.
+    toolbarItems.Add(new ShowImageDetailsToolbarItem());
+    MainOrientedImageryView.ItemsSource = toolbarItems;
+}
+
+private void ShowImageDetails_Click(object sender, RoutedEventArgs e)
+{
+    var selectedImage = MainOrientedImageryView.ViewModel.SelectedImage;
+    if (selectedImage is null)
+    {
+        return;
+    }
+
+    // Show details for selectedImage.
+}
+```

--- a/docs/oriented-imagery-view.md
+++ b/docs/oriented-imagery-view.md
@@ -1,8 +1,8 @@
 # OrientedImageryView
 
-`OrientedImageryView` displays oriented imagery with a built-in toolbar for image navigation, footprint visibility, camera location markers, and image markers. It works with an `OrientedImageryLayer` and `GeoView`. The control manages footprints and marker overlays, while your app remains responsible for searching for images and choosing which image is selected.
+The `OrientedImageryView` displays oriented imagery with a built-in toolbar for image navigation, footprint visibility, camera location markers, and image markers. It works with an `OrientedImageryLayer` and `GeoView`. The control manages footprints and marker overlays, while your app remains responsible for searching for images and choosing which image is selected.
 
-![Example Image](images/oriented-imagery.png)
+<img width="1108" height="656" alt="oriented-imagery" src="https://github.com/user-attachments/assets/d1199b2b-a9e5-4fce-89e6-0a3d85d05457" />
 
 ## Minimal implementation
 

--- a/docs/oriented-imagery-view.md
+++ b/docs/oriented-imagery-view.md
@@ -75,69 +75,72 @@ See the `OrientedImageryView` sample for a full example implementation.
 
 ## Customizing the toolbar
 
-`OrientedImageryView` is structured as an `ItemsControl` whose toolbar items are defined by its `ItemsSource` property. The default toolbar items are defined by `OrientedImageryView.GetDefaultToolbarItems()`, which includes controls for auto-updating the footprint, showing selected and unselected footprints, cycling camera marker display modes, enabling marker creation, selecting the marker symbol, and clearing markers.
+`OrientedImageryView` is structured as an `ItemsControl` whose toolbar items are defined by its `ItemsSource` property. The default toolbar items are returned by `OrientedImageryView.GetDefaultToolbarItems()`, which includes controls for auto-updating the footprint, showing selected and unselected footprints, cycling camera marker display modes, enabling marker creation, selecting the marker symbol, and clearing markers.
 
-Toolbar items are styled using the `OrientedImageryViewTemplateSelector` which maps object types to data templates. Custom toolbar items can be any type, but users may choose to derive from `OrientedImageryViewToolbarViewModelBase` to automatically gain access to the current `OrientedImageryViewModel` via the `OrientedImageryViewToolbarViewModelBase.MainViewModel` property.
+Toolbar items are rendered by the `ItemTemplateSelector`. Use an `OrientedImageryViewTemplateSelector` to map toolbar item types to data templates. When you assign a custom selector to `OrientedImageryView.ItemTemplateSelector`, the control merges in the default toolbar templates so built-in toolbar items continue to render unless you override their templates.
+
+Custom toolbar items can be any type, but deriving from `OrientedImageryToolbarItemBase` automatically provides access to the current `OrientedImageryViewModel` through the `MainViewModel` property.
 
 ### Example
 
-Define a toolbar item class deriving from `OrientedImageryViewToolbarViewModelBase`.
+Define a toolbar item class deriving from `OrientedImageryToolbarItemBase`.
 
 ```cs
-internal sealed class ShowImageDetailsToolbarItem : OrientedImageryViewToolbarViewModelBase { }
+internal sealed class ShowImageDetailsToolbarItem : OrientedImageryToolbarItemBase
+{
+}
 ```
 
-Define a data template for the custom toolbar item and create a new `OrientedImageyViewTemplateSelector` item to map it to the `ShowImageDetailsToolbarItem` type.
+Define a data template for the custom toolbar item, then create an `OrientedImageryViewTemplateSelector` that maps the item type to the template.
 
 ```xml
 <UserControl.Resources>
-    <DataTemplate x:Key="ShowImageDetailsToolbarTemplate"
-                  DataType="{x:Type local:ShowImageDetailsToolbarItem}">
-        <Button Content="Info"
-                MinWidth="48"
-                Padding="8,4"
-                ToolTip="Show selected image details"
-                Click="ShowImageDetails_Click">
-            <Button.Style>
-                <Style TargetType="{x:Type Button}">
-                    <Style.Triggers>
-                        <DataTrigger Binding="{Binding MainViewModel.SelectedImage}" Value="{x:Null}">
-                            <Setter Property="IsEnabled" Value="False" />
-                        </DataTrigger>
-                    </Style.Triggers>
-                </Style>
-            </Button.Style>
-        </Button>
-    </DataTemplate>
+    <ResourceDictionary>
+        <DataTemplate x:Key="ShowImageDetailsToolbarTemplate"
+                      DataType="{x:Type local:ShowImageDetailsToolbarItem}">
+            <Button Click="ShowImageDetails_Click"
+                    ToolTip="Show selected image details">
+                <Button.Style>
+                    <Style TargetType="{x:Type Button}">
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding MainViewModel.SelectedImage}" Value="{x:Null}">
+                                <Setter Property="IsEnabled" Value="False" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Button.Style>
+                <TextBlock Text="Info" />
+            </Button>
+        </DataTemplate>
 
-    <esri:OrientedImageryViewTemplateSelectorItem x:Key="ShowImageDetailsToolbarSelectorItem"
-                                                  Type="{x:Type local:ShowImageDetailsToolbarItem}"
-                                                  Template="{StaticResource ShowImageDetailsToolbarTemplate}" />
+        <esri:OrientedImageryViewTemplateSelector x:Key="CustomToolbarSelector">
+            <esri:OrientedImageryViewTemplateSelectorItem Type="{x:Type local:ShowImageDetailsToolbarItem}"
+                                                          Template="{StaticResource ShowImageDetailsToolbarTemplate}" />
+        </esri:OrientedImageryViewTemplateSelector>
+    </ResourceDictionary>
 </UserControl.Resources>
 ```
 
-Add the custom item to the toolbar collection and register its template after the control has loaded.
+Assign the custom selector to `OrientedImageryView.ItemTemplateSelector`.
+
+```xml
+<esri:OrientedImageryView x:Name="MainOrientedImageryView"
+                          GeoView="{Binding ElementName=MainMapView}"
+                          ItemTemplateSelector="{StaticResource CustomToolbarSelector}" />
+```
+
+Add the custom item to the toolbar collection.
 
 ```cs
 public OrientedImagerySample()
 {
     InitializeComponent();
-    MainOrientedImageryView.Loaded += (_, _) => ConfigureToolbar();
+    ConfigureToolbar();
 }
 
 private void ConfigureToolbar()
 {
-    // Register the selector item.
-    if (MainOrientedImageryView.ItemTemplateSelector is OrientedImageryViewTemplateSelector selector &&
-        TryFindResource("ShowImageDetailsToolbarSelectorItem") is OrientedImageryViewTemplateSelectorItem selectorItem)
-    {
-        selector.TypeTemplatePairs.Add(selectorItem);
-    }
-
-    // Reuse the default toolbar items (optional).
     var toolbarItems = OrientedImageryView.GetDefaultToolbarItems();
-
-    // Add the custom item to the list.
     toolbarItems.Add(new ShowImageDetailsToolbarItem());
     MainOrientedImageryView.ItemsSource = toolbarItems;
 }

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/DemoOilToolbarControl.cs
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/DemoOilToolbarControl.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery;
+
+internal class DemoOilToolbarControl
+{
+    public string Message { get; set; } = "Demo Oil Toolbar Control";
+}

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/DemoOilToolbarVM.cs
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/DemoOilToolbarVM.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery;
 
-internal class DemoOilToolbarControl
+internal class DemoOilToolbarVM
 {
-    public string Message { get; set; } = "Demo Oil Toolbar Control";
+    public string Message { get; set; } = "Demo user-implemented Oil Toolbar Control";
 }

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/ExampleOIToolbarItem.cs
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/ExampleOIToolbarItem.cs
@@ -3,6 +3,6 @@ using Esri.ArcGISRuntime.Toolkit.UI.Controls;
 
 namespace Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery;
 
-internal class ExampleOIViewerToolbarVM : OrientedImageryViewToolbarViewModelBase
+internal class ExampleOIToolbarItem : OrientedImageryToolbarItemBase
 {
 }

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/ExampleOIViewerToolbarVM.cs
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/ExampleOIViewerToolbarVM.cs
@@ -1,12 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
+﻿
 namespace Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery;
 
-internal class DemoOilToolbarVM
+internal class ExampleOIViewerToolbarVM
 {
     public string Message { get; set; } = "Demo user-implemented Oil Toolbar Control";
 }

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/ExampleOIViewerToolbarVM.cs
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/ExampleOIViewerToolbarVM.cs
@@ -1,7 +1,8 @@
 ﻿
+using Esri.ArcGISRuntime.Toolkit.UI.Controls;
+
 namespace Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery;
 
-internal class ExampleOIViewerToolbarVM
+internal class ExampleOIViewerToolbarVM : OrientedImageryViewToolbarViewModelBase
 {
-    public string Message { get; set; } = "Demo user-implemented Oil Toolbar Control";
 }

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryPopupToolbarItem.cs
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryPopupToolbarItem.cs
@@ -3,6 +3,6 @@ using Esri.ArcGISRuntime.Toolkit.UI.Controls;
 
 namespace Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery;
 
-internal class ExampleOIToolbarItem : OrientedImageryToolbarItemBase
+internal class OrientedImageryPopupToolbarItem : OrientedImageryToolbarItemBase
 {
 }

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml
@@ -8,18 +8,34 @@
              mc:Ignorable="d"
              d:DesignHeight="450" d:DesignWidth="800">
     <UserControl.Resources>
-        <esri:OrientedImageryViewModel x:Key="MainOrientedImageryVM" />
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="/Esri.ArcGISRuntime.Toolkit.WPF;component/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml" />
+            </ResourceDictionary.MergedDictionaries>
 
-        <DataTemplate x:Key="DemoOilToolbarControlTemplate" DataType="local:ExampleOIViewerToolbarVM">
-            <TextBlock Text="{Binding Message}" />
-        </DataTemplate>
+            <esri:OrientedImageryViewModel x:Key="MainOrientedImageryVM" />
 
-        <DataTemplate x:Key="AlternateAutoUpdateFootprintTemplate" DataType="esri:AutoUpdateFootprintVM">
-            <ToggleButton Foreground="Red" Content="Auto Update Footprint" IsChecked="{Binding MainViewModel.AutoUpdateFootprint, Mode=TwoWay}" />
-        </DataTemplate>
+            <DataTemplate x:Key="DemoOilToolbarControlTemplate" DataType="local:ExampleOIViewerToolbarVM">
+                <Button Click="OpenSelectedImagePopupButton_Click" ToolTip="Open popup for selected image">
+                    <Button.Style>
+                        <Style TargetType="{x:Type Button}" BasedOn="{StaticResource ToolbarButtonStyle}">
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding MainViewModel.SelectedImage}" Value="{x:Null}">
+                                    <Setter Property="IsEnabled" Value="False" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Button.Style>
+                    <Viewbox Width="20" Height="20" Stretch="Uniform">
+                        <Grid Width="32" Height="32">
+                            <Path Fill="Black" Data="M7 10h18v10H7zm17 9v-8H8v8zM15 7H7v1h8zm9 1h1V7h-1zm5 14a2 2 0 0 1-2 2h-6.69l-4.277 6.33L11.757 24H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h22a2 2 0 0 1 2 2zM28 5a1 1 0 0 0-1-1H5a1 1 0 0 0-1 1v17a1 1 0 0 0 1 1h7.289l3.744 5.543L19.778 23H27a1 1 0 0 0 1-1z" />
+                        </Grid>
+                    </Viewbox>
+                </Button>
+            </DataTemplate>
 
-        <esri:OrientedImageryViewTemplateSelectorItem x:Key="DemoOilToolbarSelectorItem" Type="{x:Type local:ExampleOIViewerToolbarVM}" Template="{StaticResource DemoOilToolbarControlTemplate}" />
-        <esri:OrientedImageryViewTemplateSelectorItem x:Key="AlternateAutoUpdateFootprintSelectorItem" Type="{x:Type esri:AutoUpdateFootprintVM}" Template="{StaticResource AlternateAutoUpdateFootprintTemplate}" />
+            <esri:OrientedImageryViewTemplateSelectorItem x:Key="DemoOilToolbarSelectorItem" Type="{x:Type local:ExampleOIViewerToolbarVM}" Template="{StaticResource DemoOilToolbarControlTemplate}" />
+        </ResourceDictionary>
     </UserControl.Resources>
 
     <Grid>
@@ -36,11 +52,9 @@
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="Auto"/>
-                <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
             <TextBox x:Name="LayerUriTextBox" Text="https://services.arcgis.com/2Pv4ow3pE6NFC9SW/arcgis/rest/services/EsriCampus_GoProSample/FeatureServer/0" />
             <Button Grid.Column="1" Content="Apply Layer" Click="ApplyLayerButton_Click" />
-            <Button Grid.Column="2" Content="Toggle Default/Custom Toolbar" Click="ToggleToolbarStyleButton_Click" />
         </Grid>
 
         <esri:MapView x:Name="MainMapView" Grid.Row="1" Grid.Column="0"/>
@@ -48,5 +62,20 @@
                                   GeoView="{Binding ElementName=MainMapView}"
                                   ViewModel="{StaticResource MainOrientedImageryVM}"
                                   Grid.Row="1" Grid.Column="1"/>
+
+        <Grid x:Name="SelectedImagePopupBackground"
+              Grid.RowSpan="2"
+              Grid.ColumnSpan="2"
+              Background="#AA333333"
+              Visibility="Collapsed"
+              MouseDown="SelectedImagePopupBackground_MouseDown">
+            <Border BorderBrush="Black"
+                    BorderThickness="1"
+                    Background="White"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center">
+                <esri:PopupViewer x:Name="SelectedImagePopupViewer" Margin="5" Width="400" MaxHeight="500" />
+            </Border>
+        </Grid>
     </Grid>
 </UserControl>

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml
@@ -8,6 +8,8 @@
              mc:Ignorable="d"
              d:DesignHeight="450" d:DesignWidth="800">
     <UserControl.Resources>
+        <esri:OrientedImageryViewModel x:Key="MainOrientedImageryVM" />
+
         <DataTemplate x:Key="DemoOilToolbarControlTemplate" DataType="local:ExampleOIViewerToolbarVM">
             <TextBlock Text="{Binding Message}" />
         </DataTemplate>
@@ -42,6 +44,9 @@
         </Grid>
 
         <esri:MapView x:Name="MainMapView" Grid.Row="1" Grid.Column="0"/>
-        <esri:OrientedImageryView x:Name="MainOrientedImageryView" GeoView="{Binding ElementName=MainMapView}" Grid.Row="1" Grid.Column="1"/>
+        <esri:OrientedImageryView x:Name="MainOrientedImageryView"
+                                  GeoView="{Binding ElementName=MainMapView}"
+                                  ViewModel="{StaticResource MainOrientedImageryVM}"
+                                  Grid.Row="1" Grid.Column="1"/>
     </Grid>
 </UserControl>

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml
@@ -8,53 +8,40 @@
              mc:Ignorable="d"
              d:DesignHeight="450" d:DesignWidth="800">
     <UserControl.Resources>
-        <DataTemplate x:Key="DemoOilToolbarControlTemplate" DataType="esri:DemoOilToolbarVM">
+        <DataTemplate x:Key="DemoOilToolbarControlTemplate" DataType="local:ExampleOIViewerToolbarVM">
             <TextBlock Text="{Binding Message}" />
         </DataTemplate>
 
-        <DataTemplate x:Key="MarkerPickerToolbarTemplate" DataType="esri:SelectNewMarkerSymbolVM">
-            <Button Command="{Binding SelectNextSymbol}">
-                <esri:SymbolDisplay Symbol="{Binding SelectedSymbol, Mode=OneWay}" />
-            </Button>
+        <DataTemplate x:Key="AlternateAutoUpdateFootprintTemplate" DataType="esri:AutoUpdateFootprintVM">
+            <ToggleButton Foreground="Red" Content="Auto Update Footprint" IsChecked="{Binding MainViewModel.AutoUpdateFootprint, Mode=TwoWay}" />
         </DataTemplate>
 
-        <DataTemplate x:Key="AutoUpdateFootprintToolbarTemplate" DataType="esri:AutoUpdateFootprintVM">
-            <ToggleButton Content="AU" IsChecked="{Binding MainViewModel.AutoUpdateFootprint}"/>
-        </DataTemplate>
-
-        <DataTemplate x:Key="ShowSelectedFootprintToolbarTemplate" DataType="esri:ShowSelectedFootprintVM">
-            <ToggleButton Content="FA" IsChecked="{Binding MainViewModel.ShowSelectedFootprint}"/>
-        </DataTemplate>
-
-        <DataTemplate x:Key="ShowUnselectedFootprintsToolbarTemplate" DataType="esri:ShowUnselectedFootprintsVM">
-            <ToggleButton Content="FA" IsChecked="{Binding MainViewModel.ShowUnselectedFootprints}"/>
-        </DataTemplate>
-
-        <DataTemplate x:Key="ShowCameraMarkersToolbarTemplate" DataType="esri:ShowCameraMarkersVM">
-            <ToggleButton Content="Cameras" />
-        </DataTemplate>
-
-        <DataTemplate x:Key="ClearMarkersToolbarTemplate" DataType="esri:ClearMarkersVM">
-            <Button Content="❌" Command="{Binding MainViewModel.ClearMarkersCommand}"/>
-        </DataTemplate>
-
-        <esri:OrientedImageryViewTemplateSelector x:Key="OIViewSelector">
-            <esri:OrientedImageryViewTemplateSelectorItem Type="{x:Type local:DemoOilToolbarVM}" Template="{StaticResource DemoOilToolbarControlTemplate}" />
-            <esri:OrientedImageryViewTemplateSelectorItem Type="{x:Type esri:SelectNewMarkerSymbolVM}" Template="{StaticResource MarkerPickerToolbarTemplate}" />
-            <esri:OrientedImageryViewTemplateSelectorItem Type="{x:Type esri:AutoUpdateFootprintVM}" Template="{StaticResource AutoUpdateFootprintToolbarTemplate}" />
-            <esri:OrientedImageryViewTemplateSelectorItem Type="{x:Type esri:ShowSelectedFootprintVM}" Template="{StaticResource ShowSelectedFootprintToolbarTemplate}" />
-            <esri:OrientedImageryViewTemplateSelectorItem Type="{x:Type esri:ShowUnselectedFootprintsVM}" Template="{StaticResource ShowUnselectedFootprintsToolbarTemplate}" />
-            <esri:OrientedImageryViewTemplateSelectorItem Type="{x:Type esri:ShowCameraMarkersVM}" Template="{StaticResource ShowCameraMarkersToolbarTemplate}" />
-            <esri:OrientedImageryViewTemplateSelectorItem Type="{x:Type esri:ClearMarkersVM}" Template="{StaticResource ClearMarkersToolbarTemplate}" />
-        </esri:OrientedImageryViewTemplateSelector>
+        <esri:OrientedImageryViewTemplateSelectorItem x:Key="DemoOilToolbarSelectorItem" Type="{x:Type local:ExampleOIViewerToolbarVM}" Template="{StaticResource DemoOilToolbarControlTemplate}" />
+        <esri:OrientedImageryViewTemplateSelectorItem x:Key="AlternateAutoUpdateFootprintSelectorItem" Type="{x:Type esri:AutoUpdateFootprintVM}" Template="{StaticResource AlternateAutoUpdateFootprintTemplate}" />
     </UserControl.Resources>
 
     <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="3*"/>
             <ColumnDefinition Width="2*"/>
         </Grid.ColumnDefinitions>
-        <esri:MapView x:Name="MainMapView" />
-        <esri:OrientedImageryView x:Name="MainOrientedImageryView" GeoView="{Binding ElementName=MainMapView}" ItemTemplateSelector="{StaticResource OIViewSelector}" Grid.Column="1"/>
+
+        <Grid x:Name="ControlPanel" Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" >
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+            <TextBox x:Name="LayerUriTextBox" Text="https://services.arcgis.com/2Pv4ow3pE6NFC9SW/arcgis/rest/services/EsriCampus_GoProSample/FeatureServer/0" />
+            <Button Grid.Column="1" Content="Apply Layer" Click="ApplyLayerButton_Click" />
+            <Button Grid.Column="2" Content="Toggle Default/Custom Toolbar" Click="ToggleToolbarStyleButton_Click" />
+        </Grid>
+
+        <esri:MapView x:Name="MainMapView" Grid.Row="1" Grid.Column="0"/>
+        <esri:OrientedImageryView x:Name="MainOrientedImageryView" GeoView="{Binding ElementName=MainMapView}" Grid.Row="1" Grid.Column="1"/>
     </Grid>
 </UserControl>

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml
@@ -45,10 +45,11 @@
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="3*"/>
+            <ColumnDefinition Width="Auto"/>
             <ColumnDefinition Width="2*"/>
         </Grid.ColumnDefinitions>
 
-        <Grid x:Name="ControlPanel" Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" >
+        <Grid x:Name="ControlPanel" Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3" >
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="Auto"/>
@@ -58,14 +59,17 @@
         </Grid>
 
         <esri:MapView x:Name="MainMapView" Grid.Row="1" Grid.Column="0"/>
+        <GridSplitter Grid.Row="1" Grid.Column="1" Width="5"
+                      HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
+                      ResizeBehavior="PreviousAndNext" />
         <esri:OrientedImageryView x:Name="MainOrientedImageryView"
                                   GeoView="{Binding ElementName=MainMapView}"
                                   ViewModel="{StaticResource MainOrientedImageryVM}"
-                                  Grid.Row="1" Grid.Column="1"/>
+                                  Grid.Row="1" Grid.Column="2"/>
 
         <Grid x:Name="SelectedImagePopupBackground"
               Grid.RowSpan="2"
-              Grid.ColumnSpan="2"
+              Grid.ColumnSpan="3"
               Background="#AA333333"
               Visibility="Collapsed"
               MouseDown="SelectedImagePopupBackground_MouseDown">

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml
@@ -8,12 +8,44 @@
              mc:Ignorable="d"
              d:DesignHeight="450" d:DesignWidth="800">
     <UserControl.Resources>
-        <DataTemplate x:Key="DemoOilToolbarControlTemplate" DataType="local:DemoOilToolbarControl">
-            <Button Content="{Binding Message}" />
+        <DataTemplate x:Key="DemoOilToolbarControlTemplate" DataType="esri:DemoOilToolbarVM">
+            <TextBlock Text="{Binding Message}" />
+        </DataTemplate>
+
+        <DataTemplate x:Key="MarkerPickerToolbarTemplate" DataType="esri:SelectNewMarkerSymbolVM">
+            <Button Command="{Binding SelectNextSymbol}">
+                <esri:SymbolDisplay Symbol="{Binding SelectedSymbol, Mode=OneWay}" />
+            </Button>
+        </DataTemplate>
+
+        <DataTemplate x:Key="AutoUpdateFootprintToolbarTemplate" DataType="esri:AutoUpdateFootprintVM">
+            <ToggleButton Content="AU" IsChecked="{Binding MainViewModel.AutoUpdateFootprint}"/>
+        </DataTemplate>
+
+        <DataTemplate x:Key="ShowSelectedFootprintToolbarTemplate" DataType="esri:ShowSelectedFootprintVM">
+            <ToggleButton Content="FA" IsChecked="{Binding MainViewModel.ShowSelectedFootprint}"/>
+        </DataTemplate>
+
+        <DataTemplate x:Key="ShowUnselectedFootprintsToolbarTemplate" DataType="esri:ShowUnselectedFootprintsVM">
+            <ToggleButton Content="FA" IsChecked="{Binding MainViewModel.ShowUnselectedFootprints}"/>
+        </DataTemplate>
+
+        <DataTemplate x:Key="ShowCameraMarkersToolbarTemplate" DataType="esri:ShowCameraMarkersVM">
+            <ToggleButton Content="Cameras" />
+        </DataTemplate>
+
+        <DataTemplate x:Key="ClearMarkersToolbarTemplate" DataType="esri:ClearMarkersVM">
+            <Button Content="❌" Command="{Binding MainViewModel.ClearMarkersCommand}"/>
         </DataTemplate>
 
         <esri:OrientedImageryViewTemplateSelector x:Key="OIViewSelector">
-            <esri:OrientedImageryViewTemplateSelectorItem Type="{x:Type local:DemoOilToolbarControl}" Template="{StaticResource DemoOilToolbarControlTemplate}" />
+            <esri:OrientedImageryViewTemplateSelectorItem Type="{x:Type local:DemoOilToolbarVM}" Template="{StaticResource DemoOilToolbarControlTemplate}" />
+            <esri:OrientedImageryViewTemplateSelectorItem Type="{x:Type esri:SelectNewMarkerSymbolVM}" Template="{StaticResource MarkerPickerToolbarTemplate}" />
+            <esri:OrientedImageryViewTemplateSelectorItem Type="{x:Type esri:AutoUpdateFootprintVM}" Template="{StaticResource AutoUpdateFootprintToolbarTemplate}" />
+            <esri:OrientedImageryViewTemplateSelectorItem Type="{x:Type esri:ShowSelectedFootprintVM}" Template="{StaticResource ShowSelectedFootprintToolbarTemplate}" />
+            <esri:OrientedImageryViewTemplateSelectorItem Type="{x:Type esri:ShowUnselectedFootprintsVM}" Template="{StaticResource ShowUnselectedFootprintsToolbarTemplate}" />
+            <esri:OrientedImageryViewTemplateSelectorItem Type="{x:Type esri:ShowCameraMarkersVM}" Template="{StaticResource ShowCameraMarkersToolbarTemplate}" />
+            <esri:OrientedImageryViewTemplateSelectorItem Type="{x:Type esri:ClearMarkersVM}" Template="{StaticResource ClearMarkersToolbarTemplate}" />
         </esri:OrientedImageryViewTemplateSelector>
     </UserControl.Resources>
 

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml
@@ -7,12 +7,22 @@
              xmlns:esri="http://schemas.esri.com/arcgis/runtime/2013"
              mc:Ignorable="d"
              d:DesignHeight="450" d:DesignWidth="800">
+    <UserControl.Resources>
+        <DataTemplate x:Key="DemoOilToolbarControlTemplate" DataType="local:DemoOilToolbarControl">
+            <Button Content="{Binding Message}" />
+        </DataTemplate>
+
+        <esri:OrientedImageryViewTemplateSelector x:Key="OIViewSelector">
+            <esri:OrientedImageryViewTemplateSelectorItem Type="{x:Type local:DemoOilToolbarControl}" Template="{StaticResource DemoOilToolbarControlTemplate}" />
+        </esri:OrientedImageryViewTemplateSelector>
+    </UserControl.Resources>
+
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="3*"/>
             <ColumnDefinition Width="2*"/>
         </Grid.ColumnDefinitions>
         <esri:MapView x:Name="MainMapView" />
-        <esri:OrientedImageryView x:Name="MainOrientedImageryView" GeoView="{Binding ElementName=MainMapView}" Grid.Column="1"/>
+        <esri:OrientedImageryView x:Name="MainOrientedImageryView" GeoView="{Binding ElementName=MainMapView}" ItemTemplateSelector="{StaticResource OIViewSelector}" Grid.Column="1"/>
     </Grid>
 </UserControl>

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml
@@ -66,7 +66,13 @@
             <Button Grid.Column="2" Content="2D/3D" Click="Toggle2DButton_Click" />
         </Grid>
 
-        <Grid x:Name="GeoViewContainer" Grid.Row="1" Grid.Column="0" />
+        <Grid Grid.Row="1" Grid.Column="0" >
+            <Grid x:Name="GeoViewContainer"/>
+            <StackPanel HorizontalAlignment="Left" VerticalAlignment="Top">
+                <Button x:Name="ToggleElevationSurfaceButton" Content="Toggle elevation surface (3D only)" Click="ToggleElevationSurfaceButton_Click" />
+                <Button x:Name="ScenePropertiesButton" Content="Update scene properties" Click="ScenePropertiesButton_Click" />
+            </StackPanel>
+        </Grid>
         <GridSplitter Grid.Row="1" Grid.Column="1" Width="5"
                       HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
                       ResizeBehavior="PreviousAndNext" />

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml
@@ -26,7 +26,7 @@
                             </Style.Triggers>
                         </Style>
                     </Button.Style>
-                    <Viewbox Width="20" Height="20" Stretch="Uniform">
+                    <Viewbox Width="32" Height="32" Stretch="Uniform">
                         <Grid Width="32" Height="32">
                             <Path Fill="Black" Data="M7 10h18v10H7zm17 9v-8H8v8zM15 7H7v1h8zm9 1h1V7h-1zm5 14a2 2 0 0 1-2 2h-6.69l-4.277 6.33L11.757 24H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h22a2 2 0 0 1 2 2zM28 5a1 1 0 0 0-1-1H5a1 1 0 0 0-1 1v17a1 1 0 0 0 1 1h7.289l3.744 5.543L19.778 23H27a1 1 0 0 0 1-1z" />
                         </Grid>

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml
@@ -1,0 +1,18 @@
+﻿<UserControl x:Class="Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery.OrientedImageryView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:local="clr-namespace:Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery"
+             xmlns:esri="http://schemas.esri.com/arcgis/runtime/2013"
+             mc:Ignorable="d"
+             d:DesignHeight="450" d:DesignWidth="800">
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="3*"/>
+            <ColumnDefinition Width="2*"/>
+        </Grid.ColumnDefinitions>
+        <esri:MapView x:Name="MainMapView" />
+        <esri:OrientedImageryView x:Name="MainOrientedImageryView" GeoView="{Binding ElementName=MainMapView}" Grid.Column="1"/>
+    </Grid>
+</UserControl>

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml
@@ -59,17 +59,18 @@
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
             <TextBox x:Name="LayerUriTextBox" Text="https://services.arcgis.com/2Pv4ow3pE6NFC9SW/arcgis/rest/services/EsriCampus_GoProSample/FeatureServer/0" />
             <Button Grid.Column="1" Content="Apply Layer" Click="ApplyLayerButton_Click" />
+            <Button Grid.Column="2" Content="2D/3D" Click="Toggle2DButton_Click" />
         </Grid>
 
-        <esri:MapView x:Name="MainMapView" Grid.Row="1" Grid.Column="0"/>
+        <Grid x:Name="GeoViewContainer" Grid.Row="1" Grid.Column="0" />
         <GridSplitter Grid.Row="1" Grid.Column="1" Width="5"
                       HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
                       ResizeBehavior="PreviousAndNext" />
         <esri:OrientedImageryView x:Name="MainOrientedImageryView"
-                                  GeoView="{Binding ElementName=MainMapView}"
                                   ViewModel="{StaticResource MainOrientedImageryVM}"
                                   ItemTemplateSelector="{StaticResource CustomToolbarSelector}"
                                   Grid.Row="1" Grid.Column="2"/>

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml
@@ -10,12 +10,15 @@
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
+                <!-- Import styles from the default OrientedImageryView theme -->
                 <ResourceDictionary Source="/Esri.ArcGISRuntime.Toolkit.WPF;component/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml" />
             </ResourceDictionary.MergedDictionaries>
 
+            <!-- Define the main OrientedImageryViewModel -->
             <esri:OrientedImageryViewModel x:Key="MainOrientedImageryVM" />
 
-            <DataTemplate x:Key="DemoOilToolbarControlTemplate" DataType="local:ExampleOIViewerToolbarVM">
+            <!-- Define a data template for a custom toolbar item type -->
+            <DataTemplate x:Key="DemoOilToolbarControlTemplate" DataType="local:ExampleOIToolbarItem">
                 <Button Click="OpenSelectedImagePopupButton_Click" ToolTip="Open popup for selected image">
                     <Button.Style>
                         <Style TargetType="{x:Type Button}" BasedOn="{StaticResource ToolbarButtonStyle}">
@@ -34,7 +37,10 @@
                 </Button>
             </DataTemplate>
 
-            <esri:OrientedImageryViewTemplateSelectorItem x:Key="DemoOilToolbarSelectorItem" Type="{x:Type local:ExampleOIViewerToolbarVM}" Template="{StaticResource DemoOilToolbarControlTemplate}" />
+            <!-- Register the toolbar data template with a selector -->
+            <esri:OrientedImageryViewTemplateSelector x:Key="CustomToolbarSelector">
+                <esri:OrientedImageryViewTemplateSelectorItem Type="{x:Type local:ExampleOIToolbarItem}" Template="{StaticResource DemoOilToolbarControlTemplate}" />
+            </esri:OrientedImageryViewTemplateSelector>
         </ResourceDictionary>
     </UserControl.Resources>
 
@@ -65,6 +71,7 @@
         <esri:OrientedImageryView x:Name="MainOrientedImageryView"
                                   GeoView="{Binding ElementName=MainMapView}"
                                   ViewModel="{StaticResource MainOrientedImageryVM}"
+                                  ItemTemplateSelector="{StaticResource CustomToolbarSelector}"
                                   Grid.Row="1" Grid.Column="2"/>
 
         <Grid x:Name="SelectedImagePopupBackground"

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml
@@ -15,12 +15,12 @@
             </ResourceDictionary.MergedDictionaries>
 
             <!-- Define a data template for a custom toolbar item type -->
-            <DataTemplate x:Key="DemoOilToolbarControlTemplate" DataType="local:ExampleOIToolbarItem">
+            <DataTemplate x:Key="PopupToolbarItemTemplate" DataType="{x:Type local:OrientedImageryPopupToolbarItem}">
                 <Button Click="OpenSelectedImagePopupButton_Click" ToolTip="Open popup for selected image">
                     <Button.Style>
                         <Style TargetType="{x:Type Button}" BasedOn="{StaticResource ToolbarButtonStyle}">
                             <Style.Triggers>
-                                <DataTrigger Binding="{Binding MainViewModel.SelectedImage}" Value="{x:Null}">
+                                <DataTrigger Binding="{Binding ViewModel.SelectedImage}" Value="{x:Null}">
                                     <Setter Property="IsEnabled" Value="False" />
                                 </DataTrigger>
                             </Style.Triggers>
@@ -36,7 +36,17 @@
 
             <!-- Register the toolbar data template with a selector -->
             <esri:OrientedImageryViewTemplateSelector x:Key="CustomToolbarSelector">
-                <esri:OrientedImageryViewTemplateSelectorItem Type="{x:Type local:ExampleOIToolbarItem}" Template="{StaticResource DemoOilToolbarControlTemplate}" />
+                <esri:OrientedImageryViewTemplateSelectorItem Type="{x:Type local:OrientedImageryPopupToolbarItem}" Template="{StaticResource PopupToolbarItemTemplate}" />
+            </esri:OrientedImageryViewTemplateSelector>
+
+            <!-- Implement a second selector that overrides an existing toolbar item style -->
+            <DataTemplate x:Key="ShowUnselectedFootprintsToolbarItemTemplate" DataType="{x:Type esri:ShowUnselectedFootprintsVM}">
+                <ToggleButton Style="{StaticResource ToolbarToggleButtonStyle}" IsChecked="{Binding ViewModel.ShowUnselectedFootprints}" ToolTip="Modified item style" Content="Override" />
+            </DataTemplate>
+
+            <esri:OrientedImageryViewTemplateSelector x:Key="AlternateToolbarSelector">
+                <esri:OrientedImageryViewTemplateSelectorItem Type="{x:Type local:OrientedImageryPopupToolbarItem}" Template="{StaticResource PopupToolbarItemTemplate}" />
+                <esri:OrientedImageryViewTemplateSelectorItem Type="{x:Type esri:ShowUnselectedFootprintsVM}" Template="{StaticResource ShowUnselectedFootprintsToolbarItemTemplate}" />
             </esri:OrientedImageryViewTemplateSelector>
         </ResourceDictionary>
     </UserControl.Resources>
@@ -68,13 +78,14 @@
             <StackPanel HorizontalAlignment="Left" VerticalAlignment="Top">
                 <Button x:Name="ToggleElevationSurfaceButton" Content="Toggle elevation surface (3D only)" Click="ToggleElevationSurfaceButton_Click" />
                 <Button x:Name="ScenePropertiesButton" Content="Update scene properties" Click="ScenePropertiesButton_Click" />
+                <Button x:Name="UpdateToolbarButton" Content="Update toolbar" Click="UpdateToolbarButton_Click" />
             </StackPanel>
         </Grid>
         <GridSplitter Grid.Row="1" Grid.Column="1" Width="5"
                       HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
                       ResizeBehavior="PreviousAndNext" />
         <esri:OrientedImageryView x:Name="MainOrientedImageryView"
-                                  ItemTemplateSelector="{StaticResource CustomToolbarSelector}"
+                                  ToolbarItemTemplateSelector="{StaticResource CustomToolbarSelector}"
                                   Grid.Row="1" Grid.Column="2"/>
 
         <Grid x:Name="SelectedImagePopupBackground"

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml
@@ -14,9 +14,6 @@
                 <ResourceDictionary Source="/Esri.ArcGISRuntime.Toolkit.WPF;component/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml" />
             </ResourceDictionary.MergedDictionaries>
 
-            <!-- Define the main OrientedImageryViewModel -->
-            <esri:OrientedImageryViewModel x:Key="MainOrientedImageryVM" />
-
             <!-- Define a data template for a custom toolbar item type -->
             <DataTemplate x:Key="DemoOilToolbarControlTemplate" DataType="local:ExampleOIToolbarItem">
                 <Button Click="OpenSelectedImagePopupButton_Click" ToolTip="Open popup for selected image">
@@ -77,7 +74,6 @@
                       HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
                       ResizeBehavior="PreviousAndNext" />
         <esri:OrientedImageryView x:Name="MainOrientedImageryView"
-                                  ViewModel="{StaticResource MainOrientedImageryVM}"
                                   ItemTemplateSelector="{StaticResource CustomToolbarSelector}"
                                   Grid.Row="1" Grid.Column="2"/>
 

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml.cs
@@ -22,6 +22,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery
     {
         private const string MapBasemap = "https://runtime.maps.arcgis.com/home/item.html?id=67372ff42cd145319639a99152b15bc3";
         private const string SceneBasemap = "https://runtime.maps.arcgis.com/home/item.html?id=0560e29930dc4d5ebeb58c635c0909c9";
+        private const string ElevationUrl = "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer";
 
         private OrientedImageryLayer? _oiLayer;
 
@@ -29,6 +30,8 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery
         private SceneView _sceneView;
         private bool _usingMapView;
         private GeoView _currentGeoView => _usingMapView ? _mapView : _sceneView;
+
+        private ElevationSource _elevationSource;
 
         public OrientedImageryView()
         {
@@ -41,6 +44,8 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery
             _mapView.GeoViewTapped += CurrentGeoView_GeoViewTapped;
             GeoViewContainer.Children.Add(_mapView);
             MainOrientedImageryView.GeoView = _mapView;
+
+            _elevationSource = new ArcGISTiledElevationSource(new Uri(ElevationUrl));
         }
 
         private void ConfigureToolbar()
@@ -58,6 +63,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery
                 await oiLayer.LoadAsync();
                 if (oiLayer.LoadStatus == LoadStatus.FailedToLoad)
                     return;
+                oiLayer.SceneProperties.SurfacePlacement = SurfacePlacement.Relative;
 
                 _oiLayer = oiLayer;
 
@@ -163,6 +169,43 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery
 
             if (_oiLayer?.FullExtent != null)
                 _currentGeoView.SetViewpoint(new Viewpoint(_oiLayer.FullExtent));
+        }
+
+        private void ToggleElevationSurfaceButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (_sceneView.Scene?.BaseSurface is not Surface surface)
+                return;
+
+            if (surface.ElevationSources.Count > 0)
+                surface.ElevationSources.Clear();
+            else
+                surface.ElevationSources.Add(_elevationSource);
+        }
+
+        private int _scenePropertiesState = 0;
+        private void ScenePropertiesButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (_oiLayer == null)
+                return;
+
+            if (_scenePropertiesState == 0)
+            {
+                _oiLayer.SceneProperties.SurfacePlacement = SurfacePlacement.DrapedFlat;
+            }
+            else if (_scenePropertiesState == 1)
+            {
+                _oiLayer.SceneProperties.SurfacePlacement = SurfacePlacement.Absolute;
+            }
+            else if (_scenePropertiesState == 2)
+            {
+                _oiLayer.SceneProperties.AltitudeOffset = 50;
+            }
+            else if (_scenePropertiesState == 3)
+            {
+                _oiLayer.SceneProperties = new LayerSceneProperties(SurfacePlacement.Relative);
+            }
+
+            _scenePropertiesState = (_scenePropertiesState + 1) % 4;
         }
     }
 }

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml.cs
@@ -1,10 +1,12 @@
 ﻿using Esri.ArcGISRuntime.Geometry;
-using System;
-using System.Threading.Tasks;
-using System.Windows.Controls;
 using Esri.ArcGISRuntime.Mapping;
+using Esri.ArcGISRuntime.Symbology;
+using Esri.ArcGISRuntime.Toolkit.UI.Controls;
+using System;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Controls;
 
 namespace Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery
 {
@@ -30,8 +32,16 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery
             MainMapView.Map = new Mapping.Map(BasemapStyle.ArcGISTopographic);
             MainMapView.Map.OperationalLayers.Add(_oiLayer);
             MainMapView.GeoViewTapped += MainMapView_GeoViewTapped;
-            var itemsSouce = new Collection<object>() { new DemoOilToolbarControl() };
+
+            var markerSymbolPickerVM = new SelectNewMarkerSymbolVM(new Collection<MarkerSymbol>()
+            {
+                new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Circle, System.Drawing.Color.Blue, 10),
+                new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Triangle, System.Drawing.Color.Yellow, 10),
+                new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Diamond, System.Drawing.Color.Orange, 10)
+            });
+            var itemsSouce = new Collection<object>() { new AutoUpdateFootprintVM(), new ShowSelectedFootprintVM(), new ShowUnselectedFootprintsVM(), new ShowCameraMarkersVM(), markerSymbolPickerVM, new ClearMarkersVM(), new DemoOilToolbarVM() };
             MainOrientedImageryView.ItemsSource = itemsSouce;
+
             MainOrientedImageryView.ViewModel.SelectedImage = new Mapping.OrientedImage();
             MainOrientedImageryView.OrientedImageryLayer = _oiLayer;
             MainMapView.SetViewpoint(new Viewpoint(_oiLayer.FullExtent));

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml.cs
@@ -1,7 +1,5 @@
-﻿using Esri.ArcGISRuntime.Geometry;
-using Esri.ArcGISRuntime.Mapping;
+﻿using Esri.ArcGISRuntime.Mapping;
 using Esri.ArcGISRuntime.Mapping.Popups;
-using Esri.ArcGISRuntime.Symbology;
 using Esri.ArcGISRuntime.Toolkit.UI.Controls;
 using Esri.ArcGISRuntime.UI;
 using System;
@@ -44,7 +42,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery
         {
             await ApplyLayer(new Uri(LayerUriTextBox.Text));
 
-            MainMapView.Map = new Mapping.Map(BasemapStyle.ArcGISTopographic);
+            MainMapView.Map = new Map(BasemapStyle.ArcGISStreets);
             MainMapView.GeoViewTapped += MainMapView_GeoViewTapped;
         }
 

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml.cs
@@ -17,6 +17,8 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery
     {
         private OrientedImageryLayer _oiLayer;
 
+        private bool _toolbarIsUsingDefaultStyle = true;
+
         public OrientedImageryView()
         {
             InitializeComponent();
@@ -26,25 +28,29 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery
 
         private async Task Initialize()
         {
-            _oiLayer = new OrientedImageryLayer(new Uri("https://services8.arcgis.com/joda3ARQ9znLf0hf/arcgis/rest/services/RedRocks/FeatureServer/0"));
-            await _oiLayer.LoadAsync();
+            await ApplyLayer(new Uri(LayerUriTextBox.Text));
 
             MainMapView.Map = new Mapping.Map(BasemapStyle.ArcGISTopographic);
-            MainMapView.Map.OperationalLayers.Add(_oiLayer);
             MainMapView.GeoViewTapped += MainMapView_GeoViewTapped;
+        }
 
-            var markerSymbolPickerVM = new SelectNewMarkerSymbolVM(new Collection<MarkerSymbol>()
-            {
-                new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Circle, System.Drawing.Color.Blue, 10),
-                new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Triangle, System.Drawing.Color.Yellow, 10),
-                new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Diamond, System.Drawing.Color.Orange, 10)
-            });
-            var itemsSouce = new Collection<object>() { new AutoUpdateFootprintVM(), new ShowSelectedFootprintVM(), new ShowUnselectedFootprintsVM(), new ShowCameraMarkersVM(), markerSymbolPickerVM, new ClearMarkersVM(), new DemoOilToolbarVM() };
-            MainOrientedImageryView.ItemsSource = itemsSouce;
+        private async Task ApplyLayer(Uri layerUri)
+        {
+            _oiLayer = new OrientedImageryLayer(layerUri);
+            await _oiLayer.LoadAsync();
+
+            MainMapView.Map ??= new Mapping.Map(BasemapStyle.ArcGISTopographic);
+            MainMapView.Map.OperationalLayers.Clear();
+            MainMapView.Map.OperationalLayers.Add(_oiLayer);
 
             MainOrientedImageryView.ViewModel.SelectedImage = new Mapping.OrientedImage();
             MainOrientedImageryView.OrientedImageryLayer = _oiLayer;
             MainMapView.SetViewpoint(new Viewpoint(_oiLayer.FullExtent));
+        }
+
+        private async void ApplyLayerButton_Click(object sender, System.Windows.RoutedEventArgs e)
+        {
+            await ApplyLayer(new Uri(LayerUriTextBox.Text));
         }
 
         private async void MainMapView_GeoViewTapped(object sender, ArcGISRuntime.UI.Controls.GeoViewInputEventArgs e)
@@ -53,6 +59,30 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery
             var images = await _oiLayer.SearchImagesAsync(e.Location, parameters);
             MainOrientedImageryView.ViewModel.SetImages(images.ToList(), e.Location);
             MainOrientedImageryView.ViewModel.SelectedImage = images.Count < 1 ? null : images[0];
+
+            var test = await _oiLayer.GetSelectedFeaturesAsync();
+        }
+
+        private void ToggleToolbarStyleButton_Click(object sender, System.Windows.RoutedEventArgs e)
+        {
+            if (_toolbarIsUsingDefaultStyle)
+            {
+                MainOrientedImageryView.ItemsSource = new ObservableCollection<object>
+                {
+                    new AutoUpdateFootprintVM(),
+                    new ShowSelectedFootprintVM(),
+                    new ExampleOIViewerToolbarVM()
+                };
+
+                var selector = MainOrientedImageryView.ItemTemplateSelector as OrientedImageryViewTemplateSelector;
+                selector.TypeTemplatePairs.Add(FindResource("DemoOilToolbarSelectorItem") as OrientedImageryViewTemplateSelectorItem);
+                selector.TypeTemplatePairs.Add(FindResource("AlternateAutoUpdateFootprintSelectorItem") as OrientedImageryViewTemplateSelectorItem);
+            }
+            else
+            {
+                MainOrientedImageryView.ItemsSource = Esri.ArcGISRuntime.Toolkit.UI.Controls.OrientedImageryView.GetDefaultToolbarItems();
+            }
+            _toolbarIsUsingDefaultStyle = !_toolbarIsUsingDefaultStyle;
         }
     }
 }

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml.cs
@@ -30,6 +30,8 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery
             MainMapView.Map = new Mapping.Map(BasemapStyle.ArcGISTopographic);
             MainMapView.Map.OperationalLayers.Add(_oiLayer);
             MainMapView.GeoViewTapped += MainMapView_GeoViewTapped;
+            var itemsSouce = new Collection<object>() { new DemoOilToolbarControl() };
+            MainOrientedImageryView.ItemsSource = itemsSouce;
             MainOrientedImageryView.ViewModel.SelectedImage = new Mapping.OrientedImage();
             MainOrientedImageryView.OrientedImageryLayer = _oiLayer;
             MainMapView.SetViewpoint(new Viewpoint(_oiLayer.FullExtent));

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml.cs
@@ -3,10 +3,11 @@
 using Esri.ArcGISRuntime.Data;
 using Esri.ArcGISRuntime.Mapping;
 using Esri.ArcGISRuntime.Mapping.Popups;
-using Esri.ArcGISRuntime.Toolkit.UI.Controls;
 using Esri.ArcGISRuntime.UI;
+using Esri.ArcGISRuntime.UI.Controls;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
@@ -19,16 +20,27 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery
     /// </summary>
     public partial class OrientedImageryView : UserControl
     {
-        private const string BasemapUri = "https://runtime.maps.arcgis.com/home/item.html?id=d8c5e76fb2cc4bb6955a6783a5f577b7";
+        private const string MapBasemap = "https://runtime.maps.arcgis.com/home/item.html?id=67372ff42cd145319639a99152b15bc3";
+        private const string SceneBasemap = "https://runtime.maps.arcgis.com/home/item.html?id=0560e29930dc4d5ebeb58c635c0909c9";
 
         private OrientedImageryLayer? _oiLayer;
+
+        private MapView _mapView;
+        private SceneView _sceneView;
+        private bool _usingMapView;
+        private GeoView _currentGeoView => _usingMapView ? _mapView : _sceneView;
 
         public OrientedImageryView()
         {
             InitializeComponent();
             ConfigureToolbar();
 
-            _ = Initialize();
+            _mapView = new MapView() { Map = new Map(new Uri(MapBasemap)) };
+            _sceneView = new SceneView() { Scene = new Scene(new Uri(SceneBasemap)) };
+            _usingMapView = true;
+            _mapView.GeoViewTapped += CurrentGeoView_GeoViewTapped;
+            GeoViewContainer.Children.Add(_mapView);
+            MainOrientedImageryView.GeoView = _mapView;
         }
 
         private void ConfigureToolbar()
@@ -38,32 +50,36 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery
             MainOrientedImageryView.ItemsSource = toolbarItems;
         }
 
-        private async Task Initialize()
-        {
-            await ApplyLayer(new Uri(LayerUriTextBox.Text));
-
-            MainMapView.Map = new Map(new Uri(BasemapUri));
-            MainMapView.GeoViewTapped += MainMapView_GeoViewTapped;
-        }
-
         private async Task ApplyLayer(Uri layerUri)
         {
-            var oiLayer = new OrientedImageryLayer(layerUri);
-            await oiLayer.LoadAsync();
-            if (oiLayer.LoadStatus == LoadStatus.FailedToLoad)
-                return;
+            try
+            {
+                var oiLayer = new OrientedImageryLayer(layerUri);
+                await oiLayer.LoadAsync();
+                if (oiLayer.LoadStatus == LoadStatus.FailedToLoad)
+                    return;
 
-            _oiLayer = oiLayer;
+                _oiLayer = oiLayer;
 
-            if (MainMapView.Map == null)
-                MainMapView.Map = new Map(new Uri(BasemapUri));
+                if (_currentGeoView is MapView mapView)
+                {
+                    mapView.Map!.OperationalLayers.Clear();
+                    mapView.Map.OperationalLayers.Add(_oiLayer);
+                }
+                else if (_currentGeoView is SceneView sceneView)
+                {
+                    sceneView.Scene!.OperationalLayers.Clear();
+                    sceneView.Scene.OperationalLayers.Add(_oiLayer);
+                }
 
-            MainMapView.Map.OperationalLayers.Clear();
-            MainMapView.Map.OperationalLayers.Add(_oiLayer);
-
-            MainOrientedImageryView.OrientedImageryLayer = _oiLayer;
-            if (_oiLayer.FullExtent != null)
-                MainMapView.SetViewpoint(new Viewpoint(_oiLayer.FullExtent));
+                MainOrientedImageryView.OrientedImageryLayer = _oiLayer;
+                if (_oiLayer?.FullExtent != null)
+                    _currentGeoView.SetViewpoint(new Viewpoint(_oiLayer.FullExtent));
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Failed to apply layer: {ex}");
+            }
         }
 
         private async void ApplyLayerButton_Click(object sender, System.Windows.RoutedEventArgs e)
@@ -71,7 +87,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery
             await ApplyLayer(new Uri(LayerUriTextBox.Text));
         }
 
-        private async void MainMapView_GeoViewTapped(object? sender, ArcGISRuntime.UI.Controls.GeoViewInputEventArgs e)
+        private async void CurrentGeoView_GeoViewTapped(object? sender, ArcGISRuntime.UI.Controls.GeoViewInputEventArgs e)
         {
             if (e.Location == null || _oiLayer == null)
                 return;
@@ -83,7 +99,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery
                 return;
             }
 
-            var identifyResult = await MainMapView.IdentifyLayerAsync(_oiLayer, e.Position, 0, false);
+            var identifyResult = await _currentGeoView.IdentifyLayerAsync(_oiLayer, e.Position, 0, false);
             if (identifyResult.GeoElements.Count > 0 && identifyResult.GeoElements[0] is Feature feature)
             {
                 MainOrientedImageryView.ViewModel.SelectedImage = await _oiLayer.FetchImageForFeatureAsync(feature);
@@ -122,6 +138,31 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery
         {
             SelectedImagePopupBackground.Visibility = Visibility.Collapsed;
             SelectedImagePopupViewer.Popup = null;
+        }
+
+        private void Toggle2DButton_Click(object sender, RoutedEventArgs e)
+        {
+            GeoViewContainer.Children.Clear();
+            _currentGeoView.GeoViewTapped -= CurrentGeoView_GeoViewTapped;
+            if (_usingMapView)
+                _mapView.Map!.OperationalLayers.Clear();
+            else
+                _sceneView.Scene!.OperationalLayers.Clear();
+
+            _usingMapView = !_usingMapView;
+            MainOrientedImageryView.GeoView = _currentGeoView;
+            _currentGeoView.GeoViewTapped += CurrentGeoView_GeoViewTapped;
+            GeoViewContainer.Children.Add(_currentGeoView);
+
+            if (_oiLayer == null)
+                return;
+            if (_usingMapView)
+                _mapView.Map!.OperationalLayers.Add(_oiLayer);
+            else
+                _sceneView.Scene!.OperationalLayers.Add(_oiLayer);
+
+            if (_oiLayer?.FullExtent != null)
+                _currentGeoView.SetViewpoint(new Viewpoint(_oiLayer.FullExtent));
         }
     }
 }

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml.cs
@@ -1,0 +1,43 @@
+﻿using Esri.ArcGISRuntime.Geometry;
+using System;
+using System.Threading.Tasks;
+using System.Windows.Controls;
+using Esri.ArcGISRuntime.Mapping;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery
+{
+    /// <summary>
+    /// Interaction logic for OrientedImageryView.xaml
+    /// </summary>
+    public partial class OrientedImageryView : UserControl
+    {
+        private OrientedImageryLayer _oiLayer;
+
+        public OrientedImageryView()
+        {
+            InitializeComponent();
+
+            _oiLayer = new OrientedImageryLayer(new Uri("https://arcgis.com/"));
+            _ = Initialize();
+        }
+
+        private async Task Initialize()
+        {
+            MainMapView.Map = new Mapping.Map(SpatialReferences.Wgs84);
+            MainMapView.GeoViewTapped += MainMapView_GeoViewTapped;
+            MainOrientedImageryView.SelectedImage = new Mapping.OrientedImage();
+            MainOrientedImageryView.OrientedImageryLayer = _oiLayer;
+        }
+
+        private async void MainMapView_GeoViewTapped(object sender, ArcGISRuntime.UI.Controls.GeoViewInputEventArgs e)
+        {
+            var parameters = new OrientedImageSearchParameters();
+            var images = await _oiLayer.SearchImagesAsync(e.Location, parameters);
+            Collection<OrientedImage> manualImages = [new OrientedImage(), new OrientedImage(), new OrientedImage()];
+            MainOrientedImageryView.SetImages(manualImages, e.Location);
+            MainOrientedImageryView.SelectedImage = images.Count < 1 ? null : images[0];
+        }
+    }
+}

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 
+using Esri.ArcGISRuntime.Data;
 using Esri.ArcGISRuntime.Mapping;
 using Esri.ArcGISRuntime.Mapping.Popups;
 using Esri.ArcGISRuntime.Toolkit.UI.Controls;
@@ -85,10 +86,17 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery
             if (MainOrientedImageryView.ViewModel.AllowAddingMarkers)
             {
                 MainOrientedImageryView.ViewModel.AddMarkerLocation(e.Location);
+                return;
+            }
+
+            var identifyResult = await MainMapView.IdentifyLayerAsync(_oiLayer, e.Position, 0, false);
+            if (identifyResult.GeoElements.Count > 0 && identifyResult.GeoElements[0] is Feature feature)
+            {
+                MainOrientedImageryView.ViewModel.SelectedImage = await _oiLayer.FetchImageForFeatureAsync(feature);
             }
             else
             {
-                var parameters = new OrientedImageSearchParameters();
+                var parameters = new OrientedImageSearchParameters() { MaxResults = -1 };
                 var images = await _oiLayer.SearchImagesAsync(e.Location, parameters) ?? new List<OrientedImage>();
                 MainOrientedImageryView.ViewModel.SetImages(images.ToList(), e.Location);
                 MainOrientedImageryView.ViewModel.SelectedImage = images.Count < 1 ? null : images[0];

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml.cs
@@ -34,14 +34,8 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery
         private void ConfigureToolbar()
         {
             var toolbarItems = Esri.ArcGISRuntime.Toolkit.UI.Controls.OrientedImageryView.GetDefaultToolbarItems();
-            toolbarItems.Add(new ExampleOIViewerToolbarVM());
+            toolbarItems.Add(new ExampleOIToolbarItem());
             MainOrientedImageryView.ItemsSource = toolbarItems;
-
-            if (MainOrientedImageryView.ItemTemplateSelector is OrientedImageryViewTemplateSelector selector &&
-                FindResource("DemoOilToolbarSelectorItem") is OrientedImageryViewTemplateSelectorItem selectorItem)
-            {
-                selector.TypeTemplatePairs.Add(selectorItem);
-            }
         }
 
         private async Task Initialize()

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml.cs
@@ -1,11 +1,13 @@
 ﻿using Esri.ArcGISRuntime.Geometry;
 using Esri.ArcGISRuntime.Mapping;
+using Esri.ArcGISRuntime.Mapping.Popups;
 using Esri.ArcGISRuntime.Symbology;
 using Esri.ArcGISRuntime.Toolkit.UI.Controls;
+using Esri.ArcGISRuntime.UI;
 using System;
-using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Windows;
 using System.Windows.Controls;
 
 namespace Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery
@@ -17,13 +19,25 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery
     {
         private OrientedImageryLayer _oiLayer;
 
-        private bool _toolbarIsUsingDefaultStyle = true;
-
         public OrientedImageryView()
         {
             InitializeComponent();
+            ConfigureToolbar();
 
             _ = Initialize();
+        }
+
+        private void ConfigureToolbar()
+        {
+            var toolbarItems = Esri.ArcGISRuntime.Toolkit.UI.Controls.OrientedImageryView.GetDefaultToolbarItems();
+            toolbarItems.Add(new ExampleOIViewerToolbarVM());
+            MainOrientedImageryView.ItemsSource = toolbarItems;
+
+            if (MainOrientedImageryView.ItemTemplateSelector is OrientedImageryViewTemplateSelector selector &&
+                FindResource("DemoOilToolbarSelectorItem") is OrientedImageryViewTemplateSelectorItem selectorItem)
+            {
+                selector.TypeTemplatePairs.Add(selectorItem);
+            }
         }
 
         private async Task Initialize()
@@ -43,7 +57,6 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery
             MainMapView.Map.OperationalLayers.Clear();
             MainMapView.Map.OperationalLayers.Add(_oiLayer);
 
-            MainOrientedImageryView.ViewModel.SelectedImage = new Mapping.OrientedImage();
             MainOrientedImageryView.OrientedImageryLayer = _oiLayer;
             MainMapView.SetViewpoint(new Viewpoint(_oiLayer.FullExtent));
         }
@@ -72,26 +85,31 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery
             }
         }
 
-        private void ToggleToolbarStyleButton_Click(object sender, System.Windows.RoutedEventArgs e)
+        private void OpenSelectedImagePopupButton_Click(object sender, RoutedEventArgs e)
         {
-            if (_toolbarIsUsingDefaultStyle)
-            {
-                MainOrientedImageryView.ItemsSource = new ObservableCollection<object>
-                {
-                    new AutoUpdateFootprintVM(),
-                    new ShowSelectedFootprintVM(),
-                    new ExampleOIViewerToolbarVM()
-                };
+            var selectedImage = MainOrientedImageryView.ViewModel.SelectedImage;
+            if (selectedImage == null)
+                return;
 
-                var selector = MainOrientedImageryView.ItemTemplateSelector as OrientedImageryViewTemplateSelector;
-                selector.TypeTemplatePairs.Add(FindResource("DemoOilToolbarSelectorItem") as OrientedImageryViewTemplateSelectorItem);
-                selector.TypeTemplatePairs.Add(FindResource("AlternateAutoUpdateFootprintSelectorItem") as OrientedImageryViewTemplateSelectorItem);
-            }
-            else
+            SelectedImagePopupViewer.Popup = CreatePopup(selectedImage);
+            SelectedImagePopupBackground.Visibility = Visibility.Visible;
+        }
+
+        private static Popup CreatePopup(Mapping.OrientedImage orientedImage)
+        {
+            var graphic = new Graphic(orientedImage.Geometry);
+            foreach (var attribute in orientedImage.Attributes)
             {
-                MainOrientedImageryView.ItemsSource = Esri.ArcGISRuntime.Toolkit.UI.Controls.OrientedImageryView.GetDefaultToolbarItems();
+                graphic.Attributes[attribute.Key] = attribute.Value;
             }
-            _toolbarIsUsingDefaultStyle = !_toolbarIsUsingDefaultStyle;
+
+            return Popup.FromGeoElement(graphic);
+        }
+
+        private void SelectedImagePopupBackground_MouseDown(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            SelectedImagePopupBackground.Visibility = Visibility.Collapsed;
+            SelectedImagePopupViewer.Popup = null;
         }
     }
 }

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using System.Windows.Controls;
 using Esri.ArcGISRuntime.Mapping;
 using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery
 {
@@ -18,24 +19,27 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery
         {
             InitializeComponent();
 
-            _oiLayer = new OrientedImageryLayer(new Uri("https://arcgis.com/"));
             _ = Initialize();
         }
 
         private async Task Initialize()
         {
-            MainMapView.Map = new Mapping.Map(SpatialReferences.Wgs84);
+            _oiLayer = new OrientedImageryLayer(new Uri("https://services8.arcgis.com/joda3ARQ9znLf0hf/arcgis/rest/services/RedRocks/FeatureServer/0"));
+            await _oiLayer.LoadAsync();
+
+            MainMapView.Map = new Mapping.Map(BasemapStyle.ArcGISTopographic);
+            MainMapView.Map.OperationalLayers.Add(_oiLayer);
             MainMapView.GeoViewTapped += MainMapView_GeoViewTapped;
             MainOrientedImageryView.ViewModel.SelectedImage = new Mapping.OrientedImage();
             MainOrientedImageryView.OrientedImageryLayer = _oiLayer;
+            MainMapView.SetViewpoint(new Viewpoint(_oiLayer.FullExtent));
         }
 
         private async void MainMapView_GeoViewTapped(object sender, ArcGISRuntime.UI.Controls.GeoViewInputEventArgs e)
         {
             var parameters = new OrientedImageSearchParameters();
             var images = await _oiLayer.SearchImagesAsync(e.Location, parameters);
-            Collection<OrientedImage> manualImages = [new OrientedImage(), new OrientedImage(), new OrientedImage()];
-            MainOrientedImageryView.ViewModel.SetImages(manualImages, e.Location);
+            MainOrientedImageryView.ViewModel.SetImages(images.ToList(), e.Location);
             MainOrientedImageryView.ViewModel.SelectedImage = images.Count < 1 ? null : images[0];
         }
     }

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml.cs
@@ -3,7 +3,6 @@ using System;
 using System.Threading.Tasks;
 using System.Windows.Controls;
 using Esri.ArcGISRuntime.Mapping;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 
 namespace Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery
@@ -27,7 +26,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery
         {
             MainMapView.Map = new Mapping.Map(SpatialReferences.Wgs84);
             MainMapView.GeoViewTapped += MainMapView_GeoViewTapped;
-            MainOrientedImageryView.SelectedImage = new Mapping.OrientedImage();
+            MainOrientedImageryView.ViewModel.SelectedImage = new Mapping.OrientedImage();
             MainOrientedImageryView.OrientedImageryLayer = _oiLayer;
         }
 
@@ -36,8 +35,8 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery
             var parameters = new OrientedImageSearchParameters();
             var images = await _oiLayer.SearchImagesAsync(e.Location, parameters);
             Collection<OrientedImage> manualImages = [new OrientedImage(), new OrientedImage(), new OrientedImage()];
-            MainOrientedImageryView.SetImages(manualImages, e.Location);
-            MainOrientedImageryView.SelectedImage = images.Count < 1 ? null : images[0];
+            MainOrientedImageryView.ViewModel.SetImages(manualImages, e.Location);
+            MainOrientedImageryView.ViewModel.SelectedImage = images.Count < 1 ? null : images[0];
         }
     }
 }

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml.cs
@@ -55,6 +55,9 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery
 
         private async void MainMapView_GeoViewTapped(object sender, ArcGISRuntime.UI.Controls.GeoViewInputEventArgs e)
         {
+            if (e.Location == null)
+                return;
+
             var parameters = new OrientedImageSearchParameters();
             var images = await _oiLayer.SearchImagesAsync(e.Location, parameters);
             MainOrientedImageryView.ViewModel.SetImages(images.ToList(), e.Location);

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml.cs
@@ -58,12 +58,18 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery
             if (e.Location == null)
                 return;
 
-            var parameters = new OrientedImageSearchParameters();
-            var images = await _oiLayer.SearchImagesAsync(e.Location, parameters);
-            MainOrientedImageryView.ViewModel.SetImages(images.ToList(), e.Location);
-            MainOrientedImageryView.ViewModel.SelectedImage = images.Count < 1 ? null : images[0];
-
-            var test = await _oiLayer.GetSelectedFeaturesAsync();
+            // In this case we are choosing to interpret OrientedImageryViewModel.AllowAddingMarkers as mutually exclusive with image searching.
+            if (!MainOrientedImageryView.ViewModel.AllowAddingMarkers)
+            {
+                var parameters = new OrientedImageSearchParameters();
+                var images = await _oiLayer.SearchImagesAsync(e.Location, parameters);
+                MainOrientedImageryView.ViewModel.SetImages(images.ToList(), e.Location);
+                MainOrientedImageryView.ViewModel.SelectedImage = images.Count < 1 ? null : images[0];
+            }
+            else
+            {
+                MainOrientedImageryView.ViewModel.AddMarkerLocation(e.Location);
+            }
         }
 
         private void ToggleToolbarStyleButton_Click(object sender, System.Windows.RoutedEventArgs e)

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml.cs
@@ -1,8 +1,11 @@
-﻿using Esri.ArcGISRuntime.Mapping;
+﻿#nullable enable
+
+using Esri.ArcGISRuntime.Mapping;
 using Esri.ArcGISRuntime.Mapping.Popups;
 using Esri.ArcGISRuntime.Toolkit.UI.Controls;
 using Esri.ArcGISRuntime.UI;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
@@ -15,7 +18,9 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery
     /// </summary>
     public partial class OrientedImageryView : UserControl
     {
-        private OrientedImageryLayer _oiLayer;
+        private const string BasemapUri = "https://runtime.maps.arcgis.com/home/item.html?id=d8c5e76fb2cc4bb6955a6783a5f577b7";
+
+        private OrientedImageryLayer? _oiLayer;
 
         public OrientedImageryView()
         {
@@ -42,21 +47,28 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery
         {
             await ApplyLayer(new Uri(LayerUriTextBox.Text));
 
-            MainMapView.Map = new Map(BasemapStyle.ArcGISStreets);
+            MainMapView.Map = new Map(new Uri(BasemapUri));
             MainMapView.GeoViewTapped += MainMapView_GeoViewTapped;
         }
 
         private async Task ApplyLayer(Uri layerUri)
         {
-            _oiLayer = new OrientedImageryLayer(layerUri);
-            await _oiLayer.LoadAsync();
+            var oiLayer = new OrientedImageryLayer(layerUri);
+            await oiLayer.LoadAsync();
+            if (oiLayer.LoadStatus == LoadStatus.FailedToLoad)
+                return;
 
-            MainMapView.Map ??= new Mapping.Map(BasemapStyle.ArcGISTopographic);
+            _oiLayer = oiLayer;
+
+            if (MainMapView.Map == null)
+                MainMapView.Map = new Map(new Uri(BasemapUri));
+
             MainMapView.Map.OperationalLayers.Clear();
             MainMapView.Map.OperationalLayers.Add(_oiLayer);
 
             MainOrientedImageryView.OrientedImageryLayer = _oiLayer;
-            MainMapView.SetViewpoint(new Viewpoint(_oiLayer.FullExtent));
+            if (_oiLayer.FullExtent != null)
+                MainMapView.SetViewpoint(new Viewpoint(_oiLayer.FullExtent));
         }
 
         private async void ApplyLayerButton_Click(object sender, System.Windows.RoutedEventArgs e)
@@ -64,22 +76,22 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery
             await ApplyLayer(new Uri(LayerUriTextBox.Text));
         }
 
-        private async void MainMapView_GeoViewTapped(object sender, ArcGISRuntime.UI.Controls.GeoViewInputEventArgs e)
+        private async void MainMapView_GeoViewTapped(object? sender, ArcGISRuntime.UI.Controls.GeoViewInputEventArgs e)
         {
-            if (e.Location == null)
+            if (e.Location == null || _oiLayer == null)
                 return;
 
             // In this case we are choosing to interpret OrientedImageryViewModel.AllowAddingMarkers as mutually exclusive with image searching.
-            if (!MainOrientedImageryView.ViewModel.AllowAddingMarkers)
+            if (MainOrientedImageryView.ViewModel.AllowAddingMarkers)
             {
-                var parameters = new OrientedImageSearchParameters();
-                var images = await _oiLayer.SearchImagesAsync(e.Location, parameters);
-                MainOrientedImageryView.ViewModel.SetImages(images.ToList(), e.Location);
-                MainOrientedImageryView.ViewModel.SelectedImage = images.Count < 1 ? null : images[0];
+                MainOrientedImageryView.ViewModel.AddMarkerLocation(e.Location);
             }
             else
             {
-                MainOrientedImageryView.ViewModel.AddMarkerLocation(e.Location);
+                var parameters = new OrientedImageSearchParameters();
+                var images = await _oiLayer.SearchImagesAsync(e.Location, parameters) ?? new List<OrientedImage>();
+                MainOrientedImageryView.ViewModel.SetImages(images.ToList(), e.Location);
+                MainOrientedImageryView.ViewModel.SelectedImage = images.Count < 1 ? null : images[0];
             }
         }
 

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml.cs
@@ -35,11 +35,11 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery
 
         private ElevationSource _elevationSource;
 
+        private bool _usingAlternateToolbarStyling = false;
+
         public OrientedImageryView()
         {
             InitializeComponent();
-
-            ConfigureToolbar();
 
             _mapView = new MapView() { Map = new Map(new Uri(MapBasemap)) };
             _sceneView = new SceneView() { Scene = new Scene(new Uri(SceneBasemap)) };
@@ -48,18 +48,13 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery
             GeoViewContainer.Children.Add(_mapView);
 
             _orientedImageryVM = new OrientedImageryViewModel();
+            _orientedImageryVM.ToolbarItems.Add(new OrientedImageryPopupToolbarItem());
+
             _elevationSource = new ArcGISTiledElevationSource(new Uri(ElevationUrl));
 
             MainOrientedImageryView.GeoView = _mapView;
             MainOrientedImageryView.ViewModel = _orientedImageryVM;
             MainOrientedImageryView.ImageTapped += MainOrientedImageryView_ImageTapped;
-        }
-
-        private void ConfigureToolbar()
-        {
-            var toolbarItems = Esri.ArcGISRuntime.Toolkit.UI.Controls.OrientedImageryView.GetDefaultToolbarItems();
-            toolbarItems.Add(new ExampleOIToolbarItem());
-            MainOrientedImageryView.ItemsSource = toolbarItems;
         }
 
         private async Task ApplyLayer(Uri layerUri)
@@ -230,6 +225,21 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery
             }
 
             _scenePropertiesState = (_scenePropertiesState + 1) % 4;
+        }
+
+        private void UpdateToolbarButton_Click(object sender, RoutedEventArgs e)
+        {
+            _usingAlternateToolbarStyling = !_usingAlternateToolbarStyling;
+            if (_usingAlternateToolbarStyling)
+            {
+                _orientedImageryVM.ToolbarItems.RemoveAt(_orientedImageryVM.ToolbarItems.Count - 1);
+                MainOrientedImageryView.ToolbarItemTemplateSelector = (OrientedImageryViewTemplateSelector)this.FindResource("AlternateToolbarSelector");
+            }
+            else
+            {
+                _orientedImageryVM.ToolbarItems.Add(new OrientedImageryPopupToolbarItem());
+                MainOrientedImageryView.ToolbarItemTemplateSelector = (OrientedImageryViewTemplateSelector)this.FindResource("CustomToolbarSelector");
+            }
         }
     }
 }

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml.cs
@@ -3,6 +3,7 @@
 using Esri.ArcGISRuntime.Data;
 using Esri.ArcGISRuntime.Mapping;
 using Esri.ArcGISRuntime.Mapping.Popups;
+using Esri.ArcGISRuntime.Toolkit.UI.Controls;
 using Esri.ArcGISRuntime.UI;
 using Esri.ArcGISRuntime.UI.Controls;
 using System;
@@ -24,6 +25,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery
         private const string SceneBasemap = "https://runtime.maps.arcgis.com/home/item.html?id=0560e29930dc4d5ebeb58c635c0909c9";
         private const string ElevationUrl = "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer";
 
+        private OrientedImageryViewModel _orientedImageryVM;
         private OrientedImageryLayer? _oiLayer;
 
         private MapView _mapView;
@@ -36,6 +38,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery
         public OrientedImageryView()
         {
             InitializeComponent();
+
             ConfigureToolbar();
 
             _mapView = new MapView() { Map = new Map(new Uri(MapBasemap)) };
@@ -43,9 +46,12 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery
             _usingMapView = true;
             _mapView.GeoViewTapped += CurrentGeoView_GeoViewTapped;
             GeoViewContainer.Children.Add(_mapView);
-            MainOrientedImageryView.GeoView = _mapView;
 
+            _orientedImageryVM = new OrientedImageryViewModel();
             _elevationSource = new ArcGISTiledElevationSource(new Uri(ElevationUrl));
+
+            MainOrientedImageryView.GeoView = _mapView;
+            MainOrientedImageryView.ViewModel = _orientedImageryVM;
         }
 
         private void ConfigureToolbar()
@@ -78,7 +84,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery
                     sceneView.Scene.OperationalLayers.Add(_oiLayer);
                 }
 
-                MainOrientedImageryView.OrientedImageryLayer = _oiLayer;
+                _orientedImageryVM.OrientedImageryLayer = _oiLayer;
                 if (_oiLayer?.FullExtent != null)
                     _currentGeoView.SetViewpoint(new Viewpoint(_oiLayer.FullExtent));
             }
@@ -99,29 +105,29 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery
                 return;
 
             // In this case we are choosing to interpret OrientedImageryViewModel.AllowAddingMarkers as mutually exclusive with image searching.
-            if (MainOrientedImageryView.ViewModel.AllowAddingMarkers)
+            if (_orientedImageryVM.AllowAddingMarkers)
             {
-                MainOrientedImageryView.ViewModel.AddMarkerLocation(e.Location);
+                _orientedImageryVM.AddMarkerLocation(e.Location);
                 return;
             }
 
             var identifyResult = await _currentGeoView.IdentifyLayerAsync(_oiLayer, e.Position, 0, false);
             if (identifyResult.GeoElements.Count > 0 && identifyResult.GeoElements[0] is Feature feature)
             {
-                MainOrientedImageryView.ViewModel.SelectedImage = await _oiLayer.FetchImageForFeatureAsync(feature);
+                _orientedImageryVM.SelectedImage = await _oiLayer.FetchImageForFeatureAsync(feature);
             }
             else
             {
                 var parameters = new OrientedImageSearchParameters() { MaxResults = -1 };
                 var images = await _oiLayer.SearchImagesAsync(e.Location, parameters) ?? new List<OrientedImage>();
-                MainOrientedImageryView.ViewModel.SetImages(images.ToList(), e.Location);
-                MainOrientedImageryView.ViewModel.SelectedImage = images.Count < 1 ? null : images[0];
+                _orientedImageryVM.SetImages(images.ToList(), e.Location);
+                _orientedImageryVM.SelectedImage = images.Count < 1 ? null : images[0];
             }
         }
 
         private void OpenSelectedImagePopupButton_Click(object sender, RoutedEventArgs e)
         {
-            var selectedImage = MainOrientedImageryView.ViewModel.SelectedImage;
+            var selectedImage = _orientedImageryVM.SelectedImage;
             if (selectedImage == null)
                 return;
 

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/OrientedImagery/OrientedImageryView.xaml.cs
@@ -52,6 +52,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery
 
             MainOrientedImageryView.GeoView = _mapView;
             MainOrientedImageryView.ViewModel = _orientedImageryVM;
+            MainOrientedImageryView.ImageTapped += MainOrientedImageryView_ImageTapped;
         }
 
         private void ConfigureToolbar()
@@ -122,6 +123,23 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.OrientedImagery
                 var images = await _oiLayer.SearchImagesAsync(e.Location, parameters) ?? new List<OrientedImage>();
                 _orientedImageryVM.SetImages(images.ToList(), e.Location);
                 _orientedImageryVM.SelectedImage = images.Count < 1 ? null : images[0];
+            }
+        }
+
+        private async void MainOrientedImageryView_ImageTapped(object? sender, OrientedImageDisplay.ImageClickedEventArgs e)
+        {
+            // Do not add a new marker if there is already one in proximity to the click location
+            if (e.Marker != null)
+                return;
+
+            try
+            {
+                var location = await e.Image.ImageToLocationAsync(e.ImagePoint);
+                _orientedImageryVM.AddMarkerLocation(location);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Error converting image point to location: {ex.Message}");
             }
         }
 

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml
@@ -22,6 +22,13 @@
 
     <Style TargetType="{x:Type controls:OrientedImageryView}">
         <Setter Property="IsTabStop" Value="False" />
+        <Setter Property="ItemsPanel">
+            <Setter.Value>
+                <ItemsPanelTemplate>
+                    <StackPanel Orientation="Horizontal" />
+                </ItemsPanelTemplate>
+            </Setter.Value>
+        </Setter>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type controls:OrientedImageryView}">
@@ -53,6 +60,7 @@
                                     Content="Show unselected images footprints"
                                     IsChecked="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=ShowUnselectedImagesFootprints, Mode=TwoWay}"
                                     ToolTip="Show unselected images footprints" />
+                                <ItemsPresenter />
                             </WrapPanel>
                             <Grid Grid.Row="1">
                                 <Grid.ColumnDefinitions>

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml
@@ -86,6 +86,41 @@
         </Style.Triggers>
     </Style>
 
+    <Style x:Key="ImageNavigationButtonStyle" TargetType="{x:Type Button}">
+        <Setter Property="Width" Value="25" />
+        <Setter Property="MinHeight" Value="60" />
+        <Setter Property="Padding" Value="4" />
+        <Setter Property="Background" Value="#40FFFFFF" />
+        <Setter Property="BorderBrush" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type Button}">
+                    <Border x:Name="Root"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}">
+                        <ContentPresenter HorizontalAlignment="Center"
+                                          VerticalAlignment="Center"
+                                          Margin="{TemplateBinding Padding}" />
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="Root" Property="Background" Value="#DFFFFFFF" />
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter TargetName="Root" Property="Background" Value="#FFFFFFFF" />
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Opacity" Value="0.35" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <!-- Toolbar data templates -->
     <DataTemplate x:Key="MarkerPickerToolbarTemplate" DataType="controls:SelectNewMarkerSymbolVM">
         <Button Style="{StaticResource ToolbarButtonStyle}" Command="{Binding SelectNextSymbol}" Visibility="{Binding MainViewModel.AllowAddingMarkers, Converter={StaticResource BooleanToVisibilityConverter}}">
@@ -155,13 +190,45 @@
     </DataTemplate>
 
     <DataTemplate x:Key="ShowCameraMarkersToolbarTemplate" DataType="controls:ShowCameraMarkersVM">
-        <ToggleButton Style="{StaticResource ToolbarToggleButtonStyle}" IsChecked="{Binding MainViewModel.ShowSelectedCameraLocationsOnDisplay}">
+        <Button Command="{Binding ToggleCameraMarkerDisplayMode}">
+            <Button.Style>
+                <Style TargetType="{x:Type Button}" BasedOn="{StaticResource ToolbarButtonStyle}">
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding MainViewModel.ShowSelectedCameraLocations}" Value="True">
+                            <Setter Property="Background" Value="#FFD3D3D3" />
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </Button.Style>
             <Viewbox Width="20" Height="20" Stretch="Uniform">
                 <Grid Width="32" Height="32">
-                    <Path Fill="Black" Data="M11 12.5v.5H6v-1h5zm19 11v-12A2.503 2.503 0 0 0 27.5 9H27a1 1 0 0 1-1-1 2 2 0 0 0-2-2h-8a2 2 0 0 0-2 2 1 1 0 0 1-1 1h-2V8H6v1H4.5A2.503 2.503 0 0 0 2 11.5v12A2.503 2.503 0 0 0 4.5 26h23a2.503 2.503 0 0 0 2.5-2.5M7 10V9h3v1h3a2 2 0 0 0 2-2 1 1 0 0 1 1-1h8a1 1 0 0 1 1 1 2 2 0 0 0 2 2h.5a1.5 1.5 0 0 1 1.5 1.5v12a1.5 1.5 0 0 1-1.5 1.5h-23A1.5 1.5 0 0 1 3 23.5v-12A1.5 1.5 0 0 1 4.5 10zm18.8 7a5.8 5.8 0 1 0-5.8 5.8 5.806 5.806 0 0 0 5.8-5.8m-1 0a4.8 4.8 0 1 1-4.8-4.8 4.805 4.805 0 0 1 4.8 4.8" />
+                    <Path Fill="Black" Data="M11 12.5v.5H6v-1h5zm19 11v-12A2.503 2.503 0 0 0 27.5 9H27a1 1 0 0 1-1-1 2 2 0 0 0-2-2h-8a2 2 0 0 0-2 2 1 1 0 0 1-1 1h-2V8H6v1H4.5A2.503 2.503 0 0 0 2 11.5v12A2.503 2.503 0 0 0 4.5 26h23a2.503 2.503 0 0 0 2.5-2.5M7 10V9h3v1h3a2 2 0 0 0 2-2 1 1 0 0 1 1-1h8a1 1 0 0 1 1 1 2 2 0 0 0 2 2h.5a1.5 1.5 0 0 1 1.5 1.5v12a1.5 1.5 0 0 1-1.5 1.5h-23A1.5 1.5 0 0 1 3 23.5v-12A1.5 1.5 0 0 1 4.5 10zm18.8 7a5.8 5.8 0 1 0-5.8 5.8 5.806 5.806 0 0 0 5.8-5.8m-1 0a4.8 4.8 0 1 1-4.8-4.8 4.805 4.805 0 0 1 4.8 4.8">
+                        <Path.Style>
+                            <Style TargetType="{x:Type Path}">
+                                <Setter Property="Visibility" Value="Visible" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding MainViewModel.ShowSelectedCameraLocationsOnDisplay}" Value="True">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Path.Style>
+                    </Path>
+                    <Path Fill="Black" Data="M11 13H6v-1h5zm16.5 13a2.503 2.503 0 0 0 2.5-2.5v-12A2.503 2.503 0 0 0 27.5 9H27a1 1 0 0 1-1-1 2 2 0 0 0-2-2h-8a2 2 0 0 0-2 2 1 1 0 0 1-1 1h-2V8H6v1H4.5A2.503 2.503 0 0 0 2 11.5V22h1V11.5A1.5 1.5 0 0 1 4.5 10H7V9h3v1h3a2 2 0 0 0 2-2 1 1 0 0 1 1-1h8a1 1 0 0 1 1 1 2 2 0 0 0 2 2h.5a1.5 1.5 0 0 1 1.5 1.5v12a1.5 1.5 0 0 1-1.5 1.5H15v.999zm-13.3-9a5.8 5.8 0 1 1 5.8 5.8 5.806 5.806 0 0 1-5.8-5.8m1 0a4.8 4.8 0 1 0 4.8-4.8 4.805 4.805 0 0 0-4.8 4.8M8 24.999h5V24H8v-5H7v5H2v.999h5V30h1z">
+                        <Path.Style>
+                            <Style TargetType="{x:Type Path}">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding MainViewModel.ShowSelectedCameraLocationsOnDisplay}" Value="True">
+                                        <Setter Property="Visibility" Value="Visible" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Path.Style>
+                    </Path>
                 </Grid>
             </Viewbox>
-        </ToggleButton>
+        </Button>
     </DataTemplate>
 
     <DataTemplate x:Key="ClearMarkersToolbarTemplate" DataType="controls:ClearMarkersVM">
@@ -281,12 +348,32 @@
                                     </Border>
                                 </Popup>
 
-                                <Button Content="&lt;"
+                                <Button Style="{StaticResource ImageNavigationButtonStyle}"
                                         Command="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=ViewModel.SelectPreviousImageCommand}"
-                                        VerticalAlignment="Center"/>
-                                <Button Content="&gt;"
+                                        VerticalAlignment="Center">
+                                    <Viewbox Width="20" Height="20" Stretch="Uniform">
+                                        <Grid Width="32" Height="32">
+                                            <Path Fill="Black" Data="M20 26.1 9.9 16 20 5.9z">
+                                                <Path.RenderTransform>
+                                                    <TranslateTransform X="-3" Y="3" />
+                                                </Path.RenderTransform>
+                                            </Path>
+                                        </Grid>
+                                    </Viewbox>
+                                </Button>
+                                <Button Style="{StaticResource ImageNavigationButtonStyle}"
                                         Command="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=ViewModel.SelectNextImageCommand}"
-                                        Grid.Column="2" VerticalAlignment="Center" />
+                                        Grid.Column="2" VerticalAlignment="Center">
+                                    <Viewbox Width="20" Height="20" Stretch="Uniform">
+                                        <Grid Width="32" Height="32">
+                                            <Path Fill="Black" Data="M12 5.9 22.1 16 12 26.1z">
+                                                <Path.RenderTransform>
+                                                    <TranslateTransform Y="2" />
+                                                </Path.RenderTransform>
+                                            </Path>
+                                        </Grid>
+                                    </Viewbox>
+                                </Button>
                             </Grid>
                         </Grid>
                     </Border>

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml
@@ -25,7 +25,7 @@
         <Setter Property="ItemsPanel">
             <Setter.Value>
                 <ItemsPanelTemplate>
-                    <StackPanel Orientation="Horizontal" />
+                    <WrapPanel Orientation="Horizontal" />
                 </ItemsPanelTemplate>
             </Setter.Value>
         </Setter>
@@ -41,27 +41,9 @@
                                 <RowDefinition Height="Auto" />
                                 <RowDefinition Height="*" />
                             </Grid.RowDefinitions>
-                            <WrapPanel Margin="4,4,4,0">
-                                <ToggleButton
-                                    Margin="0,0,4,4"
-                                    Padding="8,4"
-                                    Content="Auto update footprint"
-                                    IsChecked="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=AutoUpdateFootprint, Mode=TwoWay}"
-                                    ToolTip="Update footprint" />
-                                <ToggleButton
-                                    Margin="0,0,4,4"
-                                    Padding="8,4"
-                                    Content="Show selected image footprint"
-                                    IsChecked="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=ShowSelectedImageFootprint, Mode=TwoWay}"
-                                    ToolTip="Show selected image footprint" />
-                                <ToggleButton
-                                    Margin="0,0,4,4"
-                                    Padding="8,4"
-                                    Content="Show unselected images footprints"
-                                    IsChecked="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=ShowUnselectedImagesFootprints, Mode=TwoWay}"
-                                    ToolTip="Show unselected images footprints" />
-                                <ItemsPresenter />
-                            </WrapPanel>
+
+                            <ItemsPresenter />
+
                             <Grid Grid.Row="1">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="Auto" />

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml
@@ -351,6 +351,23 @@
                                     </ProgressBar.Style>
                                 </ProgressBar>
 
+                                <Border Grid.ColumnSpan="3"
+                                        Background="#80FFFFFF">
+                                    <Border.Style>
+                                        <Style TargetType="{x:Type Border}">
+                                            <Setter Property="Visibility" Value="Collapsed" />
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=ViewModel.SelectedImage}" Value="{x:Null}">
+                                                    <Setter Property="Visibility" Value="Visible" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Border.Style>
+                                    <TextBlock HorizontalAlignment="Center"
+                                               VerticalAlignment="Center"
+                                               Text="No images selected" />
+                                </Border>
+
                                 <Popup PlacementTarget="{Binding ElementName=PART_ImageDisplay}"
                                        Placement="Center"
                                        StaysOpen="True">

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml
@@ -138,17 +138,6 @@
         </ToggleButton>
     </DataTemplate>
 
-    <DataTemplate x:Key="AutoUpdateFootprintToolbarTemplate" DataType="controls:AutoUpdateFootprintVM">
-        <ToggleButton Style="{StaticResource ToolbarToggleButtonStyle}" IsChecked="{Binding MainViewModel.AutoUpdateFootprint}" ToolTip="Auto-update footprint">
-            <Viewbox Width="32" Height="32" Stretch="Uniform">
-                <Grid Width="32" Height="32">
-                    <Path SnapsToDevicePixels="true" Fill="Black" Opacity="0.25" Data="M20 23.672 3.962 7.225l3.243-5.019 15.574 4.727L20 8.6z" />
-                    <Path SnapsToDevicePixels="true" Fill="Black" Data="M1.456 1.696a.47.47 0 0 1 .283-.362 7.03 7.03 0 0 1 5.351.782c.043.027.078.062.12.09L4.866 5.827c-.03-.017-.06-.03-.088-.048a1.835 1.835 0 0 1-.687-2.62 2.57 2.57 0 0 1 1.067-.905 5.1 5.1 0 0 0-2.856-.011A4.58 4.58 0 0 0 4.53 6.346l-.572.884a5.15 5.15 0 0 1-2.503-5.534zM32 30v1H0v-1h1V18h14v12h5V8.6L31 2v28zm-18 0V19H2v11zm16 0V3.767l-9 5.399V30zM6 9V8H5v1zm3-7H8v1h1zm3 1h-1v1h1zm3 1h-1v1h1zm3 1h-1v1h1zm3 1h-1v1h1zM7 11h1v-1H7zm2 2h1v-1H9zm3 1h-1v1h1zm2 2h-1v1h1zm9 12h2v-2h-2zm3 0h2v-2h-2zM7 28h2v-2H7zm-3 0h2v-2H4zm6 0h2v-2h-2zm-3-3h2v-2H7zm-3 0h2v-2H4zm6 0h2v-2h-2zm-3-3h2v-2H7zm-3 0h2v-2H4zm6 0h2v-2h-2zm13 3h2v-2h-2zm3 0h2v-2h-2zm-3-3h2v-2h-2zm3 0h2v-2h-2zm-3-3h2v-2h-2zm3 0h2v-2h-2zm-3-3h2v-2h-2zm3 0h2v-2h-2zm-3-3h2v-2h-2zm3 0h2v-2h-2zm0-3h2V8h-2z" />
-                </Grid>
-            </Viewbox>
-        </ToggleButton>
-    </DataTemplate>
-
     <DataTemplate x:Key="ShowSelectedFootprintToolbarTemplate" DataType="controls:ShowSelectedFootprintVM">
         <ToggleButton Style="{StaticResource ToolbarToggleButtonStyle}" IsChecked="{Binding MainViewModel.ShowSelectedFootprint}" ToolTip="Show selected image footprint">
             <Viewbox SnapsToDevicePixels="true" Width="30" Height="30" Stretch="Uniform">
@@ -270,7 +259,6 @@
                 <controls:OrientedImageryViewTemplateSelector>
                     <controls:OrientedImageryViewTemplateSelectorItem Type="{x:Type controls:SelectNewMarkerSymbolVM}" Template="{StaticResource MarkerPickerToolbarTemplate}" />
                     <controls:OrientedImageryViewTemplateSelectorItem Type="{x:Type controls:AllowAddingMarkersVM}" Template="{StaticResource AllowAddingMarkersToolbarTemplate}" />
-                    <controls:OrientedImageryViewTemplateSelectorItem Type="{x:Type controls:AutoUpdateFootprintVM}" Template="{StaticResource AutoUpdateFootprintToolbarTemplate}" />
                     <controls:OrientedImageryViewTemplateSelectorItem Type="{x:Type controls:ShowSelectedFootprintVM}" Template="{StaticResource ShowSelectedFootprintToolbarTemplate}" />
                     <controls:OrientedImageryViewTemplateSelectorItem Type="{x:Type controls:ShowUnselectedFootprintsVM}" Template="{StaticResource ShowUnselectedFootprintsToolbarTemplate}" />
                     <controls:OrientedImageryViewTemplateSelectorItem Type="{x:Type controls:ShowCameraMarkersVM}" Template="{StaticResource ShowCameraMarkersToolbarTemplate}" />

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml
@@ -4,6 +4,33 @@
     xmlns:internal="clr-namespace:Esri.ArcGISRuntime.Toolkit.Internal"
     xmlns:controls="clr-namespace:Esri.ArcGISRuntime.Toolkit.UI.Controls">
 
+    <!-- Toolbar data templates -->
+    <DataTemplate x:Key="MarkerPickerToolbarTemplate" DataType="controls:SelectNewMarkerSymbolVM">
+        <Button Command="{Binding SelectNextSymbol}">
+            <controls:SymbolDisplay Symbol="{Binding SelectedSymbol, Mode=OneWay}" />
+        </Button>
+    </DataTemplate>
+
+    <DataTemplate x:Key="AutoUpdateFootprintToolbarTemplate" DataType="controls:AutoUpdateFootprintVM">
+        <ToggleButton Content="AU" IsChecked="{Binding MainViewModel.AutoUpdateFootprint}"/>
+    </DataTemplate>
+
+    <DataTemplate x:Key="ShowSelectedFootprintToolbarTemplate" DataType="controls:ShowSelectedFootprintVM">
+        <ToggleButton Content="FA" IsChecked="{Binding MainViewModel.ShowSelectedFootprint}"/>
+    </DataTemplate>
+
+    <DataTemplate x:Key="ShowUnselectedFootprintsToolbarTemplate" DataType="controls:ShowUnselectedFootprintsVM">
+        <ToggleButton Content="FA" IsChecked="{Binding MainViewModel.ShowUnselectedFootprints}"/>
+    </DataTemplate>
+
+    <DataTemplate x:Key="ShowCameraMarkersToolbarTemplate" DataType="controls:ShowCameraMarkersVM">
+        <ToggleButton Content="Cameras" />
+    </DataTemplate>
+
+    <DataTemplate x:Key="ClearMarkersToolbarTemplate" DataType="controls:ClearMarkersVM">
+        <Button Content="❌" Command="{Binding MainViewModel.ClearMarkersCommand}"/>
+    </DataTemplate>
+
     <Style TargetType="{x:Type controls:OrientedImageDisplay}">
         <Setter Property="IsTabStop" Value="False" />
         <Setter Property="Template">
@@ -22,6 +49,20 @@
 
     <Style TargetType="{x:Type controls:OrientedImageryView}">
         <Setter Property="IsTabStop" Value="False" />
+
+        <Setter Property="ItemTemplateSelector">
+            <Setter.Value>
+                <controls:OrientedImageryViewTemplateSelector>
+                    <controls:OrientedImageryViewTemplateSelectorItem Type="{x:Type controls:SelectNewMarkerSymbolVM}" Template="{StaticResource MarkerPickerToolbarTemplate}" />
+                    <controls:OrientedImageryViewTemplateSelectorItem Type="{x:Type controls:AutoUpdateFootprintVM}" Template="{StaticResource AutoUpdateFootprintToolbarTemplate}" />
+                    <controls:OrientedImageryViewTemplateSelectorItem Type="{x:Type controls:ShowSelectedFootprintVM}" Template="{StaticResource ShowSelectedFootprintToolbarTemplate}" />
+                    <controls:OrientedImageryViewTemplateSelectorItem Type="{x:Type controls:ShowUnselectedFootprintsVM}" Template="{StaticResource ShowUnselectedFootprintsToolbarTemplate}" />
+                    <controls:OrientedImageryViewTemplateSelectorItem Type="{x:Type controls:ShowCameraMarkersVM}" Template="{StaticResource ShowCameraMarkersToolbarTemplate}" />
+                    <controls:OrientedImageryViewTemplateSelectorItem Type="{x:Type controls:ClearMarkersVM}" Template="{StaticResource ClearMarkersToolbarTemplate}" />
+                </controls:OrientedImageryViewTemplateSelector>
+            </Setter.Value>
+        </Setter>
+
         <Setter Property="ItemsPanel">
             <Setter.Value>
                 <ItemsPanelTemplate>
@@ -29,6 +70,7 @@
                 </ItemsPanelTemplate>
             </Setter.Value>
         </Setter>
+
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type controls:OrientedImageryView}">
@@ -66,4 +108,5 @@
             </Setter.Value>
         </Setter>
     </Style>
+
 </ResourceDictionary>

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml
@@ -24,7 +24,7 @@
     </DataTemplate>
 
     <DataTemplate x:Key="ShowCameraMarkersToolbarTemplate" DataType="controls:ShowCameraMarkersVM">
-        <ToggleButton Content="Cameras" />
+        <ToggleButton Content="Cameras" IsChecked="{Binding MainViewModel.ShowSelectedCameraLocationsOnDisplay}"/>
     </DataTemplate>
 
     <DataTemplate x:Key="ClearMarkersToolbarTemplate" DataType="controls:ClearMarkersVM">

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml
@@ -6,6 +6,7 @@
 
     <FontFamily x:Key="ToolkitIconsFontFamily">pack://application:,,,/Esri.ArcGISRuntime.Toolkit.WPF;component/Assets/toolkit-icons.ttf#calcite-ui-icons-24</FontFamily>
     <internal:ColorToColorConverter x:Key="ColorToColorConverter" />
+    <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
 
     <Style x:Key="ToolbarButtonStyle" TargetType="{x:Type Button}">
         <Setter Property="MinWidth" Value="40" />
@@ -87,11 +88,21 @@
 
     <!-- Toolbar data templates -->
     <DataTemplate x:Key="MarkerPickerToolbarTemplate" DataType="controls:SelectNewMarkerSymbolVM">
-        <Button Style="{StaticResource ToolbarButtonStyle}" Command="{Binding SelectNextSymbol}">
+        <Button Style="{StaticResource ToolbarButtonStyle}" Command="{Binding SelectNextSymbol}" Visibility="{Binding MainViewModel.AllowAddingMarkers, Converter={StaticResource BooleanToVisibilityConverter}}">
             <Viewbox Width="20" Height="20" Stretch="Uniform">
                 <controls:SymbolDisplay Symbol="{Binding SelectedSymbol, Mode=OneWay}" />
             </Viewbox>
         </Button>
+    </DataTemplate>
+
+    <DataTemplate x:Key="AllowAddingMarkersToolbarTemplate" DataType="controls:AllowAddingMarkersVM">
+        <ToggleButton Style="{StaticResource ToolbarToggleButtonStyle}" IsChecked="{Binding MainViewModel.AllowAddingMarkers}">
+            <Viewbox Width="20" Height="20" Stretch="Uniform">
+                <Grid Width="32" Height="32">
+                    <Path Fill="Black" Data="M29 8v15.247l-3.997-3.669a.65.65 0 0 0-.926-.033L21 22.293l-4.554-4.131a.65.65 0 0 0-.857-.013l-5.139 4.268-.826-.391a.64.64 0 0 0-.72.117L5 25.248V20.56l-1-1.006V29h26V7H14v1zm0 20H5v-1.474l4.401-3.5 1.198.567L16 19.106l5 4.531 3.506-3.123L29 24.581zm-8-12a2 2 0 1 0-2-2 2 2 0 0 0 2 2m0-3a1 1 0 1 1-1 1 1 1 0 0 1 1-1M7 19.735l5-5.032V6.038c0-2.493-1.776-3.865-5-3.865-3.178 0-5 1.445-5 3.964v8.566zM3 6.137c0-2.45 2.175-2.964 4-2.964 2.654 0 4 .964 4 2.864v8.254l-4 4.026-4-4.026zM5 8a2 2 0 1 0 2-2 2 2 0 0 0-2 2m3 0a1 1 0 1 1-1-1 1 1 0 0 1 1 1" />
+                </Grid>
+            </Viewbox>
+        </ToggleButton>
     </DataTemplate>
 
     <DataTemplate x:Key="AutoUpdateFootprintToolbarTemplate" DataType="controls:AutoUpdateFootprintVM">
@@ -186,6 +197,7 @@
             <Setter.Value>
                 <controls:OrientedImageryViewTemplateSelector>
                     <controls:OrientedImageryViewTemplateSelectorItem Type="{x:Type controls:SelectNewMarkerSymbolVM}" Template="{StaticResource MarkerPickerToolbarTemplate}" />
+                        <controls:OrientedImageryViewTemplateSelectorItem Type="{x:Type controls:AllowAddingMarkersVM}" Template="{StaticResource AllowAddingMarkersToolbarTemplate}" />
                     <controls:OrientedImageryViewTemplateSelectorItem Type="{x:Type controls:AutoUpdateFootprintVM}" Template="{StaticResource AutoUpdateFootprintToolbarTemplate}" />
                     <controls:OrientedImageryViewTemplateSelectorItem Type="{x:Type controls:ShowSelectedFootprintVM}" Template="{StaticResource ShowSelectedFootprintToolbarTemplate}" />
                     <controls:OrientedImageryViewTemplateSelectorItem Type="{x:Type controls:ShowUnselectedFootprintsVM}" Template="{StaticResource ShowUnselectedFootprintsToolbarTemplate}" />

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml
@@ -4,6 +4,7 @@
     xmlns:internal="clr-namespace:Esri.ArcGISRuntime.Toolkit.Internal"
     xmlns:controls="clr-namespace:Esri.ArcGISRuntime.Toolkit.UI.Controls">
 
+    <FontFamily x:Key="ToolkitIconsFontFamily">pack://application:,,,/Esri.ArcGISRuntime.Toolkit.WPF;component/Assets/toolkit-icons.ttf#calcite-ui-icons-24</FontFamily>
     <internal:ColorToColorConverter x:Key="ColorToColorConverter" />
     <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
 
@@ -131,9 +132,10 @@
     <DataTemplate x:Key="AllowAddingMarkersToolbarTemplate" DataType="controls:AllowAddingMarkersVM">
         <ToggleButton Style="{StaticResource ToolbarToggleButtonStyle}" IsChecked="{Binding MainViewModel.AllowAddingMarkers}" ToolTip="{internal:LocalizedString Key=OrientedImageryViewToggleAddMarkers}">
             <Viewbox Width="32" Height="32" Stretch="Uniform">
-                <Grid Width="32" Height="32">
-                    <Path SnapsToDevicePixels="true" Fill="Black" Data="M29 8v15.247l-3.997-3.669a.65.65 0 0 0-.926-.033L21 22.293l-4.554-4.131a.65.65 0 0 0-.857-.013l-5.139 4.268-.826-.391a.64.64 0 0 0-.72.117L5 25.248V20.56l-1-1.006V29h26V7H14v1zm0 20H5v-1.474l4.401-3.5 1.198.567L16 19.106l5 4.531 3.506-3.123L29 24.581zm-8-12a2 2 0 1 0-2-2 2 2 0 0 0 2 2m0-3a1 1 0 1 1-1 1 1 1 0 0 1 1-1M7 19.735l5-5.032V6.038c0-2.493-1.776-3.865-5-3.865-3.178 0-5 1.445-5 3.964v8.566zM3 6.137c0-2.45 2.175-2.964 4-2.964 2.654 0 4 .964 4 2.864v8.254l-4 4.026-4-4.026zM5 8a2 2 0 1 0 2-2 2 2 0 0 0-2 2m3 0a1 1 0 1 1-1-1 1 1 0 0 1 1 1" />
-                </Grid>
+                <TextBlock Text="&#xe8ed;"
+                           FontSize="24"
+                           FontFamily="{StaticResource ToolkitIconsFontFamily}"
+                           Foreground="Black" />
             </Viewbox>
         </ToggleButton>
     </DataTemplate>
@@ -142,6 +144,7 @@
         <ToggleButton Style="{StaticResource ToolbarToggleButtonStyle}" IsChecked="{Binding MainViewModel.ShowSelectedFootprint}" ToolTip="{internal:LocalizedString Key=OrientedImageryViewShowSelectedImageFootprint}">
             <Viewbox SnapsToDevicePixels="true" Width="30" Height="30" Stretch="Uniform">
                 <Grid Width="24" Height="24">
+                    <!-- A font icon was not available for this calcite symbol (trapezoid). Using two manual Paths also allows binding separate colors for fill and stroke. -->
                     <Path SnapsToDevicePixels="true" Data="M19.384 20H4.616L.349 4h23.302zm-14-1h13.232l3.733-14H1.651z">
                         <Path.Fill>
                             <SolidColorBrush Color="{Binding MainViewModel.SelectedFootprintOutlineColor, Converter={StaticResource ColorToColorConverter}}" />
@@ -161,6 +164,7 @@
         <ToggleButton Style="{StaticResource ToolbarToggleButtonStyle}" IsChecked="{Binding MainViewModel.ShowUnselectedFootprints}" ToolTip="{internal:LocalizedString Key=OrientedImageryViewShowUnselectedImageFootprints}">
             <Viewbox SnapsToDevicePixels="true" Width="30" Height="30" Stretch="Uniform">
                 <Grid Width="24" Height="24">
+                    <!-- See comment on ShowSelectedFootprintToolbarTemplate. -->
                     <Path SnapsToDevicePixels="true" Data="M19.384 20H4.616L.349 4h23.302zm-14-1h13.232l3.733-14H1.651z">
                         <Path.Fill>
                             <SolidColorBrush Color="{Binding MainViewModel.UnselectedFootprintOutlineColor, Converter={StaticResource ColorToColorConverter}}" />
@@ -192,11 +196,14 @@
                     </Style.Triggers>
                 </Style>
             </Button.Style>
-            <Viewbox Width="32" Height="32" Stretch="Uniform">
-                <Grid Width="32" Height="32">
-                    <Path Fill="Black" Data="M11 12.5v.5H6v-1h5zm19 11v-12A2.503 2.503 0 0 0 27.5 9H27a1 1 0 0 1-1-1 2 2 0 0 0-2-2h-8a2 2 0 0 0-2 2 1 1 0 0 1-1 1h-2V8H6v1H4.5A2.503 2.503 0 0 0 2 11.5v12A2.503 2.503 0 0 0 4.5 26h23a2.503 2.503 0 0 0 2.5-2.5M7 10V9h3v1h3a2 2 0 0 0 2-2 1 1 0 0 1 1-1h8a1 1 0 0 1 1 1 2 2 0 0 0 2 2h.5a1.5 1.5 0 0 1 1.5 1.5v12a1.5 1.5 0 0 1-1.5 1.5h-23A1.5 1.5 0 0 1 3 23.5v-12A1.5 1.5 0 0 1 4.5 10zm18.8 7a5.8 5.8 0 1 0-5.8 5.8 5.806 5.806 0 0 0 5.8-5.8m-1 0a4.8 4.8 0 1 1-4.8-4.8 4.805 4.805 0 0 1 4.8 4.8">
-                        <Path.Style>
-                            <Style TargetType="{x:Type Path}">
+            <Grid Width="32" Height="32">
+                <Viewbox Width="32" Height="32" Stretch="Uniform">
+                    <TextBlock Text="&#xe77a;"
+                           FontSize="24"
+                           FontFamily="{StaticResource ToolkitIconsFontFamily}"
+                           Foreground="Black">
+                        <TextBlock.Style>
+                            <Style TargetType="{x:Type TextBlock}">
                                 <Setter Property="Visibility" Value="Visible" />
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding MainViewModel.ShowCameraLocationsOnDisplay}" Value="True">
@@ -204,11 +211,16 @@
                                     </DataTrigger>
                                 </Style.Triggers>
                             </Style>
-                        </Path.Style>
-                    </Path>
-                    <Path VerticalAlignment="Stretch" Fill="Black" Data="M11 13H6v-1h5zm16.5 13a2.503 2.503 0 0 0 2.5-2.5v-12A2.503 2.503 0 0 0 27.5 9H27a1 1 0 0 1-1-1 2 2 0 0 0-2-2h-8a2 2 0 0 0-2 2 1 1 0 0 1-1 1h-2V8H6v1H4.5A2.503 2.503 0 0 0 2 11.5V22h1V11.5A1.5 1.5 0 0 1 4.5 10H7V9h3v1h3a2 2 0 0 0 2-2 1 1 0 0 1 1-1h8a1 1 0 0 1 1 1 2 2 0 0 0 2 2h.5a1.5 1.5 0 0 1 1.5 1.5v12a1.5 1.5 0 0 1-1.5 1.5H15v.999zm-13.3-9a5.8 5.8 0 1 1 5.8 5.8 5.806 5.806 0 0 1-5.8-5.8m1 0a4.8 4.8 0 1 0 4.8-4.8 4.805 4.805 0 0 0-4.8 4.8M8 24.999h5V24H8v-5H7v5H2v.999h5V30h1z">
-                        <Path.Style>
-                            <Style TargetType="{x:Type Path}">
+                        </TextBlock.Style>
+                    </TextBlock>
+                </Viewbox>
+                <Viewbox>
+                    <TextBlock Text="&#xe77d;"
+                           FontSize="24"
+                           FontFamily="{StaticResource ToolkitIconsFontFamily}"
+                           Foreground="Black">
+                        <TextBlock.Style>
+                            <Style TargetType="{x:Type TextBlock}">
                                 <Setter Property="Visibility" Value="Collapsed" />
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding MainViewModel.ShowCameraLocationsOnDisplay}" Value="True">
@@ -216,19 +228,20 @@
                                     </DataTrigger>
                                 </Style.Triggers>
                             </Style>
-                        </Path.Style>
-                    </Path>
-                </Grid>
-            </Viewbox>
+                        </TextBlock.Style>
+                    </TextBlock>
+                </Viewbox>
+            </Grid>
         </Button>
     </DataTemplate>
 
     <DataTemplate x:Key="ClearMarkersToolbarTemplate" DataType="controls:ClearMarkersVM">
         <Button Style="{StaticResource ToolbarButtonStyle}" Command="{Binding MainViewModel.ClearMarkersCommand}" ToolTip="{internal:LocalizedString Key=OrientedImageryViewClearMarkers}">
             <Viewbox Width="28" Height="28" Stretch="Uniform">
-                <Grid Width="32" Height="32">
-                    <Path SnapsToDevicePixels="true" Fill="Black" Data="M30.102 16.113 15.749 3.388a1.45 1.45 0 0 0-.975-.376 1.3 1.3 0 0 0-.425.067l-14.197 4-.05 1.429c-.067 1.858 1.175 4.718 1.771 6.304a1.3 1.3 0 0 0 .308.486l13.944 14.215a1.42 1.42 0 0 0 1.012.424 1.4 1.4 0 0 0 .538-.105l13.433-5.452c1.877-.752.345-4.776-.568-7.136zM14.62 4.041l.153-.03a.46.46 0 0 1 .304.118l13.423 11.9-11.182 4.193a2.89 2.89 0 0 1-3.049-.661L2.239 7.53zm16.116 19.41L17.3 28.905a.4.4 0 0 1-.162.033.42.42 0 0 1-.3-.126L2.895 14.597a.4.4 0 0 1-.081-.125l-.293-.763c-.585-1.504-1.47-3.776-1.42-5.166l.025-.7 12.436 12.424a3.88 3.88 0 0 0 4.107.89l11.626-4.36.312.806c1.836 4.746 1.497 5.7 1.13 5.847z" />
-                </Grid>
+                <TextBlock Text="&#xe83e;"
+                           FontSize="24"
+                           FontFamily="{StaticResource ToolkitIconsFontFamily}"
+                           Foreground="Black" />
             </Viewbox>
         </Button>
     </DataTemplate>

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml
@@ -122,7 +122,7 @@
 
     <!-- Toolbar data templates -->
     <DataTemplate x:Key="MarkerPickerToolbarTemplate" DataType="controls:SelectNewMarkerSymbolVM">
-        <Button Style="{StaticResource ToolbarButtonStyle}" Command="{Binding SelectNextSymbol}" Visibility="{Binding MainViewModel.AllowAddingMarkers, Converter={StaticResource BooleanToVisibilityConverter}}">
+        <Button Style="{StaticResource ToolbarButtonStyle}" Command="{Binding SelectNextSymbol}" Visibility="{Binding MainViewModel.AllowAddingMarkers, Converter={StaticResource BooleanToVisibilityConverter}}" ToolTip="Select marker symbol">
             <Viewbox Width="20" Height="20" Stretch="Uniform">
                 <controls:SymbolDisplay Symbol="{Binding SelectedSymbol, Mode=OneWay}" />
             </Viewbox>
@@ -130,7 +130,7 @@
     </DataTemplate>
 
     <DataTemplate x:Key="AllowAddingMarkersToolbarTemplate" DataType="controls:AllowAddingMarkersVM">
-        <ToggleButton Style="{StaticResource ToolbarToggleButtonStyle}" IsChecked="{Binding MainViewModel.AllowAddingMarkers}">
+        <ToggleButton Style="{StaticResource ToolbarToggleButtonStyle}" IsChecked="{Binding MainViewModel.AllowAddingMarkers}" ToolTip="Toggle add markers">
             <Viewbox Width="20" Height="20" Stretch="Uniform">
                 <Grid Width="32" Height="32">
                     <Path Fill="Black" Data="M29 8v15.247l-3.997-3.669a.65.65 0 0 0-.926-.033L21 22.293l-4.554-4.131a.65.65 0 0 0-.857-.013l-5.139 4.268-.826-.391a.64.64 0 0 0-.72.117L5 25.248V20.56l-1-1.006V29h26V7H14v1zm0 20H5v-1.474l4.401-3.5 1.198.567L16 19.106l5 4.531 3.506-3.123L29 24.581zm-8-12a2 2 0 1 0-2-2 2 2 0 0 0 2 2m0-3a1 1 0 1 1-1 1 1 1 0 0 1 1-1M7 19.735l5-5.032V6.038c0-2.493-1.776-3.865-5-3.865-3.178 0-5 1.445-5 3.964v8.566zM3 6.137c0-2.45 2.175-2.964 4-2.964 2.654 0 4 .964 4 2.864v8.254l-4 4.026-4-4.026zM5 8a2 2 0 1 0 2-2 2 2 0 0 0-2 2m3 0a1 1 0 1 1-1-1 1 1 0 0 1 1 1" />
@@ -140,7 +140,7 @@
     </DataTemplate>
 
     <DataTemplate x:Key="AutoUpdateFootprintToolbarTemplate" DataType="controls:AutoUpdateFootprintVM">
-        <ToggleButton Style="{StaticResource ToolbarToggleButtonStyle}" IsChecked="{Binding MainViewModel.AutoUpdateFootprint}">
+        <ToggleButton Style="{StaticResource ToolbarToggleButtonStyle}" IsChecked="{Binding MainViewModel.AutoUpdateFootprint}" ToolTip="Auto-update footprint">
             <Viewbox Width="20" Height="20" Stretch="Uniform">
                 <Grid Width="32" Height="32">
                     <Path Fill="Black" Opacity="0.25" Data="M20 23.672 3.962 7.225l3.243-5.019 15.574 4.727L20 8.6z" />
@@ -151,7 +151,7 @@
     </DataTemplate>
 
     <DataTemplate x:Key="ShowSelectedFootprintToolbarTemplate" DataType="controls:ShowSelectedFootprintVM">
-        <ToggleButton Style="{StaticResource ToolbarToggleButtonStyle}" IsChecked="{Binding MainViewModel.ShowSelectedFootprint}">
+        <ToggleButton Style="{StaticResource ToolbarToggleButtonStyle}" IsChecked="{Binding MainViewModel.ShowSelectedFootprint}" ToolTip="Show selected image footprint">
             <Viewbox Width="20" Height="20" Stretch="Uniform">
                 <Grid Width="16" Height="16">
                     <Path Data="M12.382 14H3.618L.345 2h15.31zm-8-1h7.236l2.727-10H1.655z" StrokeThickness="0.7">
@@ -170,7 +170,7 @@
     </DataTemplate>
 
     <DataTemplate x:Key="ShowUnselectedFootprintsToolbarTemplate" DataType="controls:ShowUnselectedFootprintsVM">
-        <ToggleButton Style="{StaticResource ToolbarToggleButtonStyle}" IsChecked="{Binding MainViewModel.ShowUnselectedFootprints}">
+        <ToggleButton Style="{StaticResource ToolbarToggleButtonStyle}" IsChecked="{Binding MainViewModel.ShowUnselectedFootprints}" ToolTip="Show unselected image footprints">
             <Viewbox Width="20" Height="20" Stretch="Uniform">
                 <Grid Width="16" Height="16">
                     <Path Data="M12.382 14H3.618L.345 2h15.31zm-8-1h7.236l2.727-10H1.655z" StrokeThickness="0.7">
@@ -192,9 +192,14 @@
         <Button Command="{Binding ToggleCameraMarkerDisplayMode}">
             <Button.Style>
                 <Style TargetType="{x:Type Button}" BasedOn="{StaticResource ToolbarButtonStyle}">
+                    <Setter Property="ToolTip" Value="Show camera markers on geo view" />
                     <Style.Triggers>
                         <DataTrigger Binding="{Binding MainViewModel.ShowSelectedCameraLocations}" Value="True">
                             <Setter Property="Background" Value="#FFD3D3D3" />
+                            <Setter Property="ToolTip" Value="Show camera markers in geo view and image display" />
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding MainViewModel.ShowSelectedCameraLocationsOnDisplay}" Value="True">
+                            <Setter Property="ToolTip" Value="Clear camera markers" />
                         </DataTrigger>
                     </Style.Triggers>
                 </Style>
@@ -231,7 +236,7 @@
     </DataTemplate>
 
     <DataTemplate x:Key="ClearMarkersToolbarTemplate" DataType="controls:ClearMarkersVM">
-        <Button Style="{StaticResource ToolbarButtonStyle}" Command="{Binding MainViewModel.ClearMarkersCommand}">
+        <Button Style="{StaticResource ToolbarButtonStyle}" Command="{Binding MainViewModel.ClearMarkersCommand}" ToolTip="Clear markers">
             <Viewbox Width="20" Height="20" Stretch="Uniform">
                 <Grid Width="32" Height="32">
                     <Path Fill="Black" Data="M16.5 3.2a13.3 13.3 0 1 0 13.3 13.3A13.3 13.3 0 0 0 16.5 3.2m0 1a12.24 12.24 0 0 1 8.323 3.27L7.47 24.823A12.28 12.28 0 0 1 16.5 4.2m0 24.6a12.24 12.24 0 0 1-8.323-3.27L25.53 8.177A12.28 12.28 0 0 1 16.5 28.8" />

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml
@@ -4,7 +4,6 @@
     xmlns:internal="clr-namespace:Esri.ArcGISRuntime.Toolkit.Internal"
     xmlns:controls="clr-namespace:Esri.ArcGISRuntime.Toolkit.UI.Controls">
 
-    <FontFamily x:Key="ToolkitIconsFontFamily">pack://application:,,,/Esri.ArcGISRuntime.Toolkit.WPF;component/Assets/toolkit-icons.ttf#calcite-ui-icons-24</FontFamily>
     <internal:ColorToColorConverter x:Key="ColorToColorConverter" />
     <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
 

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml
@@ -194,11 +194,11 @@
                 <Style TargetType="{x:Type Button}" BasedOn="{StaticResource ToolbarButtonStyle}">
                     <Setter Property="ToolTip" Value="Show camera markers on geo view" />
                     <Style.Triggers>
-                        <DataTrigger Binding="{Binding MainViewModel.ShowSelectedCameraLocations}" Value="True">
+                        <DataTrigger Binding="{Binding MainViewModel.ShowCameraLocations}" Value="True">
                             <Setter Property="Background" Value="#FFD3D3D3" />
                             <Setter Property="ToolTip" Value="Show camera markers in geo view and image display" />
                         </DataTrigger>
-                        <DataTrigger Binding="{Binding MainViewModel.ShowSelectedCameraLocationsOnDisplay}" Value="True">
+                        <DataTrigger Binding="{Binding MainViewModel.ShowCameraLocationsOnDisplay}" Value="True">
                             <Setter Property="ToolTip" Value="Clear camera markers" />
                         </DataTrigger>
                     </Style.Triggers>
@@ -211,7 +211,7 @@
                             <Style TargetType="{x:Type Path}">
                                 <Setter Property="Visibility" Value="Visible" />
                                 <Style.Triggers>
-                                    <DataTrigger Binding="{Binding MainViewModel.ShowSelectedCameraLocationsOnDisplay}" Value="True">
+                                    <DataTrigger Binding="{Binding MainViewModel.ShowCameraLocationsOnDisplay}" Value="True">
                                         <Setter Property="Visibility" Value="Collapsed" />
                                     </DataTrigger>
                                 </Style.Triggers>
@@ -223,7 +223,7 @@
                             <Style TargetType="{x:Type Path}">
                                 <Setter Property="Visibility" Value="Collapsed" />
                                 <Style.Triggers>
-                                    <DataTrigger Binding="{Binding MainViewModel.ShowSelectedCameraLocationsOnDisplay}" Value="True">
+                                    <DataTrigger Binding="{Binding MainViewModel.ShowCameraLocationsOnDisplay}" Value="True">
                                         <Setter Property="Visibility" Value="Visible" />
                                     </DataTrigger>
                                 </Style.Triggers>

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml
@@ -7,6 +7,7 @@
     <internal:ColorToColorConverter x:Key="ColorToColorConverter" />
     <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
 
+    <!-- Helper styles -->
     <Style x:Key="ToolbarButtonStyle" TargetType="{x:Type Button}">
         <Setter Property="MinWidth" Value="40" />
         <Setter Property="MinHeight" Value="40" />
@@ -243,6 +244,7 @@
         </Button>
     </DataTemplate>
 
+    <!-- Display style -->
     <Style TargetType="{x:Type controls:OrientedImageDisplay}">
         <Setter Property="IsTabStop" Value="False" />
         <Setter Property="Template">
@@ -259,6 +261,7 @@
         </Setter>
     </Style>
 
+    <!-- Main view style -->
     <Style TargetType="{x:Type controls:OrientedImageryView}">
         <Setter Property="IsTabStop" Value="False" />
 
@@ -266,7 +269,7 @@
             <Setter.Value>
                 <controls:OrientedImageryViewTemplateSelector>
                     <controls:OrientedImageryViewTemplateSelectorItem Type="{x:Type controls:SelectNewMarkerSymbolVM}" Template="{StaticResource MarkerPickerToolbarTemplate}" />
-                        <controls:OrientedImageryViewTemplateSelectorItem Type="{x:Type controls:AllowAddingMarkersVM}" Template="{StaticResource AllowAddingMarkersToolbarTemplate}" />
+                    <controls:OrientedImageryViewTemplateSelectorItem Type="{x:Type controls:AllowAddingMarkersVM}" Template="{StaticResource AllowAddingMarkersToolbarTemplate}" />
                     <controls:OrientedImageryViewTemplateSelectorItem Type="{x:Type controls:AutoUpdateFootprintVM}" Template="{StaticResource AutoUpdateFootprintToolbarTemplate}" />
                     <controls:OrientedImageryViewTemplateSelectorItem Type="{x:Type controls:ShowSelectedFootprintVM}" Template="{StaticResource ShowSelectedFootprintToolbarTemplate}" />
                     <controls:OrientedImageryViewTemplateSelectorItem Type="{x:Type controls:ShowUnselectedFootprintsVM}" Template="{StaticResource ShowUnselectedFootprintsToolbarTemplate}" />

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml
@@ -237,7 +237,49 @@
                                     <ColumnDefinition Width="Auto" />
                                 </Grid.ColumnDefinitions>
 
-                                <controls:OrientedImageDisplay Grid.ColumnSpan="3" x:Name="PART_ImageDisplay" />
+                                <controls:OrientedImageDisplay Grid.ColumnSpan="3"
+                                                               x:Name="PART_ImageDisplay"
+                                                               DisplayBackgroundColor="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=DisplayBackgroundColor}" />
+
+                                <Border Grid.ColumnSpan="3"
+                                        Background="#80FFFFFF">
+                                    <Border.Style>
+                                        <Style TargetType="{x:Type Border}">
+                                            <Setter Property="Visibility" Value="Collapsed" />
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding ElementName=PART_ImageDisplay, Path=IsActive}" Value="True">
+                                                    <Setter Property="Visibility" Value="Visible" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Border.Style>
+                                    <TextBlock HorizontalAlignment="Center"
+                                               VerticalAlignment="Center"
+                                               Text="Loading..." />
+                                </Border>
+
+                                <Popup PlacementTarget="{Binding ElementName=PART_ImageDisplay}"
+                                       Placement="Center"
+                                       StaysOpen="True">
+                                    <Popup.Style>
+                                        <Style TargetType="{x:Type Popup}">
+                                            <Setter Property="IsOpen" Value="True" />
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding ElementName=PART_ImageDisplay, Path=Error}" Value="{x:Null}">
+                                                    <Setter Property="IsOpen" Value="False" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Popup.Style>
+                                    <Border Background="White"
+                                            BorderBrush="Gray"
+                                            BorderThickness="1"
+                                            Padding="8">
+                                        <TextBlock MaxWidth="300"
+                                                   Text="{Binding ElementName=PART_ImageDisplay, Path=Error.Message}"
+                                                   TextWrapping="Wrap" />
+                                    </Border>
+                                </Popup>
 
                                 <Button Content="&lt;"
                                         Command="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=ViewModel.SelectPreviousImageCommand}"

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml
@@ -123,13 +123,13 @@
 
     <!-- Toolbar data templates -->
     <DataTemplate x:Key="MarkerPickerToolbarTemplate" DataType="controls:SelectNewMarkerSymbolVM">
-        <Button Style="{StaticResource ToolbarButtonStyle}" Command="{Binding SelectNextSymbol}" Visibility="{Binding MainViewModel.AllowAddingMarkers, Converter={StaticResource BooleanToVisibilityConverter}}" ToolTip="Select marker symbol">
+        <Button Style="{StaticResource ToolbarButtonStyle}" Command="{Binding SelectNextSymbol}" Visibility="{Binding MainViewModel.AllowAddingMarkers, Converter={StaticResource BooleanToVisibilityConverter}}" ToolTip="{internal:LocalizedString Key=OrientedImageryViewSelectMarkerSymbol}">
             <controls:SymbolDisplay Width="32" Height="32" Symbol="{Binding SelectedSymbol, Mode=OneWay}" />
         </Button>
     </DataTemplate>
 
     <DataTemplate x:Key="AllowAddingMarkersToolbarTemplate" DataType="controls:AllowAddingMarkersVM">
-        <ToggleButton Style="{StaticResource ToolbarToggleButtonStyle}" IsChecked="{Binding MainViewModel.AllowAddingMarkers}" ToolTip="Toggle add markers">
+        <ToggleButton Style="{StaticResource ToolbarToggleButtonStyle}" IsChecked="{Binding MainViewModel.AllowAddingMarkers}" ToolTip="{internal:LocalizedString Key=OrientedImageryViewToggleAddMarkers}">
             <Viewbox Width="32" Height="32" Stretch="Uniform">
                 <Grid Width="32" Height="32">
                     <Path SnapsToDevicePixels="true" Fill="Black" Data="M29 8v15.247l-3.997-3.669a.65.65 0 0 0-.926-.033L21 22.293l-4.554-4.131a.65.65 0 0 0-.857-.013l-5.139 4.268-.826-.391a.64.64 0 0 0-.72.117L5 25.248V20.56l-1-1.006V29h26V7H14v1zm0 20H5v-1.474l4.401-3.5 1.198.567L16 19.106l5 4.531 3.506-3.123L29 24.581zm-8-12a2 2 0 1 0-2-2 2 2 0 0 0 2 2m0-3a1 1 0 1 1-1 1 1 1 0 0 1 1-1M7 19.735l5-5.032V6.038c0-2.493-1.776-3.865-5-3.865-3.178 0-5 1.445-5 3.964v8.566zM3 6.137c0-2.45 2.175-2.964 4-2.964 2.654 0 4 .964 4 2.864v8.254l-4 4.026-4-4.026zM5 8a2 2 0 1 0 2-2 2 2 0 0 0-2 2m3 0a1 1 0 1 1-1-1 1 1 0 0 1 1 1" />
@@ -139,7 +139,7 @@
     </DataTemplate>
 
     <DataTemplate x:Key="ShowSelectedFootprintToolbarTemplate" DataType="controls:ShowSelectedFootprintVM">
-        <ToggleButton Style="{StaticResource ToolbarToggleButtonStyle}" IsChecked="{Binding MainViewModel.ShowSelectedFootprint}" ToolTip="Show selected image footprint">
+        <ToggleButton Style="{StaticResource ToolbarToggleButtonStyle}" IsChecked="{Binding MainViewModel.ShowSelectedFootprint}" ToolTip="{internal:LocalizedString Key=OrientedImageryViewShowSelectedImageFootprint}">
             <Viewbox SnapsToDevicePixels="true" Width="30" Height="30" Stretch="Uniform">
                 <Grid Width="24" Height="24">
                     <Path SnapsToDevicePixels="true" Data="M19.384 20H4.616L.349 4h23.302zm-14-1h13.232l3.733-14H1.651z">
@@ -158,7 +158,7 @@
     </DataTemplate>
 
     <DataTemplate x:Key="ShowUnselectedFootprintsToolbarTemplate" DataType="controls:ShowUnselectedFootprintsVM">
-        <ToggleButton Style="{StaticResource ToolbarToggleButtonStyle}" IsChecked="{Binding MainViewModel.ShowUnselectedFootprints}" ToolTip="Show unselected image footprints">
+        <ToggleButton Style="{StaticResource ToolbarToggleButtonStyle}" IsChecked="{Binding MainViewModel.ShowUnselectedFootprints}" ToolTip="{internal:LocalizedString Key=OrientedImageryViewShowUnselectedImageFootprints}">
             <Viewbox SnapsToDevicePixels="true" Width="30" Height="30" Stretch="Uniform">
                 <Grid Width="24" Height="24">
                     <Path SnapsToDevicePixels="true" Data="M19.384 20H4.616L.349 4h23.302zm-14-1h13.232l3.733-14H1.651z">
@@ -180,14 +180,14 @@
         <Button Command="{Binding ToggleCameraMarkerDisplayMode}">
             <Button.Style>
                 <Style TargetType="{x:Type Button}" BasedOn="{StaticResource ToolbarButtonStyle}">
-                    <Setter Property="ToolTip" Value="Show camera markers on geo view" />
+                    <Setter Property="ToolTip" Value="{internal:LocalizedString Key=OrientedImageryViewShowCameraMarkersOnGeoView}" />
                     <Style.Triggers>
                         <DataTrigger Binding="{Binding MainViewModel.ShowCameraLocations}" Value="True">
                             <Setter Property="Background" Value="#FFD3D3D3" />
-                            <Setter Property="ToolTip" Value="Show camera markers in geo view and image display" />
+                            <Setter Property="ToolTip" Value="{internal:LocalizedString Key=OrientedImageryViewShowCameraMarkersOnGeoViewAndImageDisplay}" />
                         </DataTrigger>
                         <DataTrigger Binding="{Binding MainViewModel.ShowCameraLocationsOnDisplay}" Value="True">
-                            <Setter Property="ToolTip" Value="Clear camera markers" />
+                            <Setter Property="ToolTip" Value="{internal:LocalizedString Key=OrientedImageryViewClearCameraMarkers}" />
                         </DataTrigger>
                     </Style.Triggers>
                 </Style>
@@ -224,7 +224,7 @@
     </DataTemplate>
 
     <DataTemplate x:Key="ClearMarkersToolbarTemplate" DataType="controls:ClearMarkersVM">
-        <Button Style="{StaticResource ToolbarButtonStyle}" Command="{Binding MainViewModel.ClearMarkersCommand}" ToolTip="Clear markers">
+        <Button Style="{StaticResource ToolbarButtonStyle}" Command="{Binding MainViewModel.ClearMarkersCommand}" ToolTip="{internal:LocalizedString Key=OrientedImageryViewClearMarkers}">
             <Viewbox Width="28" Height="28" Stretch="Uniform">
                 <Grid Width="32" Height="32">
                     <Path SnapsToDevicePixels="true" Fill="Black" Data="M30.102 16.113 15.749 3.388a1.45 1.45 0 0 0-.975-.376 1.3 1.3 0 0 0-.425.067l-14.197 4-.05 1.429c-.067 1.858 1.175 4.718 1.771 6.304a1.3 1.3 0 0 0 .308.486l13.944 14.215a1.42 1.42 0 0 0 1.012.424 1.4 1.4 0 0 0 .538-.105l13.433-5.452c1.877-.752.345-4.776-.568-7.136zM14.62 4.041l.153-.03a.46.46 0 0 1 .304.118l13.423 11.9-11.182 4.193a2.89 2.89 0 0 1-3.049-.661L2.239 7.53zm16.116 19.41L17.3 28.905a.4.4 0 0 1-.162.033.42.42 0 0 1-.3-.126L2.895 14.597a.4.4 0 0 1-.081-.125l-.293-.763c-.585-1.504-1.47-3.776-1.42-5.166l.025-.7 12.436 12.424a3.88 3.88 0 0 0 4.107.89l11.626-4.36.312.806c1.836 4.746 1.497 5.7 1.13 5.847z" />
@@ -318,7 +318,7 @@
                                     </Border.Style>
                                     <TextBlock HorizontalAlignment="Center"
                                                VerticalAlignment="Center"
-                                               Text="Loading..." />
+                                               Text="{internal:LocalizedString Key=OrientedImageryViewLoading}" />
                                 </Border>
 
                                 <ProgressBar Grid.ColumnSpan="3"
@@ -354,7 +354,7 @@
                                     </Border.Style>
                                     <TextBlock HorizontalAlignment="Center"
                                                VerticalAlignment="Center"
-                                               Text="No images selected" />
+                                               Text="{internal:LocalizedString Key=OrientedImageryViewNoImagesSelected}" />
                                 </Border>
 
                                 <Popup PlacementTarget="{Binding ElementName=PART_ImageDisplay}"

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml
@@ -4,31 +4,163 @@
     xmlns:internal="clr-namespace:Esri.ArcGISRuntime.Toolkit.Internal"
     xmlns:controls="clr-namespace:Esri.ArcGISRuntime.Toolkit.UI.Controls">
 
+    <FontFamily x:Key="ToolkitIconsFontFamily">pack://application:,,,/Esri.ArcGISRuntime.Toolkit.WPF;component/Assets/toolkit-icons.ttf#calcite-ui-icons-24</FontFamily>
+    <internal:ColorToColorConverter x:Key="ColorToColorConverter" />
+
+    <Style x:Key="ToolbarButtonStyle" TargetType="{x:Type Button}">
+        <Setter Property="MinWidth" Value="40" />
+        <Setter Property="MinHeight" Value="40" />
+        <Setter Property="Padding" Value="4" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderBrush" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type Button}">
+                    <Border x:Name="Root"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}">
+                        <ContentPresenter HorizontalAlignment="Center"
+                                          VerticalAlignment="Center"
+                                          Margin="{TemplateBinding Padding}" />
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="Root" Property="Background" Value="#FFEFEFEF" />
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter TargetName="Root" Property="Background" Value="#FFD3D3D3" />
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Opacity" Value="0.5" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="ToolbarToggleButtonStyle" TargetType="{x:Type ToggleButton}">
+        <Setter Property="MinWidth" Value="40" />
+        <Setter Property="MinHeight" Value="40" />
+        <Setter Property="Padding" Value="4" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderBrush" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ToggleButton}">
+                    <Border x:Name="Root"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}">
+                        <ContentPresenter HorizontalAlignment="Center"
+                                          VerticalAlignment="Center"
+                                          Margin="{TemplateBinding Padding}" />
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="Root" Property="Background" Value="#FFEFEFEF" />
+                        </Trigger>
+                        <Trigger Property="IsChecked" Value="True">
+                            <Setter TargetName="Root" Property="Background" Value="#FFD3D3D3" />
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter TargetName="Root" Property="Background" Value="#FFC0C0C0" />
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Opacity" Value="0.5" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+        <Style.Triggers>
+            <Trigger Property="IsChecked" Value="True">
+                <Setter Property="Background" Value="#FFD3D3D3" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
     <!-- Toolbar data templates -->
     <DataTemplate x:Key="MarkerPickerToolbarTemplate" DataType="controls:SelectNewMarkerSymbolVM">
-        <Button Command="{Binding SelectNextSymbol}">
-            <controls:SymbolDisplay Symbol="{Binding SelectedSymbol, Mode=OneWay}" />
+        <Button Style="{StaticResource ToolbarButtonStyle}" Command="{Binding SelectNextSymbol}">
+            <Viewbox Width="20" Height="20" Stretch="Uniform">
+                <controls:SymbolDisplay Symbol="{Binding SelectedSymbol, Mode=OneWay}" />
+            </Viewbox>
         </Button>
     </DataTemplate>
 
     <DataTemplate x:Key="AutoUpdateFootprintToolbarTemplate" DataType="controls:AutoUpdateFootprintVM">
-        <ToggleButton Content="AU" IsChecked="{Binding MainViewModel.AutoUpdateFootprint}"/>
+        <ToggleButton Style="{StaticResource ToolbarToggleButtonStyle}" IsChecked="{Binding MainViewModel.AutoUpdateFootprint}">
+            <Viewbox Width="20" Height="20" Stretch="Uniform">
+                <Grid Width="32" Height="32">
+                    <Path Fill="Black" Opacity="0.25" Data="M20 23.672 3.962 7.225l3.243-5.019 15.574 4.727L20 8.6z" />
+                    <Path Fill="Black" Data="M1.456 1.696a.47.47 0 0 1 .283-.362 7.03 7.03 0 0 1 5.351.782c.043.027.078.062.12.09L4.866 5.827c-.03-.017-.06-.03-.088-.048a1.835 1.835 0 0 1-.687-2.62 2.57 2.57 0 0 1 1.067-.905 5.1 5.1 0 0 0-2.856-.011A4.58 4.58 0 0 0 4.53 6.346l-.572.884a5.15 5.15 0 0 1-2.503-5.534zM32 30v1H0v-1h1V18h14v12h5V8.6L31 2v28zm-18 0V19H2v11zm16 0V3.767l-9 5.399V30zM6 9V8H5v1zm3-7H8v1h1zm3 1h-1v1h1zm3 1h-1v1h1zm3 1h-1v1h1zm3 1h-1v1h1zM7 11h1v-1H7zm2 2h1v-1H9zm3 1h-1v1h1zm2 2h-1v1h1zm9 12h2v-2h-2zm3 0h2v-2h-2zM7 28h2v-2H7zm-3 0h2v-2H4zm6 0h2v-2h-2zm-3-3h2v-2H7zm-3 0h2v-2H4zm6 0h2v-2h-2zm-3-3h2v-2H7zm-3 0h2v-2H4zm6 0h2v-2h-2zm13 3h2v-2h-2zm3 0h2v-2h-2zm-3-3h2v-2h-2zm3 0h2v-2h-2zm-3-3h2v-2h-2zm3 0h2v-2h-2zm-3-3h2v-2h-2zm3 0h2v-2h-2zm-3-3h2v-2h-2zm3 0h2v-2h-2zm0-3h2V8h-2z" />
+                </Grid>
+            </Viewbox>
+        </ToggleButton>
     </DataTemplate>
 
     <DataTemplate x:Key="ShowSelectedFootprintToolbarTemplate" DataType="controls:ShowSelectedFootprintVM">
-        <ToggleButton Content="FA" IsChecked="{Binding MainViewModel.ShowSelectedFootprint}"/>
+        <ToggleButton Style="{StaticResource ToolbarToggleButtonStyle}" IsChecked="{Binding MainViewModel.ShowSelectedFootprint}">
+            <Viewbox Width="20" Height="20" Stretch="Uniform">
+                <Grid Width="16" Height="16">
+                    <Path Data="M12.382 14H3.618L.345 2h15.31zm-8-1h7.236l2.727-10H1.655z" StrokeThickness="0.7">
+                        <Path.Stroke>
+                            <SolidColorBrush Color="{Binding MainViewModel.SelectedFootprintOutlineColor, Converter={StaticResource ColorToColorConverter}}" />
+                        </Path.Stroke>
+                    </Path>
+                    <Path Data="M14.35 3l-2.73 10H4.38L1.65 3z">
+                        <Path.Fill>
+                            <SolidColorBrush Color="{Binding MainViewModel.SelectedFootprintFillColor, Converter={StaticResource ColorToColorConverter}}" />
+                        </Path.Fill>
+                    </Path>
+                </Grid>
+            </Viewbox>
+        </ToggleButton>
     </DataTemplate>
 
     <DataTemplate x:Key="ShowUnselectedFootprintsToolbarTemplate" DataType="controls:ShowUnselectedFootprintsVM">
-        <ToggleButton Content="FA" IsChecked="{Binding MainViewModel.ShowUnselectedFootprints}"/>
+        <ToggleButton Style="{StaticResource ToolbarToggleButtonStyle}" IsChecked="{Binding MainViewModel.ShowUnselectedFootprints}">
+            <Viewbox Width="20" Height="20" Stretch="Uniform">
+                <Grid Width="16" Height="16">
+                    <Path Data="M12.382 14H3.618L.345 2h15.31zm-8-1h7.236l2.727-10H1.655z" StrokeThickness="0.7">
+                        <Path.Stroke>
+                            <SolidColorBrush Color="{Binding MainViewModel.UnselectedFootprintOutlineColor, Converter={StaticResource ColorToColorConverter}}" />
+                        </Path.Stroke>
+                    </Path>
+                    <Path Data="M14.35 3l-2.73 10H4.38L1.65 3z">
+                        <Path.Fill>
+                            <SolidColorBrush Color="{Binding MainViewModel.UnselectedFootprintFillColor, Converter={StaticResource ColorToColorConverter}}" />
+                        </Path.Fill>
+                    </Path>
+                </Grid>
+            </Viewbox>
+        </ToggleButton>
     </DataTemplate>
 
     <DataTemplate x:Key="ShowCameraMarkersToolbarTemplate" DataType="controls:ShowCameraMarkersVM">
-        <ToggleButton Content="Cameras" IsChecked="{Binding MainViewModel.ShowSelectedCameraLocationsOnDisplay}"/>
+        <ToggleButton Style="{StaticResource ToolbarToggleButtonStyle}" IsChecked="{Binding MainViewModel.ShowSelectedCameraLocationsOnDisplay}">
+            <Viewbox Width="20" Height="20" Stretch="Uniform">
+                <Grid Width="32" Height="32">
+                    <Path Fill="Black" Data="M11 12.5v.5H6v-1h5zm19 11v-12A2.503 2.503 0 0 0 27.5 9H27a1 1 0 0 1-1-1 2 2 0 0 0-2-2h-8a2 2 0 0 0-2 2 1 1 0 0 1-1 1h-2V8H6v1H4.5A2.503 2.503 0 0 0 2 11.5v12A2.503 2.503 0 0 0 4.5 26h23a2.503 2.503 0 0 0 2.5-2.5M7 10V9h3v1h3a2 2 0 0 0 2-2 1 1 0 0 1 1-1h8a1 1 0 0 1 1 1 2 2 0 0 0 2 2h.5a1.5 1.5 0 0 1 1.5 1.5v12a1.5 1.5 0 0 1-1.5 1.5h-23A1.5 1.5 0 0 1 3 23.5v-12A1.5 1.5 0 0 1 4.5 10zm18.8 7a5.8 5.8 0 1 0-5.8 5.8 5.806 5.806 0 0 0 5.8-5.8m-1 0a4.8 4.8 0 1 1-4.8-4.8 4.805 4.805 0 0 1 4.8 4.8" />
+                </Grid>
+            </Viewbox>
+        </ToggleButton>
     </DataTemplate>
 
     <DataTemplate x:Key="ClearMarkersToolbarTemplate" DataType="controls:ClearMarkersVM">
-        <Button Content="❌" Command="{Binding MainViewModel.ClearMarkersCommand}"/>
+        <Button Style="{StaticResource ToolbarButtonStyle}" Command="{Binding MainViewModel.ClearMarkersCommand}">
+            <Viewbox Width="20" Height="20" Stretch="Uniform">
+                <Grid Width="32" Height="32">
+                    <Path Fill="Black" Data="M16.5 3.2a13.3 13.3 0 1 0 13.3 13.3A13.3 13.3 0 0 0 16.5 3.2m0 1a12.24 12.24 0 0 1 8.323 3.27L7.47 24.823A12.28 12.28 0 0 1 16.5 4.2m0 24.6a12.24 12.24 0 0 1-8.323-3.27L25.53 8.177A12.28 12.28 0 0 1 16.5 28.8" />
+                </Grid>
+            </Viewbox>
+        </Button>
     </DataTemplate>
 
     <Style TargetType="{x:Type controls:OrientedImageDisplay}">
@@ -66,7 +198,7 @@
         <Setter Property="ItemsPanel">
             <Setter.Value>
                 <ItemsPanelTemplate>
-                    <WrapPanel Orientation="Horizontal" />
+                    <WrapPanel HorizontalAlignment="Center" Orientation="Horizontal" />
                 </ItemsPanelTemplate>
             </Setter.Value>
         </Setter>

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml
@@ -89,7 +89,7 @@
         <Setter Property="Width" Value="25" />
         <Setter Property="MinHeight" Value="60" />
         <Setter Property="Padding" Value="4" />
-        <Setter Property="Background" Value="#40FFFFFF" />
+        <Setter Property="Background" Value="#80FFFFFF" />
         <Setter Property="BorderBrush" Value="Transparent" />
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="FocusVisualStyle" Value="{x:Null}" />
@@ -112,7 +112,7 @@
                             <Setter TargetName="Root" Property="Background" Value="#FFFFFFFF" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
-                            <Setter Property="Opacity" Value="0.35" />
+                            <Setter Property="Visibility" Value="Collapsed" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml
@@ -123,17 +123,15 @@
     <!-- Toolbar data templates -->
     <DataTemplate x:Key="MarkerPickerToolbarTemplate" DataType="controls:SelectNewMarkerSymbolVM">
         <Button Style="{StaticResource ToolbarButtonStyle}" Command="{Binding SelectNextSymbol}" Visibility="{Binding MainViewModel.AllowAddingMarkers, Converter={StaticResource BooleanToVisibilityConverter}}" ToolTip="Select marker symbol">
-            <Viewbox Width="20" Height="20" Stretch="Uniform">
-                <controls:SymbolDisplay Symbol="{Binding SelectedSymbol, Mode=OneWay}" />
-            </Viewbox>
+            <controls:SymbolDisplay Width="32" Height="32" Symbol="{Binding SelectedSymbol, Mode=OneWay}" />
         </Button>
     </DataTemplate>
 
     <DataTemplate x:Key="AllowAddingMarkersToolbarTemplate" DataType="controls:AllowAddingMarkersVM">
         <ToggleButton Style="{StaticResource ToolbarToggleButtonStyle}" IsChecked="{Binding MainViewModel.AllowAddingMarkers}" ToolTip="Toggle add markers">
-            <Viewbox Width="20" Height="20" Stretch="Uniform">
+            <Viewbox Width="32" Height="32" Stretch="Uniform">
                 <Grid Width="32" Height="32">
-                    <Path Fill="Black" Data="M29 8v15.247l-3.997-3.669a.65.65 0 0 0-.926-.033L21 22.293l-4.554-4.131a.65.65 0 0 0-.857-.013l-5.139 4.268-.826-.391a.64.64 0 0 0-.72.117L5 25.248V20.56l-1-1.006V29h26V7H14v1zm0 20H5v-1.474l4.401-3.5 1.198.567L16 19.106l5 4.531 3.506-3.123L29 24.581zm-8-12a2 2 0 1 0-2-2 2 2 0 0 0 2 2m0-3a1 1 0 1 1-1 1 1 1 0 0 1 1-1M7 19.735l5-5.032V6.038c0-2.493-1.776-3.865-5-3.865-3.178 0-5 1.445-5 3.964v8.566zM3 6.137c0-2.45 2.175-2.964 4-2.964 2.654 0 4 .964 4 2.864v8.254l-4 4.026-4-4.026zM5 8a2 2 0 1 0 2-2 2 2 0 0 0-2 2m3 0a1 1 0 1 1-1-1 1 1 0 0 1 1 1" />
+                    <Path SnapsToDevicePixels="true" Fill="Black" Data="M29 8v15.247l-3.997-3.669a.65.65 0 0 0-.926-.033L21 22.293l-4.554-4.131a.65.65 0 0 0-.857-.013l-5.139 4.268-.826-.391a.64.64 0 0 0-.72.117L5 25.248V20.56l-1-1.006V29h26V7H14v1zm0 20H5v-1.474l4.401-3.5 1.198.567L16 19.106l5 4.531 3.506-3.123L29 24.581zm-8-12a2 2 0 1 0-2-2 2 2 0 0 0 2 2m0-3a1 1 0 1 1-1 1 1 1 0 0 1 1-1M7 19.735l5-5.032V6.038c0-2.493-1.776-3.865-5-3.865-3.178 0-5 1.445-5 3.964v8.566zM3 6.137c0-2.45 2.175-2.964 4-2.964 2.654 0 4 .964 4 2.864v8.254l-4 4.026-4-4.026zM5 8a2 2 0 1 0 2-2 2 2 0 0 0-2 2m3 0a1 1 0 1 1-1-1 1 1 0 0 1 1 1" />
                 </Grid>
             </Viewbox>
         </ToggleButton>
@@ -141,10 +139,10 @@
 
     <DataTemplate x:Key="AutoUpdateFootprintToolbarTemplate" DataType="controls:AutoUpdateFootprintVM">
         <ToggleButton Style="{StaticResource ToolbarToggleButtonStyle}" IsChecked="{Binding MainViewModel.AutoUpdateFootprint}" ToolTip="Auto-update footprint">
-            <Viewbox Width="20" Height="20" Stretch="Uniform">
+            <Viewbox Width="32" Height="32" Stretch="Uniform">
                 <Grid Width="32" Height="32">
-                    <Path Fill="Black" Opacity="0.25" Data="M20 23.672 3.962 7.225l3.243-5.019 15.574 4.727L20 8.6z" />
-                    <Path Fill="Black" Data="M1.456 1.696a.47.47 0 0 1 .283-.362 7.03 7.03 0 0 1 5.351.782c.043.027.078.062.12.09L4.866 5.827c-.03-.017-.06-.03-.088-.048a1.835 1.835 0 0 1-.687-2.62 2.57 2.57 0 0 1 1.067-.905 5.1 5.1 0 0 0-2.856-.011A4.58 4.58 0 0 0 4.53 6.346l-.572.884a5.15 5.15 0 0 1-2.503-5.534zM32 30v1H0v-1h1V18h14v12h5V8.6L31 2v28zm-18 0V19H2v11zm16 0V3.767l-9 5.399V30zM6 9V8H5v1zm3-7H8v1h1zm3 1h-1v1h1zm3 1h-1v1h1zm3 1h-1v1h1zm3 1h-1v1h1zM7 11h1v-1H7zm2 2h1v-1H9zm3 1h-1v1h1zm2 2h-1v1h1zm9 12h2v-2h-2zm3 0h2v-2h-2zM7 28h2v-2H7zm-3 0h2v-2H4zm6 0h2v-2h-2zm-3-3h2v-2H7zm-3 0h2v-2H4zm6 0h2v-2h-2zm-3-3h2v-2H7zm-3 0h2v-2H4zm6 0h2v-2h-2zm13 3h2v-2h-2zm3 0h2v-2h-2zm-3-3h2v-2h-2zm3 0h2v-2h-2zm-3-3h2v-2h-2zm3 0h2v-2h-2zm-3-3h2v-2h-2zm3 0h2v-2h-2zm-3-3h2v-2h-2zm3 0h2v-2h-2zm0-3h2V8h-2z" />
+                    <Path SnapsToDevicePixels="true" Fill="Black" Opacity="0.25" Data="M20 23.672 3.962 7.225l3.243-5.019 15.574 4.727L20 8.6z" />
+                    <Path SnapsToDevicePixels="true" Fill="Black" Data="M1.456 1.696a.47.47 0 0 1 .283-.362 7.03 7.03 0 0 1 5.351.782c.043.027.078.062.12.09L4.866 5.827c-.03-.017-.06-.03-.088-.048a1.835 1.835 0 0 1-.687-2.62 2.57 2.57 0 0 1 1.067-.905 5.1 5.1 0 0 0-2.856-.011A4.58 4.58 0 0 0 4.53 6.346l-.572.884a5.15 5.15 0 0 1-2.503-5.534zM32 30v1H0v-1h1V18h14v12h5V8.6L31 2v28zm-18 0V19H2v11zm16 0V3.767l-9 5.399V30zM6 9V8H5v1zm3-7H8v1h1zm3 1h-1v1h1zm3 1h-1v1h1zm3 1h-1v1h1zm3 1h-1v1h1zM7 11h1v-1H7zm2 2h1v-1H9zm3 1h-1v1h1zm2 2h-1v1h1zm9 12h2v-2h-2zm3 0h2v-2h-2zM7 28h2v-2H7zm-3 0h2v-2H4zm6 0h2v-2h-2zm-3-3h2v-2H7zm-3 0h2v-2H4zm6 0h2v-2h-2zm-3-3h2v-2H7zm-3 0h2v-2H4zm6 0h2v-2h-2zm13 3h2v-2h-2zm3 0h2v-2h-2zm-3-3h2v-2h-2zm3 0h2v-2h-2zm-3-3h2v-2h-2zm3 0h2v-2h-2zm-3-3h2v-2h-2zm3 0h2v-2h-2zm-3-3h2v-2h-2zm3 0h2v-2h-2zm0-3h2V8h-2z" />
                 </Grid>
             </Viewbox>
         </ToggleButton>
@@ -152,14 +150,14 @@
 
     <DataTemplate x:Key="ShowSelectedFootprintToolbarTemplate" DataType="controls:ShowSelectedFootprintVM">
         <ToggleButton Style="{StaticResource ToolbarToggleButtonStyle}" IsChecked="{Binding MainViewModel.ShowSelectedFootprint}" ToolTip="Show selected image footprint">
-            <Viewbox Width="20" Height="20" Stretch="Uniform">
-                <Grid Width="16" Height="16">
-                    <Path Data="M12.382 14H3.618L.345 2h15.31zm-8-1h7.236l2.727-10H1.655z" StrokeThickness="0.7">
-                        <Path.Stroke>
+            <Viewbox SnapsToDevicePixels="true" Width="30" Height="30" Stretch="Uniform">
+                <Grid Width="24" Height="24">
+                    <Path SnapsToDevicePixels="true" Data="M19.384 20H4.616L.349 4h23.302zm-14-1h13.232l3.733-14H1.651z">
+                        <Path.Fill>
                             <SolidColorBrush Color="{Binding MainViewModel.SelectedFootprintOutlineColor, Converter={StaticResource ColorToColorConverter}}" />
-                        </Path.Stroke>
+                        </Path.Fill>
                     </Path>
-                    <Path Data="M14.35 3l-2.73 10H4.38L1.65 3z">
+                    <Path SnapsToDevicePixels="true" Data="m22.35 5-3.73 14H5.38L1.65 5z">
                         <Path.Fill>
                             <SolidColorBrush Color="{Binding MainViewModel.SelectedFootprintFillColor, Converter={StaticResource ColorToColorConverter}}" />
                         </Path.Fill>
@@ -171,14 +169,14 @@
 
     <DataTemplate x:Key="ShowUnselectedFootprintsToolbarTemplate" DataType="controls:ShowUnselectedFootprintsVM">
         <ToggleButton Style="{StaticResource ToolbarToggleButtonStyle}" IsChecked="{Binding MainViewModel.ShowUnselectedFootprints}" ToolTip="Show unselected image footprints">
-            <Viewbox Width="20" Height="20" Stretch="Uniform">
-                <Grid Width="16" Height="16">
-                    <Path Data="M12.382 14H3.618L.345 2h15.31zm-8-1h7.236l2.727-10H1.655z" StrokeThickness="0.7">
-                        <Path.Stroke>
+            <Viewbox SnapsToDevicePixels="true" Width="30" Height="30" Stretch="Uniform">
+                <Grid Width="24" Height="24">
+                    <Path SnapsToDevicePixels="true" Data="M19.384 20H4.616L.349 4h23.302zm-14-1h13.232l3.733-14H1.651z">
+                        <Path.Fill>
                             <SolidColorBrush Color="{Binding MainViewModel.UnselectedFootprintOutlineColor, Converter={StaticResource ColorToColorConverter}}" />
-                        </Path.Stroke>
+                        </Path.Fill>
                     </Path>
-                    <Path Data="M14.35 3l-2.73 10H4.38L1.65 3z">
+                    <Path SnapsToDevicePixels="true" Data="m22.35 5-3.73 14H5.38L1.65 5z">
                         <Path.Fill>
                             <SolidColorBrush Color="{Binding MainViewModel.UnselectedFootprintFillColor, Converter={StaticResource ColorToColorConverter}}" />
                         </Path.Fill>
@@ -204,7 +202,7 @@
                     </Style.Triggers>
                 </Style>
             </Button.Style>
-            <Viewbox Width="20" Height="20" Stretch="Uniform">
+            <Viewbox Width="32" Height="32" Stretch="Uniform">
                 <Grid Width="32" Height="32">
                     <Path Fill="Black" Data="M11 12.5v.5H6v-1h5zm19 11v-12A2.503 2.503 0 0 0 27.5 9H27a1 1 0 0 1-1-1 2 2 0 0 0-2-2h-8a2 2 0 0 0-2 2 1 1 0 0 1-1 1h-2V8H6v1H4.5A2.503 2.503 0 0 0 2 11.5v12A2.503 2.503 0 0 0 4.5 26h23a2.503 2.503 0 0 0 2.5-2.5M7 10V9h3v1h3a2 2 0 0 0 2-2 1 1 0 0 1 1-1h8a1 1 0 0 1 1 1 2 2 0 0 0 2 2h.5a1.5 1.5 0 0 1 1.5 1.5v12a1.5 1.5 0 0 1-1.5 1.5h-23A1.5 1.5 0 0 1 3 23.5v-12A1.5 1.5 0 0 1 4.5 10zm18.8 7a5.8 5.8 0 1 0-5.8 5.8 5.806 5.806 0 0 0 5.8-5.8m-1 0a4.8 4.8 0 1 1-4.8-4.8 4.805 4.805 0 0 1 4.8 4.8">
                         <Path.Style>
@@ -218,7 +216,7 @@
                             </Style>
                         </Path.Style>
                     </Path>
-                    <Path Fill="Black" Data="M11 13H6v-1h5zm16.5 13a2.503 2.503 0 0 0 2.5-2.5v-12A2.503 2.503 0 0 0 27.5 9H27a1 1 0 0 1-1-1 2 2 0 0 0-2-2h-8a2 2 0 0 0-2 2 1 1 0 0 1-1 1h-2V8H6v1H4.5A2.503 2.503 0 0 0 2 11.5V22h1V11.5A1.5 1.5 0 0 1 4.5 10H7V9h3v1h3a2 2 0 0 0 2-2 1 1 0 0 1 1-1h8a1 1 0 0 1 1 1 2 2 0 0 0 2 2h.5a1.5 1.5 0 0 1 1.5 1.5v12a1.5 1.5 0 0 1-1.5 1.5H15v.999zm-13.3-9a5.8 5.8 0 1 1 5.8 5.8 5.806 5.806 0 0 1-5.8-5.8m1 0a4.8 4.8 0 1 0 4.8-4.8 4.805 4.805 0 0 0-4.8 4.8M8 24.999h5V24H8v-5H7v5H2v.999h5V30h1z">
+                    <Path VerticalAlignment="Stretch" Fill="Black" Data="M11 13H6v-1h5zm16.5 13a2.503 2.503 0 0 0 2.5-2.5v-12A2.503 2.503 0 0 0 27.5 9H27a1 1 0 0 1-1-1 2 2 0 0 0-2-2h-8a2 2 0 0 0-2 2 1 1 0 0 1-1 1h-2V8H6v1H4.5A2.503 2.503 0 0 0 2 11.5V22h1V11.5A1.5 1.5 0 0 1 4.5 10H7V9h3v1h3a2 2 0 0 0 2-2 1 1 0 0 1 1-1h8a1 1 0 0 1 1 1 2 2 0 0 0 2 2h.5a1.5 1.5 0 0 1 1.5 1.5v12a1.5 1.5 0 0 1-1.5 1.5H15v.999zm-13.3-9a5.8 5.8 0 1 1 5.8 5.8 5.806 5.806 0 0 1-5.8-5.8m1 0a4.8 4.8 0 1 0 4.8-4.8 4.805 4.805 0 0 0-4.8 4.8M8 24.999h5V24H8v-5H7v5H2v.999h5V30h1z">
                         <Path.Style>
                             <Style TargetType="{x:Type Path}">
                                 <Setter Property="Visibility" Value="Collapsed" />
@@ -237,9 +235,9 @@
 
     <DataTemplate x:Key="ClearMarkersToolbarTemplate" DataType="controls:ClearMarkersVM">
         <Button Style="{StaticResource ToolbarButtonStyle}" Command="{Binding MainViewModel.ClearMarkersCommand}" ToolTip="Clear markers">
-            <Viewbox Width="20" Height="20" Stretch="Uniform">
+            <Viewbox Width="28" Height="28" Stretch="Uniform">
                 <Grid Width="32" Height="32">
-                    <Path Fill="Black" Data="M16.5 3.2a13.3 13.3 0 1 0 13.3 13.3A13.3 13.3 0 0 0 16.5 3.2m0 1a12.24 12.24 0 0 1 8.323 3.27L7.47 24.823A12.28 12.28 0 0 1 16.5 4.2m0 24.6a12.24 12.24 0 0 1-8.323-3.27L25.53 8.177A12.28 12.28 0 0 1 16.5 28.8" />
+                    <Path SnapsToDevicePixels="true" Fill="Black" Data="M30.102 16.113 15.749 3.388a1.45 1.45 0 0 0-.975-.376 1.3 1.3 0 0 0-.425.067l-14.197 4-.05 1.429c-.067 1.858 1.175 4.718 1.771 6.304a1.3 1.3 0 0 0 .308.486l13.944 14.215a1.42 1.42 0 0 0 1.012.424 1.4 1.4 0 0 0 .538-.105l13.433-5.452c1.877-.752.345-4.776-.568-7.136zM14.62 4.041l.153-.03a.46.46 0 0 1 .304.118l13.423 11.9-11.182 4.193a2.89 2.89 0 0 1-3.049-.661L2.239 7.53zm16.116 19.41L17.3 28.905a.4.4 0 0 1-.162.033.42.42 0 0 1-.3-.126L2.895 14.597a.4.4 0 0 1-.081-.125l-.293-.763c-.585-1.504-1.47-3.776-1.42-5.166l.025-.7 12.436 12.424a3.88 3.88 0 0 0 4.107.89l11.626-4.36.312.806c1.836 4.746 1.497 5.7 1.13 5.847z" />
                 </Grid>
             </Viewbox>
         </Button>
@@ -396,7 +394,7 @@
                                         VerticalAlignment="Center">
                                     <Viewbox Width="20" Height="20" Stretch="Uniform">
                                         <Grid Width="32" Height="32">
-                                            <Path Fill="Black" Data="M20 26.1 9.9 16 20 5.9z">
+                                            <Path SnapsToDevicePixels="true" Fill="Black" Data="M20 26.1 9.9 16 20 5.9z">
                                                 <Path.RenderTransform>
                                                     <TranslateTransform X="-3" Y="3" />
                                                 </Path.RenderTransform>
@@ -409,7 +407,7 @@
                                         Grid.Column="2" VerticalAlignment="Center">
                                     <Viewbox Width="20" Height="20" Stretch="Uniform">
                                         <Grid Width="32" Height="32">
-                                            <Path Fill="Black" Data="M12 5.9 22.1 16 12 26.1z">
+                                            <Path SnapsToDevicePixels="true" Fill="Black" Data="M12 5.9 22.1 16 12 26.1z">
                                                 <Path.RenderTransform>
                                                     <TranslateTransform Y="2" />
                                                 </Path.RenderTransform>

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml
@@ -318,8 +318,11 @@
                                         <Style TargetType="{x:Type Border}">
                                             <Setter Property="Visibility" Value="Collapsed" />
                                             <Style.Triggers>
-                                                <DataTrigger Binding="{Binding ElementName=PART_ImageDisplay, Path=IsActive}" Value="True">
+                                                <DataTrigger Binding="{Binding ElementName=PART_ImageDisplay, Path=IsInteractive}" Value="False">
                                                     <Setter Property="Visibility" Value="Visible" />
+                                                </DataTrigger>
+                                                <DataTrigger Binding="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=ViewModel.SelectedImage}" Value="{x:Null}">
+                                                    <Setter Property="Visibility" Value="Collapsed" />
                                                 </DataTrigger>
                                             </Style.Triggers>
                                         </Style>
@@ -328,6 +331,25 @@
                                                VerticalAlignment="Center"
                                                Text="Loading..." />
                                 </Border>
+
+                                <ProgressBar Grid.ColumnSpan="3"
+                                             Height="2"
+                                             VerticalAlignment="Top"
+                                             IsIndeterminate="True">
+                                    <ProgressBar.Style>
+                                        <Style TargetType="{x:Type ProgressBar}">
+                                            <Setter Property="Visibility" Value="Collapsed" />
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding ElementName=PART_ImageDisplay, Path=IsBusy}" Value="True">
+                                                    <Setter Property="Visibility" Value="Visible" />
+                                                </DataTrigger>
+                                                <DataTrigger Binding="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=ViewModel.SelectedImage}" Value="{x:Null}">
+                                                    <Setter Property="Visibility" Value="Collapsed" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </ProgressBar.Style>
+                                </ProgressBar>
 
                                 <Popup PlacementTarget="{Binding ElementName=PART_ImageDisplay}"
                                        Placement="Center"

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml
@@ -54,7 +54,22 @@
                                     IsChecked="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=ShowUnselectedImagesFootprints, Mode=TwoWay}"
                                     ToolTip="Show unselected images footprints" />
                             </WrapPanel>
-                            <controls:OrientedImageDisplay x:Name="PART_ImageDisplay" Grid.Row="1" />
+                            <Grid Grid.Row="1">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+
+                                <controls:OrientedImageDisplay Grid.ColumnSpan="3" x:Name="PART_ImageDisplay" />
+
+                                <Button Content="&lt;"
+                                        Command="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=ViewModel.SelectPreviousImageCommand}"
+                                        VerticalAlignment="Center"/>
+                                <Button Content="&gt;"
+                                        Command="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=ViewModel.SelectNextImageCommand}"
+                                        Grid.Column="2" VerticalAlignment="Center" />
+                            </Grid>
                         </Grid>
                     </Border>
                 </ControlTemplate>

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml
@@ -1,7 +1,9 @@
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:internal="clr-namespace:Esri.ArcGISRuntime.Toolkit.Internal"
     xmlns:controls="clr-namespace:Esri.ArcGISRuntime.Toolkit.UI.Controls">
+
     <Style TargetType="{x:Type controls:OrientedImageDisplay}">
         <Setter Property="IsTabStop" Value="False" />
         <Setter Property="Template">
@@ -12,6 +14,48 @@
                         BorderBrush="{TemplateBinding BorderBrush}"
                         BorderThickness="{TemplateBinding BorderThickness}">
                         <ContentPresenter x:Name="PART_DisplayHost" />
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style TargetType="{x:Type controls:OrientedImageryView}">
+        <Setter Property="IsTabStop" Value="False" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type controls:OrientedImageryView}">
+                    <Border
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}">
+                        <Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="*" />
+                            </Grid.RowDefinitions>
+                            <WrapPanel Margin="4,4,4,0">
+                                <ToggleButton
+                                    Margin="0,0,4,4"
+                                    Padding="8,4"
+                                    Content="Auto update footprint"
+                                    IsChecked="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=AutoUpdateFootprint, Mode=TwoWay}"
+                                    ToolTip="Update footprint" />
+                                <ToggleButton
+                                    Margin="0,0,4,4"
+                                    Padding="8,4"
+                                    Content="Show selected image footprint"
+                                    IsChecked="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=ShowSelectedImageFootprint, Mode=TwoWay}"
+                                    ToolTip="Show selected image footprint" />
+                                <ToggleButton
+                                    Margin="0,0,4,4"
+                                    Padding="8,4"
+                                    Content="Show unselected images footprints"
+                                    IsChecked="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=ShowUnselectedImagesFootprints, Mode=TwoWay}"
+                                    ToolTip="Show unselected images footprints" />
+                            </WrapPanel>
+                            <controls:OrientedImageDisplay x:Name="PART_ImageDisplay" Grid.Row="1" />
+                        </Grid>
                     </Border>
                 </ControlTemplate>
             </Setter.Value>

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml
@@ -123,22 +123,6 @@
     </Style>
 
     <!-- Toolbar data templates -->
-    <DataTemplate x:Key="MarkerPickerToolbarTemplate" DataType="controls:SelectNewMarkerSymbolVM">
-        <Button Style="{StaticResource ToolbarButtonStyle}" Command="{Binding SelectNextSymbol}" Visibility="{Binding MainViewModel.AllowAddingMarkers, Converter={StaticResource BooleanToVisibilityConverter}}" ToolTip="{internal:LocalizedString Key=OrientedImageryViewSelectMarkerSymbol}">
-            <controls:SymbolDisplay Width="32" Height="32" Symbol="{Binding SelectedSymbol, Mode=OneWay}" />
-        </Button>
-    </DataTemplate>
-
-    <DataTemplate x:Key="AllowAddingMarkersToolbarTemplate" DataType="controls:AllowAddingMarkersVM">
-        <ToggleButton Style="{StaticResource ToolbarToggleButtonStyle}" IsChecked="{Binding MainViewModel.AllowAddingMarkers}" ToolTip="{internal:LocalizedString Key=OrientedImageryViewToggleAddMarkers}">
-            <Viewbox Width="32" Height="32" Stretch="Uniform">
-                <TextBlock Text="&#xe8ed;"
-                           FontSize="24"
-                           FontFamily="{StaticResource ToolkitIconsFontFamily}"
-                           Foreground="Black" />
-            </Viewbox>
-        </ToggleButton>
-    </DataTemplate>
 
     <DataTemplate x:Key="ShowSelectedFootprintToolbarTemplate" DataType="controls:ShowSelectedFootprintVM">
         <ToggleButton Style="{StaticResource ToolbarToggleButtonStyle}" IsChecked="{Binding MainViewModel.ShowSelectedFootprint}" ToolTip="{internal:LocalizedString Key=OrientedImageryViewShowSelectedImageFootprint}">
@@ -232,6 +216,23 @@
                     </TextBlock>
                 </Viewbox>
             </Grid>
+        </Button>
+    </DataTemplate>
+
+    <DataTemplate x:Key="AllowAddingMarkersToolbarTemplate" DataType="controls:AllowAddingMarkersVM">
+        <ToggleButton Style="{StaticResource ToolbarToggleButtonStyle}" IsChecked="{Binding MainViewModel.AllowAddingMarkers}" ToolTip="{internal:LocalizedString Key=OrientedImageryViewToggleAddMarkers}">
+            <Viewbox Width="32" Height="32" Stretch="Uniform">
+                <TextBlock Text="&#xe8ed;"
+                           FontSize="24"
+                           FontFamily="{StaticResource ToolkitIconsFontFamily}"
+                           Foreground="Black" />
+            </Viewbox>
+        </ToggleButton>
+    </DataTemplate>
+
+    <DataTemplate x:Key="MarkerPickerToolbarTemplate" DataType="controls:SelectNewMarkerSymbolVM">
+        <Button Style="{StaticResource ToolbarButtonStyle}" Command="{Binding SelectNextSymbol}" Visibility="{Binding MainViewModel.AllowAddingMarkers, Converter={StaticResource BooleanToVisibilityConverter}}" ToolTip="{internal:LocalizedString Key=OrientedImageryViewSelectMarkerSymbol}">
+            <controls:SymbolDisplay Width="32" Height="32" Symbol="{Binding SelectedSymbol, Mode=OneWay}" />
         </Button>
     </DataTemplate>
 

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml
@@ -16,7 +16,6 @@
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="BorderBrush" Value="Transparent" />
         <Setter Property="BorderThickness" Value="1" />
-        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Button}">
@@ -51,7 +50,6 @@
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="BorderBrush" Value="Transparent" />
         <Setter Property="BorderThickness" Value="1" />
-        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ToggleButton}">
@@ -94,7 +92,6 @@
         <Setter Property="Background" Value="#80FFFFFF" />
         <Setter Property="BorderBrush" Value="Transparent" />
         <Setter Property="BorderThickness" Value="0" />
-        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Button}">
@@ -232,7 +229,7 @@
 
     <DataTemplate x:Key="MarkerPickerToolbarTemplate" DataType="controls:SelectNewMarkerSymbolVM">
         <Button Style="{StaticResource ToolbarButtonStyle}" Command="{Binding SelectNextSymbol}" Visibility="{Binding ViewModel.AllowAddingMarkers, Converter={StaticResource BooleanToVisibilityConverter}}" ToolTip="{internal:LocalizedString Key=OrientedImageryViewSelectMarkerSymbol}">
-            <controls:SymbolDisplay Width="32" Height="32" Symbol="{Binding SelectedSymbol, Mode=OneWay}" />
+            <controls:SymbolDisplay Width="32" Height="32" Symbol="{Binding SelectedSymbol, Mode=OneWay}" IsTabStop="False" Focusable="False" />
         </Button>
     </DataTemplate>
 

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/OrientedImagery/OrientedImagery.Theme.xaml
@@ -125,18 +125,18 @@
     <!-- Toolbar data templates -->
 
     <DataTemplate x:Key="ShowSelectedFootprintToolbarTemplate" DataType="controls:ShowSelectedFootprintVM">
-        <ToggleButton Style="{StaticResource ToolbarToggleButtonStyle}" IsChecked="{Binding MainViewModel.ShowSelectedFootprint}" ToolTip="{internal:LocalizedString Key=OrientedImageryViewShowSelectedImageFootprint}">
+        <ToggleButton Style="{StaticResource ToolbarToggleButtonStyle}" IsChecked="{Binding ViewModel.ShowSelectedFootprint}" ToolTip="{internal:LocalizedString Key=OrientedImageryViewShowSelectedImageFootprint}">
             <Viewbox SnapsToDevicePixels="true" Width="30" Height="30" Stretch="Uniform">
                 <Grid Width="24" Height="24">
                     <!-- A font icon was not available for this calcite symbol (trapezoid). Using two manual Paths also allows binding separate colors for fill and stroke. -->
                     <Path SnapsToDevicePixels="true" Data="M19.384 20H4.616L.349 4h23.302zm-14-1h13.232l3.733-14H1.651z">
                         <Path.Fill>
-                            <SolidColorBrush Color="{Binding MainViewModel.SelectedFootprintOutlineColor, Converter={StaticResource ColorToColorConverter}}" />
+                            <SolidColorBrush Color="{Binding ViewModel.SelectedFootprintOutlineColor, Converter={StaticResource ColorToColorConverter}}" />
                         </Path.Fill>
                     </Path>
                     <Path SnapsToDevicePixels="true" Data="m22.35 5-3.73 14H5.38L1.65 5z">
                         <Path.Fill>
-                            <SolidColorBrush Color="{Binding MainViewModel.SelectedFootprintFillColor, Converter={StaticResource ColorToColorConverter}}" />
+                            <SolidColorBrush Color="{Binding ViewModel.SelectedFootprintFillColor, Converter={StaticResource ColorToColorConverter}}" />
                         </Path.Fill>
                     </Path>
                 </Grid>
@@ -145,18 +145,18 @@
     </DataTemplate>
 
     <DataTemplate x:Key="ShowUnselectedFootprintsToolbarTemplate" DataType="controls:ShowUnselectedFootprintsVM">
-        <ToggleButton Style="{StaticResource ToolbarToggleButtonStyle}" IsChecked="{Binding MainViewModel.ShowUnselectedFootprints}" ToolTip="{internal:LocalizedString Key=OrientedImageryViewShowUnselectedImageFootprints}">
+        <ToggleButton Style="{StaticResource ToolbarToggleButtonStyle}" IsChecked="{Binding ViewModel.ShowUnselectedFootprints}" ToolTip="{internal:LocalizedString Key=OrientedImageryViewShowUnselectedImageFootprints}">
             <Viewbox SnapsToDevicePixels="true" Width="30" Height="30" Stretch="Uniform">
                 <Grid Width="24" Height="24">
                     <!-- See comment on ShowSelectedFootprintToolbarTemplate. -->
                     <Path SnapsToDevicePixels="true" Data="M19.384 20H4.616L.349 4h23.302zm-14-1h13.232l3.733-14H1.651z">
                         <Path.Fill>
-                            <SolidColorBrush Color="{Binding MainViewModel.UnselectedFootprintOutlineColor, Converter={StaticResource ColorToColorConverter}}" />
+                            <SolidColorBrush Color="{Binding ViewModel.UnselectedFootprintOutlineColor, Converter={StaticResource ColorToColorConverter}}" />
                         </Path.Fill>
                     </Path>
                     <Path SnapsToDevicePixels="true" Data="m22.35 5-3.73 14H5.38L1.65 5z">
                         <Path.Fill>
-                            <SolidColorBrush Color="{Binding MainViewModel.UnselectedFootprintFillColor, Converter={StaticResource ColorToColorConverter}}" />
+                            <SolidColorBrush Color="{Binding ViewModel.UnselectedFootprintFillColor, Converter={StaticResource ColorToColorConverter}}" />
                         </Path.Fill>
                     </Path>
                 </Grid>
@@ -170,11 +170,11 @@
                 <Style TargetType="{x:Type Button}" BasedOn="{StaticResource ToolbarButtonStyle}">
                     <Setter Property="ToolTip" Value="{internal:LocalizedString Key=OrientedImageryViewShowCameraMarkersOnGeoView}" />
                     <Style.Triggers>
-                        <DataTrigger Binding="{Binding MainViewModel.ShowCameraLocations}" Value="True">
+                        <DataTrigger Binding="{Binding ViewModel.ShowCameraLocations}" Value="True">
                             <Setter Property="Background" Value="#FFD3D3D3" />
                             <Setter Property="ToolTip" Value="{internal:LocalizedString Key=OrientedImageryViewShowCameraMarkersOnGeoViewAndImageDisplay}" />
                         </DataTrigger>
-                        <DataTrigger Binding="{Binding MainViewModel.ShowCameraLocationsOnDisplay}" Value="True">
+                        <DataTrigger Binding="{Binding ViewModel.ShowCameraLocationsOnDisplay}" Value="True">
                             <Setter Property="ToolTip" Value="{internal:LocalizedString Key=OrientedImageryViewClearCameraMarkers}" />
                         </DataTrigger>
                     </Style.Triggers>
@@ -190,7 +190,7 @@
                             <Style TargetType="{x:Type TextBlock}">
                                 <Setter Property="Visibility" Value="Visible" />
                                 <Style.Triggers>
-                                    <DataTrigger Binding="{Binding MainViewModel.ShowCameraLocationsOnDisplay}" Value="True">
+                                    <DataTrigger Binding="{Binding ViewModel.ShowCameraLocationsOnDisplay}" Value="True">
                                         <Setter Property="Visibility" Value="Collapsed" />
                                     </DataTrigger>
                                 </Style.Triggers>
@@ -207,7 +207,7 @@
                             <Style TargetType="{x:Type TextBlock}">
                                 <Setter Property="Visibility" Value="Collapsed" />
                                 <Style.Triggers>
-                                    <DataTrigger Binding="{Binding MainViewModel.ShowCameraLocationsOnDisplay}" Value="True">
+                                    <DataTrigger Binding="{Binding ViewModel.ShowCameraLocationsOnDisplay}" Value="True">
                                         <Setter Property="Visibility" Value="Visible" />
                                     </DataTrigger>
                                 </Style.Triggers>
@@ -220,7 +220,7 @@
     </DataTemplate>
 
     <DataTemplate x:Key="AllowAddingMarkersToolbarTemplate" DataType="controls:AllowAddingMarkersVM">
-        <ToggleButton Style="{StaticResource ToolbarToggleButtonStyle}" IsChecked="{Binding MainViewModel.AllowAddingMarkers}" ToolTip="{internal:LocalizedString Key=OrientedImageryViewToggleAddMarkers}">
+        <ToggleButton Style="{StaticResource ToolbarToggleButtonStyle}" IsChecked="{Binding ViewModel.AllowAddingMarkers}" ToolTip="{internal:LocalizedString Key=OrientedImageryViewToggleAddMarkers}">
             <Viewbox Width="32" Height="32" Stretch="Uniform">
                 <TextBlock Text="&#xe8ed;"
                            FontSize="24"
@@ -231,13 +231,13 @@
     </DataTemplate>
 
     <DataTemplate x:Key="MarkerPickerToolbarTemplate" DataType="controls:SelectNewMarkerSymbolVM">
-        <Button Style="{StaticResource ToolbarButtonStyle}" Command="{Binding SelectNextSymbol}" Visibility="{Binding MainViewModel.AllowAddingMarkers, Converter={StaticResource BooleanToVisibilityConverter}}" ToolTip="{internal:LocalizedString Key=OrientedImageryViewSelectMarkerSymbol}">
+        <Button Style="{StaticResource ToolbarButtonStyle}" Command="{Binding SelectNextSymbol}" Visibility="{Binding ViewModel.AllowAddingMarkers, Converter={StaticResource BooleanToVisibilityConverter}}" ToolTip="{internal:LocalizedString Key=OrientedImageryViewSelectMarkerSymbol}">
             <controls:SymbolDisplay Width="32" Height="32" Symbol="{Binding SelectedSymbol, Mode=OneWay}" />
         </Button>
     </DataTemplate>
 
     <DataTemplate x:Key="ClearMarkersToolbarTemplate" DataType="controls:ClearMarkersVM">
-        <Button Style="{StaticResource ToolbarButtonStyle}" Command="{Binding MainViewModel.ClearMarkersCommand}" ToolTip="{internal:LocalizedString Key=OrientedImageryViewClearMarkers}">
+        <Button Style="{StaticResource ToolbarButtonStyle}" Command="{Binding ViewModel.ClearMarkersCommand}" ToolTip="{internal:LocalizedString Key=OrientedImageryViewClearMarkers}">
             <Viewbox Width="28" Height="28" Stretch="Uniform">
                 <TextBlock Text="&#xe83e;"
                            FontSize="24"
@@ -247,7 +247,7 @@
         </Button>
     </DataTemplate>
 
-    <!-- Display style -->
+    <!-- Image display style -->
     <Style TargetType="{x:Type controls:OrientedImageDisplay}">
         <Setter Property="IsTabStop" Value="False" />
         <Setter Property="Template">
@@ -264,11 +264,22 @@
         </Setter>
     </Style>
 
+    <!-- Toolbar container style -->
+    <Style TargetType="{x:Type ItemsControl}">
+        <Setter Property="ItemsPanel">
+            <Setter.Value>
+                <ItemsPanelTemplate>
+                    <WrapPanel HorizontalAlignment="Center" Orientation="Horizontal" />
+                </ItemsPanelTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <!-- Main view style -->
     <Style TargetType="{x:Type controls:OrientedImageryView}">
         <Setter Property="IsTabStop" Value="False" />
 
-        <Setter Property="ItemTemplateSelector">
+        <Setter Property="ToolbarItemTemplateSelector">
             <Setter.Value>
                 <controls:OrientedImageryViewTemplateSelector>
                     <controls:OrientedImageryViewTemplateSelectorItem Type="{x:Type controls:SelectNewMarkerSymbolVM}" Template="{StaticResource MarkerPickerToolbarTemplate}" />
@@ -278,14 +289,6 @@
                     <controls:OrientedImageryViewTemplateSelectorItem Type="{x:Type controls:ShowCameraMarkersVM}" Template="{StaticResource ShowCameraMarkersToolbarTemplate}" />
                     <controls:OrientedImageryViewTemplateSelectorItem Type="{x:Type controls:ClearMarkersVM}" Template="{StaticResource ClearMarkersToolbarTemplate}" />
                 </controls:OrientedImageryViewTemplateSelector>
-            </Setter.Value>
-        </Setter>
-
-        <Setter Property="ItemsPanel">
-            <Setter.Value>
-                <ItemsPanelTemplate>
-                    <WrapPanel HorizontalAlignment="Center" Orientation="Horizontal" />
-                </ItemsPanelTemplate>
             </Setter.Value>
         </Setter>
 
@@ -302,7 +305,7 @@
                                 <RowDefinition Height="*" />
                             </Grid.RowDefinitions>
 
-                            <ItemsPresenter />
+                            <ItemsControl x:Name="PART_ToolbarContainer" />
 
                             <Grid Grid.Row="1">
                                 <Grid.ColumnDefinitions>

--- a/src/Toolkit/Toolkit/Internal/Command.cs
+++ b/src/Toolkit/Toolkit/Internal/Command.cs
@@ -1,0 +1,41 @@
+﻿// /*******************************************************************************
+//  * Copyright 2026 Esri
+//  *
+//  *  Licensed under the Apache License, Version 2.0 (the "License");
+//  *  you may not use this file except in compliance with the License.
+//  *  You may obtain a copy of the License at
+//  *
+//  *  http://www.apache.org/licenses/LICENSE-2.0
+//  *
+//  *   Unless required by applicable law or agreed to in writing, software
+//  *   distributed under the License is distributed on an "AS IS" BASIS,
+//  *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  *   See the License for the specific language governing permissions and
+//  *   limitations under the License.
+//  ******************************************************************************/
+
+#if MAUI
+using Microsoft.Maui.Controls;
+#else
+
+namespace Esri.ArcGISRuntime.Toolkit.Internal;
+
+internal class Command : System.Windows.Input.ICommand
+{
+    private Action _execute;
+    private Func<bool> _canExecute;
+
+    public Command(Action execute, Func<bool> canExecute)
+    {
+        _execute = execute;
+        _canExecute = canExecute;
+    }
+    internal void ChangeCanExecute() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+
+    public event EventHandler? CanExecuteChanged;
+
+    public bool CanExecute(object? parameter) => _canExecute();
+
+    public void Execute(object? parameter) => _execute();
+}
+#endif

--- a/src/Toolkit/Toolkit/LocalizedStrings/Resources.resx
+++ b/src/Toolkit/Toolkit/LocalizedStrings/Resources.resx
@@ -1049,4 +1049,44 @@
     <value>Oriented image, {0}</value>
     <comment>UIA AutomationProperties.Name for the image shown by OrientedImageDisplay; {0} is the oriented image type (e.g. Nadir)</comment>
   </data>
+  <data name="OrientedImageryViewSelectMarkerSymbol" xml:space="preserve">
+    <value>Select marker symbol</value>
+    <comment>Tooltip for the OrientedImageryView button that selects the marker symbol.</comment>
+  </data>
+  <data name="OrientedImageryViewToggleAddMarkers" xml:space="preserve">
+    <value>Toggle add markers</value>
+    <comment>Tooltip for the OrientedImageryView button that enables or disables adding markers.</comment>
+  </data>
+  <data name="OrientedImageryViewShowSelectedImageFootprint" xml:space="preserve">
+    <value>Show selected image footprint</value>
+    <comment>Tooltip for the OrientedImageryView button that shows the selected image footprint.</comment>
+  </data>
+  <data name="OrientedImageryViewShowUnselectedImageFootprints" xml:space="preserve">
+    <value>Show unselected image footprints</value>
+    <comment>Tooltip for the OrientedImageryView button that shows unselected image footprints.</comment>
+  </data>
+  <data name="OrientedImageryViewShowCameraMarkersOnGeoView" xml:space="preserve">
+    <value>Show camera markers on geo view</value>
+    <comment>Tooltip for the OrientedImageryView button when camera markers can be shown on the geo view.</comment>
+  </data>
+  <data name="OrientedImageryViewShowCameraMarkersOnGeoViewAndImageDisplay" xml:space="preserve">
+    <value>Show camera markers in geo view and image display</value>
+    <comment>Tooltip for the OrientedImageryView button when camera markers can be shown on both the geo view and image display.</comment>
+  </data>
+  <data name="OrientedImageryViewClearCameraMarkers" xml:space="preserve">
+    <value>Clear camera markers</value>
+    <comment>Tooltip for the OrientedImageryView button when camera markers can be cleared.</comment>
+  </data>
+  <data name="OrientedImageryViewClearMarkers" xml:space="preserve">
+    <value>Clear markers</value>
+    <comment>Tooltip for the OrientedImageryView button that clears markers.</comment>
+  </data>
+  <data name="OrientedImageryViewLoading" xml:space="preserve">
+    <value>Loading...</value>
+    <comment>Message shown by OrientedImageryView while an image is loading.</comment>
+  </data>
+  <data name="OrientedImageryViewNoImagesSelected" xml:space="preserve">
+    <value>No images selected</value>
+    <comment>Message shown by OrientedImageryView when no images are selected.</comment>
+  </data>
 </root>

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FeatureFormView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FeatureFormView.cs
@@ -70,25 +70,6 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             Unloaded += (s, e) => ClearUtilityAssociationCandidateSelection();
         }
 
-        private class Command : System.Windows.Input.ICommand
-        {
-            private Action _execute;
-            private Func<bool> _canExecute;
-
-            public Command(Action execute, Func<bool> canExecute)
-            {
-                _execute = execute;
-                _canExecute = canExecute;
-            }
-            internal void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
-
-            public event EventHandler? CanExecuteChanged;
-
-            public bool CanExecute(object? parameter) => _canExecute();
-
-            public void Execute(object? parameter) => _execute();
-        }
-
         /// <summary>
         /// Command for calling <see cref="FinishEditingAsync(bool)"/> and applying edits to the currently active Feature Form if all fields are valid.
         /// </summary>
@@ -176,7 +157,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             foreach (var item in GetDescendentsOfType<FieldFormElementView>(this))
             {
                 item.ResetValidationState();
-                ((Command)FinishEditingCommand).RaiseCanExecuteChanged();
+                ((Command)FinishEditingCommand).ChangeCanExecute();
             }
         }
 
@@ -252,8 +233,8 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             {
                 this.Dispatch(() =>
                 {
-                    ((Command)FinishEditingCommand).RaiseCanExecuteChanged();
-                    ((Command)DiscardEditsCommand).RaiseCanExecuteChanged();
+                    ((Command)FinishEditingCommand).ChangeCanExecute();
+                    ((Command)DiscardEditsCommand).ChangeCanExecute();
                 });
             }
         }
@@ -276,7 +257,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
 #if MAUI
                     base.OnPropertyChanged(nameof(IsValid));
 #endif
-                    ((Command)FinishEditingCommand).RaiseCanExecuteChanged();
+                    ((Command)FinishEditingCommand).ChangeCanExecute();
                 }
             }
         }
@@ -495,8 +476,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
                 {
                     item.ResetValidationState();
                 }
-                ((Command)FinishEditingCommand).RaiseCanExecuteChanged();
-
+                ((Command)FinishEditingCommand).ChangeCanExecute();
                 if (requireAllErrorsResolved && ScrollToFirstError()) return false;
                 await FinishEditingAsync();
                 return true;
@@ -1047,8 +1027,8 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
                 inpcNew.PropertyChanged += _elementPropertyChangedListener.OnEvent;
             }
             UpdateIsValidProperty();
-            ((Command)FinishEditingCommand).RaiseCanExecuteChanged();
-            ((Command)DiscardEditsCommand).RaiseCanExecuteChanged();
+            ((Command)FinishEditingCommand).ChangeCanExecute();
+            ((Command)DiscardEditsCommand).ChangeCanExecute();
         }
 
         /// <summary>

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OIViewDefaultToolbarVMs.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OIViewDefaultToolbarVMs.cs
@@ -31,6 +31,7 @@ public abstract class OrientedImageryViewToolbarViewModelBase : INotifyPropertyC
             if (value == _mainViewModel) return;
             var oldValue = _mainViewModel;
             _mainViewModel = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(MainViewModel)));
             OnMainViewModelChanged(oldValue, value);
         }
     }
@@ -60,6 +61,11 @@ public abstract class OrientedImageryViewToolbarViewModelBase : INotifyPropertyC
 /// View model for the "Auto Update Footprint" toolbar control in the Oriented Imagery View.
 /// </summary>
 public class AutoUpdateFootprintVM : OrientedImageryViewToolbarViewModelBase { }
+
+/// <summary>
+/// View model for the "Allow Adding Markers" toolbar control in the Oriented Imagery View.
+/// </summary>
+public class AllowAddingMarkersVM : OrientedImageryViewToolbarViewModelBase { }
 
 /// <summary>
 /// View model for the "Show Selected Footprint" toolbar control in the Oriented Imagery View.

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OIViewDefaultToolbarVMs.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OIViewDefaultToolbarVMs.cs
@@ -15,7 +15,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls;
 /// Base class for view models that are used in the toolbar of the <see cref="OrientedImageryView"/>.
 /// Derive from this class to automatically get access to the main view model of the oriented imagery view via the <see cref="MainViewModel"/> property.
 /// </summary>
-public abstract class OrientedImageryViewToolbarViewModelBase : INotifyPropertyChanged
+public abstract class OrientedImageryToolbarItemBase : INotifyPropertyChanged
 {
     private OrientedImageryViewModel? _mainViewModel;
 
@@ -60,27 +60,27 @@ public abstract class OrientedImageryViewToolbarViewModelBase : INotifyPropertyC
 /// <summary>
 /// View model for the "Auto Update Footprint" toolbar control in the Oriented Imagery View.
 /// </summary>
-public class AutoUpdateFootprintVM : OrientedImageryViewToolbarViewModelBase { }
+public class AutoUpdateFootprintVM : OrientedImageryToolbarItemBase { }
 
 /// <summary>
 /// View model for the "Allow Adding Markers" toolbar control in the Oriented Imagery View.
 /// </summary>
-public class AllowAddingMarkersVM : OrientedImageryViewToolbarViewModelBase { }
+public class AllowAddingMarkersVM : OrientedImageryToolbarItemBase { }
 
 /// <summary>
 /// View model for the "Show Selected Footprint" toolbar control in the Oriented Imagery View.
 /// </summary>
-public class ShowSelectedFootprintVM : OrientedImageryViewToolbarViewModelBase { }
+public class ShowSelectedFootprintVM : OrientedImageryToolbarItemBase { }
 
 /// <summary>
 /// View model for the "Show Unselected Footprints" toolbar control in the Oriented Imagery View.
 /// </summary>
-public class ShowUnselectedFootprintsVM : OrientedImageryViewToolbarViewModelBase { }
+public class ShowUnselectedFootprintsVM : OrientedImageryToolbarItemBase { }
 
 /// <summary>
 /// View model for the "Show Camera Markers" toolbar control in the Oriented Imagery View.
 /// </summary>
-public class ShowCameraMarkersVM : OrientedImageryViewToolbarViewModelBase
+public class ShowCameraMarkersVM : OrientedImageryToolbarItemBase
 {
     private CameraMarkerDisplayMode DisplayMode
     {
@@ -151,13 +151,13 @@ public class ShowCameraMarkersVM : OrientedImageryViewToolbarViewModelBase
 /// <summary>
 /// View model for the "Clear Markers" toolbar control in the Oriented Imagery View.
 /// </summary>
-public class ClearMarkersVM : OrientedImageryViewToolbarViewModelBase { }
+public class ClearMarkersVM : OrientedImageryToolbarItemBase { }
 
 /// <summary>
 /// View model for the "Select New Marker Symbol" toolbar control in the Oriented Imagery View.
 /// This control allows the user to loop through a collection of marker symbols and select one to be used for new markers in the oriented imagery view.
 /// </summary>
-public class SelectNewMarkerSymbolVM : OrientedImageryViewToolbarViewModelBase
+public class SelectNewMarkerSymbolVM : OrientedImageryToolbarItemBase
 {
     private static readonly MarkerSymbol DefaultSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.X, System.Drawing.Color.Red, 10);
 

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OIViewDefaultToolbarVMs.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OIViewDefaultToolbarVMs.cs
@@ -86,10 +86,10 @@ public class ShowCameraMarkersVM : OrientedImageryViewToolbarViewModelBase
     {
         get
         {
-            if (MainViewModel == null || !MainViewModel.ShowSelectedCameraLocations)
+            if (MainViewModel == null || !MainViewModel.ShowCameraLocations)
                 return CameraMarkerDisplayMode.Off;
 
-            return MainViewModel.ShowSelectedCameraLocationsOnDisplay ? CameraMarkerDisplayMode.All : CameraMarkerDisplayMode.GeoView;
+            return MainViewModel.ShowCameraLocationsOnDisplay ? CameraMarkerDisplayMode.All : CameraMarkerDisplayMode.GeoView;
         }
         set
         {
@@ -99,16 +99,16 @@ public class ShowCameraMarkersVM : OrientedImageryViewToolbarViewModelBase
             switch (value)
             {
                 case CameraMarkerDisplayMode.Off:
-                    MainViewModel.ShowSelectedCameraLocations = false;
-                    MainViewModel.ShowSelectedCameraLocationsOnDisplay = false;
+                    MainViewModel.ShowCameraLocations = false;
+                    MainViewModel.ShowCameraLocationsOnDisplay = false;
                     break;
                 case CameraMarkerDisplayMode.GeoView:
-                    MainViewModel.ShowSelectedCameraLocations = true;
-                    MainViewModel.ShowSelectedCameraLocationsOnDisplay = false;
+                    MainViewModel.ShowCameraLocations = true;
+                    MainViewModel.ShowCameraLocationsOnDisplay = false;
                     break;
                 case CameraMarkerDisplayMode.All:
-                    MainViewModel.ShowSelectedCameraLocations = true;
-                    MainViewModel.ShowSelectedCameraLocationsOnDisplay = true;
+                    MainViewModel.ShowCameraLocations = true;
+                    MainViewModel.ShowCameraLocationsOnDisplay = true;
                     break;
             }
         }

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OIViewDefaultToolbarVMs.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OIViewDefaultToolbarVMs.cs
@@ -1,0 +1,152 @@
+﻿#if WPF
+using Esri.ArcGISRuntime.Symbology;
+using Esri.ArcGISRuntime.Toolkit.Internal;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Windows.Input;
+
+namespace Esri.ArcGISRuntime.Toolkit.UI.Controls;
+
+public abstract class OrientedImageryViewToolbarVM : INotifyPropertyChanged
+{
+    private OrientedImageryViewModel? _mainViewModel;
+
+    /// <summary>
+    /// Gets or sets the main view model for the oriented imagery view. This property will be set automatically when the toolbar is added to <see cref="OrientedImageryView.ItemsSource"/>.
+    /// </summary>
+    public OrientedImageryViewModel? MainViewModel
+    {
+        get => _mainViewModel;
+        set
+        {
+            if (value == _mainViewModel) return;
+            var oldValue = _mainViewModel;
+            _mainViewModel = value;
+            OnMainViewModelChanged(oldValue, value);
+        }
+    }
+
+    /// <summary>
+    /// Called when the <see cref="MainViewModel"/> property changes. Override this method to handle changes to the main view model.
+    /// </summary>
+    protected virtual void OnMainViewModelChanged(OrientedImageryViewModel? oldValue, OrientedImageryViewModel? newValue) { }
+
+    /// <inheritdoc/>
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    /// <summary>
+    /// Sets the property and raises the <see cref="PropertyChanged"/> event if the value has changed.
+    /// </summary>
+    protected void SetProperty<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+    {
+        if (!EqualityComparer<T>.Default.Equals(field, value))
+        {
+            field = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}
+
+public class AutoUpdateFootprintVM : OrientedImageryViewToolbarVM { }
+
+public class ShowSelectedFootprintVM : OrientedImageryViewToolbarVM { }
+
+public class ShowUnselectedFootprintsVM : OrientedImageryViewToolbarVM { }
+
+public class ShowCameraMarkersVM : OrientedImageryViewToolbarVM { }
+
+public class ClearMarkersVM : OrientedImageryViewToolbarVM { }
+
+/// <summary>
+/// View model for the "Select New Marker Symbol" toolbar control in the Oriented Imagery View. This control allows the user to loop through a collection of marker symbols and select one to be used for new markers in the oriented imagery view.
+/// </summary>
+public class SelectNewMarkerSymbolVM : OrientedImageryViewToolbarVM
+{
+    private static readonly MarkerSymbol DefaultSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.X, System.Drawing.Color.Red, 10);
+
+    /// <summary>
+    /// Gets the collection of marker symbol options that can be used for selecting a new marker symbol.
+    /// </summary>
+    public ObservableCollection<MarkerSymbol> SymbolOptions { get; private set; }
+
+    /// <summary>
+    /// Creates a new instance of the <see cref="SelectNewMarkerSymbolVM"/> class.
+    /// </summary>
+    public SelectNewMarkerSymbolVM(Collection<MarkerSymbol>? markers = null)
+    {
+        SymbolOptions = new ObservableCollection<MarkerSymbol>(markers ?? new Collection<MarkerSymbol>());
+        SymbolOptions.CollectionChanged += MarkerSymbolOptions_CollectionChanged;
+
+        _selectedSymbol = SymbolOptions.Count > 0 ? SymbolOptions[0] : DefaultSymbol;
+
+        SelectNextSymbol = new Command(
+        execute: () =>
+        {
+            if (SymbolOptions.Count < 1)
+            {
+                SelectedSymbol = DefaultSymbol;
+            }
+            var currentIndex = SymbolOptions.IndexOf(SelectedSymbol);
+            if (currentIndex < 0 || currentIndex >= SymbolOptions.Count - 1)
+            {
+                SelectedSymbol = SymbolOptions[0];
+            }
+            else
+            {
+                SelectedSymbol = SymbolOptions[currentIndex + 1];
+            }
+        },
+        canExecute: () => true);
+    }
+
+    private void MarkerSymbolOptions_CollectionChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+    {
+        if (SymbolOptions.Count < 1)
+        {
+            SelectedSymbol = DefaultSymbol;
+        }
+        else if (!SymbolOptions.Contains(SelectedSymbol))
+        {
+            SelectedSymbol = SymbolOptions[0];
+        }
+    }
+
+    private MarkerSymbol _selectedSymbol;
+    /// <summary>
+    /// Gets the currently-selected marker symbol.
+    /// </summary>
+    public MarkerSymbol SelectedSymbol
+    {
+        get => _selectedSymbol;
+        private set
+        {
+            if (value == _selectedSymbol) { return; }
+            SetProperty(ref _selectedSymbol, value);
+            if (MainViewModel != null)
+            {
+                MainViewModel.NewMarkerSymbol = _selectedSymbol;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Selects the next symbol from <see cref="SymbolOptions"/>.
+    /// </summary>
+    /// <remarks>
+    /// If the current <see cref="SelectedSymbol"/> is at the end of the <see cref="SymbolOptions"/> collection, this command will wrap around and select the first symbol in the collection.
+    /// </remarks>
+    public ICommand SelectNextSymbol { get; private set; }
+
+    /// <inheritdoc />
+    protected override void OnMainViewModelChanged(OrientedImageryViewModel? oldValue, OrientedImageryViewModel? newValue)
+    {
+        base.OnMainViewModelChanged(oldValue, newValue);
+        if (MainViewModel != null)
+            MainViewModel.NewMarkerSymbol = _selectedSymbol;
+    }
+}
+#endif

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OIViewDefaultToolbarVMs.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OIViewDefaultToolbarVMs.cs
@@ -11,12 +11,17 @@ using System.Windows.Input;
 
 namespace Esri.ArcGISRuntime.Toolkit.UI.Controls;
 
-public abstract class OrientedImageryViewToolbarVM : INotifyPropertyChanged
+/// <summary>
+/// Base class for view models that are used in the toolbar of the <see cref="OrientedImageryView"/>.
+/// Derive from this class to automatically get access to the main view model of the oriented imagery view via the <see cref="MainViewModel"/> property.
+/// </summary>
+public abstract class OrientedImageryViewToolbarViewModelBase : INotifyPropertyChanged
 {
     private OrientedImageryViewModel? _mainViewModel;
 
     /// <summary>
-    /// Gets or sets the main view model for the oriented imagery view. This property will be set automatically when the toolbar is added to <see cref="OrientedImageryView.ItemsSource"/>.
+    /// Gets or sets the main view model for the oriented imagery view. This property will be set automatically when the toolbar is added to the
+    /// <see cref="ItemsControl.ItemsSource"/> of the <see cref="OrientedImageryView"/>.
     /// </summary>
     public OrientedImageryViewModel? MainViewModel
     {
@@ -51,20 +56,36 @@ public abstract class OrientedImageryViewToolbarVM : INotifyPropertyChanged
     }
 }
 
-public class AutoUpdateFootprintVM : OrientedImageryViewToolbarVM { }
-
-public class ShowSelectedFootprintVM : OrientedImageryViewToolbarVM { }
-
-public class ShowUnselectedFootprintsVM : OrientedImageryViewToolbarVM { }
-
-public class ShowCameraMarkersVM : OrientedImageryViewToolbarVM { }
-
-public class ClearMarkersVM : OrientedImageryViewToolbarVM { }
+/// <summary>
+/// View model for the "Auto Update Footprint" toolbar control in the Oriented Imagery View.
+/// </summary>
+public class AutoUpdateFootprintVM : OrientedImageryViewToolbarViewModelBase { }
 
 /// <summary>
-/// View model for the "Select New Marker Symbol" toolbar control in the Oriented Imagery View. This control allows the user to loop through a collection of marker symbols and select one to be used for new markers in the oriented imagery view.
+/// View model for the "Show Selected Footprint" toolbar control in the Oriented Imagery View.
 /// </summary>
-public class SelectNewMarkerSymbolVM : OrientedImageryViewToolbarVM
+public class ShowSelectedFootprintVM : OrientedImageryViewToolbarViewModelBase { }
+
+/// <summary>
+/// View model for the "Show Unselected Footprints" toolbar control in the Oriented Imagery View.
+/// </summary>
+public class ShowUnselectedFootprintsVM : OrientedImageryViewToolbarViewModelBase { }
+
+/// <summary>
+/// View model for the "Show Camera Markers" toolbar control in the Oriented Imagery View.
+/// </summary>
+public class ShowCameraMarkersVM : OrientedImageryViewToolbarViewModelBase { }
+
+/// <summary>
+/// View model for the "Clear Markers" toolbar control in the Oriented Imagery View.
+/// </summary>
+public class ClearMarkersVM : OrientedImageryViewToolbarViewModelBase { }
+
+/// <summary>
+/// View model for the "Select New Marker Symbol" toolbar control in the Oriented Imagery View.
+/// This control allows the user to loop through a collection of marker symbols and select one to be used for new markers in the oriented imagery view.
+/// </summary>
+public class SelectNewMarkerSymbolVM : OrientedImageryViewToolbarViewModelBase
 {
     private static readonly MarkerSymbol DefaultSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.X, System.Drawing.Color.Red, 10);
 

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OIViewDefaultToolbarVMs.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OIViewDefaultToolbarVMs.cs
@@ -80,7 +80,73 @@ public class ShowUnselectedFootprintsVM : OrientedImageryViewToolbarViewModelBas
 /// <summary>
 /// View model for the "Show Camera Markers" toolbar control in the Oriented Imagery View.
 /// </summary>
-public class ShowCameraMarkersVM : OrientedImageryViewToolbarViewModelBase { }
+public class ShowCameraMarkersVM : OrientedImageryViewToolbarViewModelBase
+{
+    private CameraMarkerDisplayMode DisplayMode
+    {
+        get
+        {
+            if (MainViewModel == null || !MainViewModel.ShowSelectedCameraLocations)
+                return CameraMarkerDisplayMode.Off;
+
+            return MainViewModel.ShowSelectedCameraLocationsOnDisplay ? CameraMarkerDisplayMode.All : CameraMarkerDisplayMode.GeoView;
+        }
+        set
+        {
+            if (MainViewModel == null)
+                return;
+
+            switch (value)
+            {
+                case CameraMarkerDisplayMode.Off:
+                    MainViewModel.ShowSelectedCameraLocations = false;
+                    MainViewModel.ShowSelectedCameraLocationsOnDisplay = false;
+                    break;
+                case CameraMarkerDisplayMode.GeoView:
+                    MainViewModel.ShowSelectedCameraLocations = true;
+                    MainViewModel.ShowSelectedCameraLocationsOnDisplay = false;
+                    break;
+                case CameraMarkerDisplayMode.All:
+                    MainViewModel.ShowSelectedCameraLocations = true;
+                    MainViewModel.ShowSelectedCameraLocationsOnDisplay = true;
+                    break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Advances to the next camera marker display mode.
+    /// </summary>
+    public ICommand ToggleCameraMarkerDisplayMode { get; }
+
+    /// <summary>
+    /// Creates a new instance of the <see cref="ShowCameraMarkersVM" /> class.
+    /// </summary>
+    public ShowCameraMarkersVM()
+    {
+        ToggleCameraMarkerDisplayMode = new Command(
+        execute: () =>
+        {
+            if (MainViewModel == null)
+                return;
+
+            DisplayMode = DisplayMode switch
+            {
+                CameraMarkerDisplayMode.Off => CameraMarkerDisplayMode.GeoView,
+                CameraMarkerDisplayMode.GeoView => CameraMarkerDisplayMode.All,
+                _ => CameraMarkerDisplayMode.Off,
+            };
+        },
+        canExecute: () => true);
+    }
+
+    private enum CameraMarkerDisplayMode
+    {
+        Off,
+        GeoView,
+        All,
+    }
+}
 
 /// <summary>
 /// View model for the "Clear Markers" toolbar control in the Oriented Imagery View.

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OIViewDefaultToolbarVMs.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OIViewDefaultToolbarVMs.cs
@@ -192,6 +192,7 @@ public class SelectNewMarkerSymbolVM : OrientedImageryToolbarItemBase
             if (SymbolOptions.Count < 1)
             {
                 SelectedSymbol = DefaultSymbol;
+                return;
             }
             var currentIndex = SymbolOptions.IndexOf(SelectedSymbol);
             if (currentIndex < 0 || currentIndex >= SymbolOptions.Count - 1)

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OIViewDefaultToolbarVMs.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OIViewDefaultToolbarVMs.cs
@@ -12,18 +12,28 @@ using System.Windows.Input;
 namespace Esri.ArcGISRuntime.Toolkit.UI.Controls;
 
 /// <summary>
-/// Base class for view models that are used in the toolbar of the <see cref="OrientedImageryView"/>.
-/// Derive from this class to automatically get access to the main view model of the oriented imagery view via the <see cref="MainViewModel"/> property.
+/// Base class for view models backing the toolbar controls of an <see cref="OrientedImageryView"/>.
 /// </summary>
+/// <remarks>
+/// <para>
+///   <see cref="OrientedImageryToolbarItemBase"/> objects are meant to be held in <see cref="OrientedImageryViewModel.ToolbarItems"/>.
+///   They supply an <see cref="ViewModel"/> property for convenient access to the containing <see cref="OrientedImageryViewModel"/>, and implement
+///   <see cref="INotifyPropertyChanged"/>.
+/// </para>
+/// <para>
+///   <see cref="ViewModel"/> is populated when an <see cref="OrientedImageryToolbarItemBase"/> instance is added to <see cref="OrientedImageryViewModel.ToolbarItems"/>.
+///   The same <see cref="OrientedImageryToolbarItemBase"/> instance should not be shared between multiple <see cref="OrientedImageryViewModel"/> instances, as only
+///   one view model can be referenced by the <see cref="ViewModel"/> property at a time.
+/// </para>
+/// </remarks>
 public abstract class OrientedImageryToolbarItemBase : INotifyPropertyChanged
 {
     private OrientedImageryViewModel? _mainViewModel;
 
     /// <summary>
-    /// Gets or sets the main view model for the oriented imagery view. This property will be set automatically when the toolbar is added to the
-    /// <see cref="ItemsControl.ItemsSource"/> of the <see cref="OrientedImageryView"/>.
+    /// Gets or sets the linked <see cref="OrientedImageryViewModel"/>. This property will be set automatically when the toolbar item is added to <see cref="OrientedImageryViewModel.ToolbarItems"/>.
     /// </summary>
-    public OrientedImageryViewModel? MainViewModel
+    public OrientedImageryViewModel? ViewModel
     {
         get => _mainViewModel;
         set
@@ -31,13 +41,13 @@ public abstract class OrientedImageryToolbarItemBase : INotifyPropertyChanged
             if (value == _mainViewModel) return;
             var oldValue = _mainViewModel;
             _mainViewModel = value;
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(MainViewModel)));
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(ViewModel)));
             OnMainViewModelChanged(oldValue, value);
         }
     }
 
     /// <summary>
-    /// Called when the <see cref="MainViewModel"/> property changes. Override this method to handle changes to the main view model.
+    /// Called when the <see cref="ViewModel"/> property changes. Override this method to handle changes to the main view model.
     /// </summary>
     protected virtual void OnMainViewModelChanged(OrientedImageryViewModel? oldValue, OrientedImageryViewModel? newValue) { }
 
@@ -86,29 +96,29 @@ public class ShowCameraMarkersVM : OrientedImageryToolbarItemBase
     {
         get
         {
-            if (MainViewModel == null || !MainViewModel.ShowCameraLocations)
+            if (ViewModel == null || !ViewModel.ShowCameraLocations)
                 return CameraMarkerDisplayMode.Off;
 
-            return MainViewModel.ShowCameraLocationsOnDisplay ? CameraMarkerDisplayMode.All : CameraMarkerDisplayMode.GeoView;
+            return ViewModel.ShowCameraLocationsOnDisplay ? CameraMarkerDisplayMode.All : CameraMarkerDisplayMode.GeoView;
         }
         set
         {
-            if (MainViewModel == null)
+            if (ViewModel == null)
                 return;
 
             switch (value)
             {
                 case CameraMarkerDisplayMode.Off:
-                    MainViewModel.ShowCameraLocations = false;
-                    MainViewModel.ShowCameraLocationsOnDisplay = false;
+                    ViewModel.ShowCameraLocations = false;
+                    ViewModel.ShowCameraLocationsOnDisplay = false;
                     break;
                 case CameraMarkerDisplayMode.GeoView:
-                    MainViewModel.ShowCameraLocations = true;
-                    MainViewModel.ShowCameraLocationsOnDisplay = false;
+                    ViewModel.ShowCameraLocations = true;
+                    ViewModel.ShowCameraLocationsOnDisplay = false;
                     break;
                 case CameraMarkerDisplayMode.All:
-                    MainViewModel.ShowCameraLocations = true;
-                    MainViewModel.ShowCameraLocationsOnDisplay = true;
+                    ViewModel.ShowCameraLocations = true;
+                    ViewModel.ShowCameraLocationsOnDisplay = true;
                     break;
             }
         }
@@ -127,7 +137,7 @@ public class ShowCameraMarkersVM : OrientedImageryToolbarItemBase
         ToggleCameraMarkerDisplayMode = new Command(
         execute: () =>
         {
-            if (MainViewModel == null)
+            if (ViewModel == null)
                 return;
 
             DisplayMode = DisplayMode switch
@@ -219,9 +229,9 @@ public class SelectNewMarkerSymbolVM : OrientedImageryToolbarItemBase
         {
             if (value == _selectedSymbol) { return; }
             SetProperty(ref _selectedSymbol, value);
-            if (MainViewModel != null)
+            if (ViewModel != null)
             {
-                MainViewModel.NewMarkerSymbol = _selectedSymbol;
+                ViewModel.NewMarkerSymbol = _selectedSymbol;
             }
         }
     }
@@ -238,8 +248,8 @@ public class SelectNewMarkerSymbolVM : OrientedImageryToolbarItemBase
     protected override void OnMainViewModelChanged(OrientedImageryViewModel? oldValue, OrientedImageryViewModel? newValue)
     {
         base.OnMainViewModelChanged(oldValue, newValue);
-        if (MainViewModel != null)
-            MainViewModel.NewMarkerSymbol = _selectedSymbol;
+        if (ViewModel != null)
+            ViewModel.NewMarkerSymbol = _selectedSymbol;
     }
 }
 #endif

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImagePanoramicDisplay.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImagePanoramicDisplay.cs
@@ -302,6 +302,9 @@ internal sealed partial class OrientedImagePanoramicDisplay : OrientedImageInner
         }
         else if (position.Location is MapPoint location)
         {
+            if (image.LoadStatus != LoadStatus.Loaded)
+                return null;
+
             try
             {
                 pixel = await image.LocationToImageAsync(location).ConfigureAwait(false);

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageRasterDisplay.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageRasterDisplay.cs
@@ -129,8 +129,14 @@ internal sealed partial class OrientedImageRasterDisplay : OrientedImageInnerDis
 
             // GetLayerViewState throws if the layer isn't in the current map (can happen during a map swap).
             if (_mapView.Map?.OperationalLayers.Contains(layer) == true &&
-                _mapView.GetLayerViewState(layer)?.Error is Exception viewError)
-                return viewError;
+                _mapView.GetLayerViewState(layer) is LayerViewState layerViewState &&
+                layerViewState.Error is Exception viewError)
+            {
+                // It's now standard for core to raise a warning on RasterLayers whenever pedata hasn't been set, which doesn't apply to most oriented image rasters
+                // since most don't have a spatial reference in the first place
+                if (!(layerViewState.Status.HasFlag(LayerViewStatus.Warning) && viewError.Message.Contains("The pedata directory has not been set.")))
+                    return viewError;
+            }
         }
 
         return PresentationError;

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageRasterDisplay.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageRasterDisplay.cs
@@ -406,6 +406,9 @@ internal sealed partial class OrientedImageRasterDisplay : OrientedImageInnerDis
         }
         else if (position.Location is MapPoint location && Footprint?.OrientedImage is OrientedImage image)
         {
+            if (image.LoadStatus != LoadStatus.Loaded)
+                return null;
+
             try
             {
                 pixel = await image.LocationToImageAsync(location);

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryView.Windows.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryView.Windows.cs
@@ -1,10 +1,51 @@
 #if WPF // Limiting this to WPF for now to keep things simple
 
+using System.Collections;
+using System.Collections.Specialized;
+
 namespace Esri.ArcGISRuntime.Toolkit.UI.Controls;
 
 [TemplatePart(Name = ImageDisplayName, Type = typeof(OrientedImageDisplay))]
 public partial class OrientedImageryView : ItemsControl
 {
+    /// <inheritdoc />
+    protected override void OnItemsChanged(NotifyCollectionChangedEventArgs e)
+    {
+        base.OnItemsChanged(e);
+
+        foreach (var toolbarVM in e.OldItems?.OfType<OrientedImageryViewToolbarVM>() ?? [])
+        {
+            toolbarVM.MainViewModel = null;
+        }
+
+        foreach (var toolbarVM in e.NewItems?.OfType<OrientedImageryViewToolbarVM>() ?? [])
+        {
+            toolbarVM.MainViewModel = this.ViewModel;
+        }
+    }
+
+    /// <inheritdoc />
+    protected override void OnItemsSourceChanged(IEnumerable oldValue, IEnumerable newValue)
+    {
+        base.OnItemsSourceChanged(oldValue, newValue);
+
+        try
+        {
+
+            foreach (var toolbarVM in oldValue?.OfType<OrientedImageryViewToolbarVM>() ?? [])
+            {
+                toolbarVM.MainViewModel = null;
+            }
+
+            foreach (var toolbarVM in newValue?.OfType<OrientedImageryViewToolbarVM>() ?? [])
+            {
+                toolbarVM.MainViewModel = this.ViewModel;
+            }
+        }
+        catch (Exception ex) {
+            var hi = 1;
+        }
+    }
 }
 
 #endif

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryView.Windows.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryView.Windows.cs
@@ -8,6 +8,14 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls;
 [TemplatePart(Name = ImageDisplayName, Type = typeof(OrientedImageDisplay))]
 public partial class OrientedImageryView : ItemsControl
 {
+    private void SetToolbarViewModels(OrientedImageryViewModel? viewModel)
+    {
+        foreach (var toolbarVM in Items.OfType<OrientedImageryViewToolbarViewModelBase>())
+        {
+            toolbarVM.MainViewModel = viewModel;
+        }
+    }
+
     /// <inheritdoc />
     protected override void OnItemsChanged(NotifyCollectionChangedEventArgs e)
     {
@@ -18,10 +26,7 @@ public partial class OrientedImageryView : ItemsControl
             toolbarVM.MainViewModel = null;
         }
 
-        foreach (var toolbarVM in e.NewItems?.OfType<OrientedImageryViewToolbarViewModelBase>() ?? [])
-        {
-            toolbarVM.MainViewModel = this.ViewModel;
-        }
+        SetToolbarViewModels(ViewModel);
     }
 
     /// <inheritdoc />
@@ -29,22 +34,12 @@ public partial class OrientedImageryView : ItemsControl
     {
         base.OnItemsSourceChanged(oldValue, newValue);
 
-        try
+        foreach (var toolbarVM in oldValue?.OfType<OrientedImageryViewToolbarViewModelBase>() ?? [])
         {
-
-            foreach (var toolbarVM in oldValue?.OfType<OrientedImageryViewToolbarViewModelBase>() ?? [])
-            {
-                toolbarVM.MainViewModel = null;
-            }
-
-            foreach (var toolbarVM in newValue?.OfType<OrientedImageryViewToolbarViewModelBase>() ?? [])
-            {
-                toolbarVM.MainViewModel = this.ViewModel;
-            }
+            toolbarVM.MainViewModel = null;
         }
-        catch (Exception ex) {
-            var hi = 1;
-        }
+
+        SetToolbarViewModels(ViewModel);
     }
 }
 

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryView.Windows.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryView.Windows.cs
@@ -3,7 +3,7 @@
 namespace Esri.ArcGISRuntime.Toolkit.UI.Controls;
 
 [TemplatePart(Name = ImageDisplayName, Type = typeof(OrientedImageDisplay))]
-public partial class OrientedImageryView : Control
+public partial class OrientedImageryView : ItemsControl
 {
 }
 

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryView.Windows.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryView.Windows.cs
@@ -8,9 +8,11 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls;
 [TemplatePart(Name = ImageDisplayName, Type = typeof(OrientedImageDisplay))]
 public partial class OrientedImageryView : ItemsControl
 {
+    private OrientedImageryViewTemplateSelector? _defaultItemTemplateSelector;
+
     private void SetToolbarViewModels(OrientedImageryViewModel? viewModel)
     {
-        foreach (var toolbarVM in Items.OfType<OrientedImageryViewToolbarViewModelBase>())
+        foreach (var toolbarVM in Items.OfType<OrientedImageryToolbarItemBase>())
         {
             toolbarVM.MainViewModel = viewModel;
         }
@@ -21,7 +23,7 @@ public partial class OrientedImageryView : ItemsControl
     {
         base.OnItemsChanged(e);
 
-        foreach (var toolbarVM in e.OldItems?.OfType<OrientedImageryViewToolbarViewModelBase>() ?? [])
+        foreach (var toolbarVM in e.OldItems?.OfType<OrientedImageryToolbarItemBase>() ?? [])
         {
             toolbarVM.MainViewModel = null;
         }
@@ -34,12 +36,31 @@ public partial class OrientedImageryView : ItemsControl
     {
         base.OnItemsSourceChanged(oldValue, newValue);
 
-        foreach (var toolbarVM in oldValue?.OfType<OrientedImageryViewToolbarViewModelBase>() ?? [])
+        foreach (var toolbarVM in oldValue?.OfType<OrientedImageryToolbarItemBase>() ?? [])
         {
             toolbarVM.MainViewModel = null;
         }
 
         SetToolbarViewModels(ViewModel);
+    }
+
+    /// <inheritdoc />
+    protected override void OnItemTemplateSelectorChanged(DataTemplateSelector oldItemTemplateSelector, DataTemplateSelector newItemTemplateSelector)
+    {
+        if (newItemTemplateSelector is not OrientedImageryViewTemplateSelector newSelector)
+        {
+            return;
+        }
+
+        // Save and in the future merge the default selector so the default styles are always available unless overridden.
+        if (ReadLocalValue(ItemTemplateSelectorProperty) == DependencyProperty.UnsetValue)
+        {
+            _defaultItemTemplateSelector = newSelector;
+        }
+        else if (_defaultItemTemplateSelector is not null)
+        {
+            newSelector.Merge(_defaultItemTemplateSelector);
+        }
     }
 }
 

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryView.Windows.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryView.Windows.cs
@@ -1,0 +1,10 @@
+#if WPF // Limiting this to WPF for now to keep things simple
+
+namespace Esri.ArcGISRuntime.Toolkit.UI.Controls;
+
+[TemplatePart(Name = ImageDisplayName, Type = typeof(OrientedImageDisplay))]
+public partial class OrientedImageryView : Control
+{
+}
+
+#endif

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryView.Windows.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryView.Windows.cs
@@ -13,12 +13,12 @@ public partial class OrientedImageryView : ItemsControl
     {
         base.OnItemsChanged(e);
 
-        foreach (var toolbarVM in e.OldItems?.OfType<OrientedImageryViewToolbarVM>() ?? [])
+        foreach (var toolbarVM in e.OldItems?.OfType<OrientedImageryViewToolbarViewModelBase>() ?? [])
         {
             toolbarVM.MainViewModel = null;
         }
 
-        foreach (var toolbarVM in e.NewItems?.OfType<OrientedImageryViewToolbarVM>() ?? [])
+        foreach (var toolbarVM in e.NewItems?.OfType<OrientedImageryViewToolbarViewModelBase>() ?? [])
         {
             toolbarVM.MainViewModel = this.ViewModel;
         }
@@ -32,12 +32,12 @@ public partial class OrientedImageryView : ItemsControl
         try
         {
 
-            foreach (var toolbarVM in oldValue?.OfType<OrientedImageryViewToolbarVM>() ?? [])
+            foreach (var toolbarVM in oldValue?.OfType<OrientedImageryViewToolbarViewModelBase>() ?? [])
             {
                 toolbarVM.MainViewModel = null;
             }
 
-            foreach (var toolbarVM in newValue?.OfType<OrientedImageryViewToolbarVM>() ?? [])
+            foreach (var toolbarVM in newValue?.OfType<OrientedImageryViewToolbarViewModelBase>() ?? [])
             {
                 toolbarVM.MainViewModel = this.ViewModel;
             }

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryView.Windows.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryView.Windows.cs
@@ -1,67 +1,13 @@
 #if WPF // Limiting this to WPF for now to keep things simple
 
-using System.Collections;
-using System.Collections.Specialized;
+using Esri.ArcGISRuntime.Toolkit.Internal;
 
 namespace Esri.ArcGISRuntime.Toolkit.UI.Controls;
 
 [TemplatePart(Name = ImageDisplayName, Type = typeof(OrientedImageDisplay))]
-public partial class OrientedImageryView : ItemsControl
+[TemplatePart(Name = ToolbarContainerName, Type = typeof(ItemsControl))]
+public partial class OrientedImageryView : Control
 {
-    private OrientedImageryViewTemplateSelector? _defaultItemTemplateSelector;
-
-    private void SetToolbarViewModels(OrientedImageryViewModel? viewModel)
-    {
-        foreach (var toolbarVM in Items.OfType<OrientedImageryToolbarItemBase>())
-        {
-            toolbarVM.MainViewModel = viewModel;
-        }
-    }
-
-    /// <inheritdoc />
-    protected override void OnItemsChanged(NotifyCollectionChangedEventArgs e)
-    {
-        base.OnItemsChanged(e);
-
-        foreach (var toolbarVM in e.OldItems?.OfType<OrientedImageryToolbarItemBase>() ?? [])
-        {
-            toolbarVM.MainViewModel = null;
-        }
-
-        SetToolbarViewModels(ViewModel);
-    }
-
-    /// <inheritdoc />
-    protected override void OnItemsSourceChanged(IEnumerable oldValue, IEnumerable newValue)
-    {
-        base.OnItemsSourceChanged(oldValue, newValue);
-
-        foreach (var toolbarVM in oldValue?.OfType<OrientedImageryToolbarItemBase>() ?? [])
-        {
-            toolbarVM.MainViewModel = null;
-        }
-
-        SetToolbarViewModels(ViewModel);
-    }
-
-    /// <inheritdoc />
-    protected override void OnItemTemplateSelectorChanged(DataTemplateSelector oldItemTemplateSelector, DataTemplateSelector newItemTemplateSelector)
-    {
-        if (newItemTemplateSelector is not OrientedImageryViewTemplateSelector newSelector)
-        {
-            return;
-        }
-
-        // Save and in the future merge the default selector so the default styles are always available unless overridden.
-        if (ReadLocalValue(ItemTemplateSelectorProperty) == DependencyProperty.UnsetValue)
-        {
-            _defaultItemTemplateSelector = newSelector;
-        }
-        else if (_defaultItemTemplateSelector is not null)
-        {
-            newSelector.Merge(_defaultItemTemplateSelector);
-        }
-    }
 }
 
 #endif

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryView.cs
@@ -1,8 +1,10 @@
 #if WPF
 
 using Esri.ArcGISRuntime.Mapping;
+using Esri.ArcGISRuntime.Symbology;
 using Esri.ArcGISRuntime.Toolkit.Internal;
 using Esri.ArcGISRuntime.UI;
+using System.Collections.ObjectModel;
 
 namespace Esri.ArcGISRuntime.Toolkit.UI.Controls;
 
@@ -19,6 +21,8 @@ public partial class OrientedImageryView
 
         ViewModel = new OrientedImageryViewModel();
         ViewModel.PropertyChanged += ViewModel_PropertyChanged;
+
+        ItemsSource = GetDefaultToolbarItems();
 
 #if MAUI
         // MAUI layout containers are not tab stops by default, so no IsTabStop is needed here.
@@ -52,6 +56,20 @@ public partial class OrientedImageryView
         _display.Markers = ViewModel.Markers;
         _display.Footprint = ViewModel.SelectedImageFootprint;
         _display.ImageClicked += Display_ImageClicked;
+    }
+
+    /// <summary>
+    /// Gets the default toolbar items for the OrientedImageryView.
+    /// </summary>
+    public static Collection<object> GetDefaultToolbarItems()
+    {
+        var markerSymbolPickerVM = new SelectNewMarkerSymbolVM(new Collection<MarkerSymbol>()
+        {
+            new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Circle, System.Drawing.Color.Blue, 10),
+            new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Triangle, System.Drawing.Color.Yellow, 10),
+            new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Diamond, System.Drawing.Color.Orange, 10)
+        });
+        return new() { new AutoUpdateFootprintVM(), new ShowSelectedFootprintVM(), new ShowUnselectedFootprintsVM(), new ShowCameraMarkersVM(), markerSymbolPickerVM, new ClearMarkersVM() };
     }
 
     // Setter should eventually be public and handle event wiring

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryView.cs
@@ -1,0 +1,279 @@
+#if WPF
+
+using Esri.ArcGISRuntime.Geometry;
+using Esri.ArcGISRuntime.Location;
+using Esri.ArcGISRuntime.Mapping;
+using Esri.ArcGISRuntime.Symbology;
+using Esri.ArcGISRuntime.Toolkit.Internal;
+using Esri.ArcGISRuntime.UI;
+using System.Collections.ObjectModel;
+using static System.Net.Mime.MediaTypeNames;
+
+namespace Esri.ArcGISRuntime.Toolkit.UI.Controls;
+
+public partial class OrientedImageryView
+{
+    private const string ImageDisplayName = "PART_ImageDisplay";
+
+    private OrientedImageDisplay? _display;
+    private List<OrientedImage> _images;
+    private ObservableCollection<OrientedImageMarker> _markers;
+    private GraphicsOverlay _markersOverlay;
+
+    public OrientedImageryView() : base()
+    {
+        _markersOverlay = new GraphicsOverlay() { Id = "OrientedImageryView_Markers_Overlay" };
+        _display = new OrientedImageDisplay();
+        AutoUpdateFootprint = true;
+        NewMarkerSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.X, System.Drawing.Color.Red, 20);
+        SearchPointMarkerSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Circle, System.Drawing.Color.Blue, 20);
+        _markers = new ObservableCollection<OrientedImageMarker>();
+        _markers.CollectionChanged += (_, _) => UpdateMarkerGraphics();
+
+#if MAUI
+        // MAUI layout containers are not tab stops by default, so no IsTabStop is needed here.
+        ControlTemplate = DefaultControlTemplate;
+#else
+        DefaultStyleKey = typeof(OrientedImageryView);
+#endif
+    }
+
+    /// <inheritdoc/>
+#if WINDOWS_XAML || MAUI
+    protected override void OnApplyTemplate()
+#elif WPF
+    public override void OnApplyTemplate()
+#endif
+    {
+        base.OnApplyTemplate();
+
+        if (_display != null)
+            _display.ImageClicked -= Display_ImageClicked;
+
+        _display = GetTemplateChild(ImageDisplayName) as OrientedImageDisplay;
+
+        if (_display == null)
+            return;
+
+        _display.AutoUpdateFootprint = AutoUpdateFootprint;
+        _display.Markers = _markers;
+        _display.Footprint = SelectedImage == null ? null : new OrientedImageFootprint(SelectedImage);
+        UpdateVisibleFootprints();
+        _display.ImageClicked += Display_ImageClicked;
+    }
+
+    private async void Display_ImageClicked(object? sender, OrientedImageDisplay.ImageClickedEventArgs e)
+    {
+        if (e.Marker != null)
+            return; // do not add a new marker if there is already one in proximity to the click location
+
+        var location = await SelectedImage!.ImageToLocationAsync(e.ImagePoint);
+        _markers.Add(new OrientedImageMarker(OrientedImageMarkerPosition.FromLocation(location), NewMarkerSymbol));
+    }
+
+    #region GeoViewStuff
+    private OrientedImageryLayer _oiLayer;
+    public OrientedImageryLayer OrientedImageryLayer
+    {
+        get => _oiLayer;
+        set
+        {
+            if (_oiLayer == value) return;
+
+            if (_oiLayer != null)
+            {
+                _oiLayer.VisibleFootprints.Clear();
+            }
+
+            _oiLayer = value;
+            UpdateVisibleFootprints();
+        }
+    }
+
+    public GeoView? GeoView
+    {
+        get => (GeoView?)GetValue(GeoViewProperty);
+        set => SetValue(GeoViewProperty, value);
+    }
+
+    public static readonly DependencyProperty GeoViewProperty =
+        PropertyHelper.CreateProperty<GeoView?, OrientedImageryView>(nameof(GeoView), null, (s, oldValue, newValue) => s.UpdateGeoView(oldValue, newValue));
+
+    private void UpdateGeoView(GeoView? oldGeoView, GeoView? newGeoView)
+    {
+        if (oldGeoView == newGeoView) return;
+
+        if (oldGeoView != null)
+        {
+            oldGeoView.GraphicsOverlays?.Remove(_markersOverlay);
+        }
+
+        if (newGeoView != null)
+        {
+            if (newGeoView.GraphicsOverlays == null)
+                newGeoView.GraphicsOverlays = new GraphicsOverlayCollection();
+            newGeoView.GraphicsOverlays.Add(_markersOverlay);
+        }
+    }
+    #endregion
+
+    #region ImageManagement
+    /// <summary>
+    /// Sets the images to display in the control. Optionally, a search point can be provided to indicate the origin of the search.
+    /// </summary>
+    public void SetImages(Collection<OrientedImage> images, MapPoint? searchPoint = null)
+    {
+        UpdateSearchPointMarker(searchPoint);
+
+        _images = images.ToList();
+        _footprints = _images.Select((img) => new OrientedImageFootprint(img)).ToList();
+        UpdateVisibleFootprints();
+    }
+
+    private OrientedImage? _selectedImage;
+    public OrientedImage? SelectedImage
+    {
+        get => _selectedImage;
+        set
+        {
+            if (value == _selectedImage) return;
+
+            _selectedImage = value;
+
+            if (_display == null) return;
+
+            if (_selectedImage != null)
+            {
+                var footprint = _footprints.FirstOrDefault((fpt) => fpt.OrientedImage == _selectedImage);
+                _display.Footprint = footprint ?? new OrientedImageFootprint(_selectedImage);
+            }
+            else
+            {
+                _display.Footprint = null;
+            }
+            UpdateVisibleFootprints();
+        }
+    }
+
+    // Commands for move to next/previous image. Use Images.IndexOf, no need to track index as a field
+    #endregion ImageManagement
+
+    #region FootprintManagement
+    private List<OrientedImageFootprint> _footprints = new();
+
+    // These booleans need to be bindable
+    public bool ShowSelectedFootprint = true;
+    public bool ShowUnselectedFootprints = false;
+
+    private bool _autoUpdateFootprint;
+    public bool AutoUpdateFootprint
+    {
+        get => _autoUpdateFootprint;
+        set
+        {
+            _autoUpdateFootprint = value;
+            if (_display != null)
+            {
+                _display.AutoUpdateFootprint = value;
+            }
+        }
+    }
+
+    // These colors should be bindable
+    public System.Drawing.Color SelectedFootprintFillColor = System.Drawing.Color.Orange;
+    public System.Drawing.Color SelectedFootprintOutlineColor = System.Drawing.Color.Black;
+    public System.Drawing.Color UnselectedFootprintFillColor = System.Drawing.Color.Blue;
+    public System.Drawing.Color UnselectedFootprintOutlineColor = System.Drawing.Color.Orange;
+
+    private void UpdateVisibleFootprints()
+    {
+        if (OrientedImageryLayer == null) return;
+
+        // Not performant but simple
+        bool selectedFootprintInFootprints = false;
+        foreach (var ftp in _footprints)
+        {
+            if (ftp != _display?.Footprint)
+            {
+                ftp.FillColor = SelectedFootprintFillColor;
+                ftp.OutlineColor = SelectedFootprintOutlineColor;
+            }
+            else
+            {
+                ftp.FillColor = UnselectedFootprintFillColor;
+                ftp.OutlineColor = UnselectedFootprintOutlineColor;
+                selectedFootprintInFootprints = true;
+            }
+        }
+
+        OrientedImageryLayer.VisibleFootprints.Clear();
+        if (ShowUnselectedFootprints)
+        {
+            foreach (var ftp in _footprints)
+            {
+                if (ftp == _display?.Footprint && !ShowSelectedFootprint)
+                    continue;
+
+                OrientedImageryLayer.VisibleFootprints.Add(ftp);
+            }
+        }
+        if (ShowSelectedFootprint && (!selectedFootprintInFootprints && _display?.Footprint != null))
+            OrientedImageryLayer.VisibleFootprints.Add(_display.Footprint);
+    }
+    #endregion FootprintManagement
+
+    #region Markers
+    /// <summary>
+    /// Gets or sets the default symbology to use when adding new markers.
+    /// </summary>
+    public MarkerSymbol NewMarkerSymbol { get; set; }
+
+
+    /// <summary>
+    /// Gets or sets the symbol to use for the search point marker.
+    /// </summary>
+    public MarkerSymbol SearchPointMarkerSymbol { get; set; }
+
+    private const string SearchPointMarkerTag = "SearchPointMarker";
+    private void UpdateSearchPointMarker(MapPoint? location)
+    {
+        var existingMarker = _markers.FirstOrDefault((marker) => marker?.Tag is string tag && tag == SearchPointMarkerTag, null);
+
+        if (existingMarker != null)
+            _markers.Remove(existingMarker);
+
+        if (location != null)
+        {
+            _markers.Add(new OrientedImageMarker(OrientedImageMarkerPosition.FromLocation(location), SearchPointMarkerSymbol) { Tag = SearchPointMarkerTag });
+        }
+    }
+
+    /// <summary>
+    /// Add a marker from a geographic location. The new marker is added uses the <cref="NewMarkerSymbol"/> unless
+    /// overriden using the <paramref name="symbol"/> parameter.
+    /// </summary>
+    public void AddMarkerLocation(MapPoint location, MarkerSymbol? symbol)
+    {
+        _markers.Add(new OrientedImageMarker(OrientedImageMarkerPosition.FromLocation(location), symbol ?? NewMarkerSymbol));
+    }
+
+    /// <summary>
+    /// Clears all markers on the image. Saves the search point marker if it exists.
+    /// </summary>
+    public void ClearMarkers()
+    {
+        var searchPointMarker = _markers.FirstOrDefault((marker) => marker.Tag is string tag && tag == SearchPointMarkerTag);
+        _markers.Clear();
+        if (searchPointMarker != null)
+            _markers.Add(searchPointMarker);
+    }
+
+    private void UpdateMarkerGraphics()
+    {
+        _markersOverlay.Graphics.Clear();
+        _markersOverlay.Graphics.AddRange(_markers.Select((mk) => new Graphic(mk.Position.Location!, mk.Symbol)));
+    }
+    #endregion Markers
+}
+
+#endif

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryView.cs
@@ -50,7 +50,7 @@ public partial class OrientedImageryView
             return;
 
         _display.ImageClicked += Display_ImageClicked;
-        WireDisplayToViewModel();
+        WireDisplayProperties();
     }
 
     /// <summary>
@@ -109,10 +109,10 @@ public partial class OrientedImageryView
             GeoView.GraphicsOverlays.Add(newValue.MarkersOverlay);
         }
 
-        WireDisplayToViewModel();
+        WireDisplayProperties();
     }
 
-    private void WireDisplayToViewModel()
+    private void WireDisplayProperties()
     {
         if (_display == null)
             return;
@@ -120,6 +120,7 @@ public partial class OrientedImageryView
         _display.AutoUpdateFootprint = ViewModel.AutoUpdateFootprint;
         _display.Markers = ViewModel.Markers;
         _display.Footprint = ViewModel.SelectedImageFootprint;
+        _display.DisplayBackgroundColor = DisplayBackgroundColor;
     }
 
     // This should be overridable, probably as an Action dependency property or something. Or maybe it should be its own event with this as the default handler.
@@ -136,6 +137,27 @@ public partial class OrientedImageryView
     }
 
     #region GisProperties
+    /// <summary>
+    /// Gets or sets the background color shown where the image does not fill the display.
+    /// </summary>
+    public System.Drawing.Color DisplayBackgroundColor
+    {
+        get => (System.Drawing.Color)GetValue(DisplayBackgroundColorProperty);
+        set => SetValue(DisplayBackgroundColorProperty, value);
+    }
+
+    /// <summary>
+    /// Identifies the <see cref="DisplayBackgroundColor" /> dependency property.
+    /// </summary>
+    public static readonly DependencyProperty DisplayBackgroundColorProperty =
+        PropertyHelper.CreateProperty<System.Drawing.Color, OrientedImageryView>(nameof(DisplayBackgroundColor), System.Drawing.Color.White, (s, oldValue, newValue) => s.UpdateDisplayBackgroundColor(newValue));
+
+    private void UpdateDisplayBackgroundColor(System.Drawing.Color displayBackgroundColor)
+    {
+        if (_display != null)
+            _display.DisplayBackgroundColor = displayBackgroundColor;
+    }
+
     public OrientedImageryLayer OrientedImageryLayer
     {
         get => ViewModel.OrientedImageryLayer;

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryView.cs
@@ -13,14 +13,12 @@ public partial class OrientedImageryView
     private const string ImageDisplayName = "PART_ImageDisplay";
 
     private OrientedImageDisplay? _display;
-    private OrientedImageryViewModel _viewModel;
 
     public OrientedImageryView() : base()
     {
         _display = new OrientedImageDisplay();
 
         ViewModel = new OrientedImageryViewModel();
-        ViewModel.PropertyChanged += ViewModel_PropertyChanged;
 
         ItemsSource = GetDefaultToolbarItems();
 
@@ -41,7 +39,7 @@ public partial class OrientedImageryView
     {
         base.OnApplyTemplate();
 
-        DataContext = _viewModel;
+        DataContext = ViewModel;
 
         if (_display != null)
             _display.ImageClicked -= Display_ImageClicked;
@@ -51,11 +49,8 @@ public partial class OrientedImageryView
         if (_display == null)
             return;
 
-        // These should probably be proper bindings
-        _display.AutoUpdateFootprint = ViewModel.AutoUpdateFootprint;
-        _display.Markers = ViewModel.Markers;
-        _display.Footprint = ViewModel.SelectedImageFootprint;
         _display.ImageClicked += Display_ImageClicked;
+        WireDisplayToViewModel();
     }
 
     /// <summary>
@@ -72,11 +67,59 @@ public partial class OrientedImageryView
         return new() { new AutoUpdateFootprintVM(), new ShowSelectedFootprintVM(), new ShowUnselectedFootprintsVM(), new ShowCameraMarkersVM(), new AllowAddingMarkersVM(), markerSymbolPickerVM, new ClearMarkersVM() };
     }
 
-    // Setter should eventually be public and handle event wiring
+    /// <summary>
+    /// Gets or sets the view model for the oriented imagery view.
+    /// </summary>
     public OrientedImageryViewModel ViewModel
     {
-        get { return _viewModel; }
-        private set { _viewModel = value; }
+        get => (OrientedImageryViewModel)GetValue(ViewModelProperty);
+        set => SetValue(ViewModelProperty, value);
+    }
+
+    /// <summary>
+    /// Identifies the <see cref="ViewModel" /> dependency property.
+    /// </summary>
+    public static readonly DependencyProperty ViewModelProperty =
+        PropertyHelper.CreateProperty<OrientedImageryViewModel?, OrientedImageryView>(nameof(ViewModel), null, (s, oldValue, newValue) => s.OnViewModelChanged(oldValue, newValue));
+
+    private void OnViewModelChanged(OrientedImageryViewModel? oldValue, OrientedImageryViewModel? newValue)
+    {
+        if (oldValue != null)
+        {
+            oldValue.PropertyChanged -= ViewModel_PropertyChanged;
+
+            if (GeoView?.GraphicsOverlays != null)
+                GeoView.GraphicsOverlays.Remove(oldValue.MarkersOverlay);
+        }
+
+        if (newValue == null)
+        {
+            SetCurrentValue(ViewModelProperty, new OrientedImageryViewModel());
+            return;
+        }
+
+        newValue.PropertyChanged += ViewModel_PropertyChanged;
+        DataContext = newValue;
+        SetToolbarViewModels(newValue);
+
+        if (GeoView != null)
+        {
+            if (GeoView.GraphicsOverlays == null)
+                GeoView.GraphicsOverlays = new GraphicsOverlayCollection();
+            GeoView.GraphicsOverlays.Add(newValue.MarkersOverlay);
+        }
+
+        WireDisplayToViewModel();
+    }
+
+    private void WireDisplayToViewModel()
+    {
+        if (_display == null)
+            return;
+
+        _display.AutoUpdateFootprint = ViewModel.AutoUpdateFootprint;
+        _display.Markers = ViewModel.Markers;
+        _display.Footprint = ViewModel.SelectedImageFootprint;
     }
 
     // This should be overridable, probably as an Action dependency property or something. Or maybe it should be its own event with this as the default handler.
@@ -93,7 +136,6 @@ public partial class OrientedImageryView
     }
 
     #region GisProperties
-    // This should be made a dependency property
     public OrientedImageryLayer OrientedImageryLayer
     {
         get => ViewModel.OrientedImageryLayer;

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryView.cs
@@ -65,11 +65,11 @@ public partial class OrientedImageryView
     {
         var markerSymbolPickerVM = new SelectNewMarkerSymbolVM(new Collection<MarkerSymbol>()
         {
-            new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Circle, System.Drawing.Color.Blue, 10),
+            new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Square, System.Drawing.Color.Purple, 10),
             new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Triangle, System.Drawing.Color.Yellow, 10),
             new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Diamond, System.Drawing.Color.Orange, 10)
         });
-        return new() { new AutoUpdateFootprintVM(), new ShowSelectedFootprintVM(), new ShowUnselectedFootprintsVM(), new ShowCameraMarkersVM(), markerSymbolPickerVM, new ClearMarkersVM() };
+        return new() { new AutoUpdateFootprintVM(), new ShowSelectedFootprintVM(), new ShowUnselectedFootprintsVM(), new ShowCameraMarkersVM(), new AllowAddingMarkersVM(), markerSymbolPickerVM, new ClearMarkersVM() };
     }
 
     // Setter should eventually be public and handle event wiring

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryView.cs
@@ -21,8 +21,6 @@ public partial class OrientedImageryView
     /// </summary>
     public OrientedImageryView() : base()
     {
-        _display = new OrientedImageDisplay();
-
         ViewModel = new OrientedImageryViewModel();
 
         ItemsSource = GetDefaultToolbarItems();

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryView.cs
@@ -8,12 +8,18 @@ using System.Collections.ObjectModel;
 
 namespace Esri.ArcGISRuntime.Toolkit.UI.Controls;
 
+/// <summary>
+/// Displays oriented imagery and provides controls for managing image selection, footprints, and markers.
+/// </summary>
 public partial class OrientedImageryView
 {
     private const string ImageDisplayName = "PART_ImageDisplay";
 
     private OrientedImageDisplay? _display;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OrientedImageryView"/> class.
+    /// </summary>
     public OrientedImageryView() : base()
     {
         _display = new OrientedImageDisplay();
@@ -158,18 +164,30 @@ public partial class OrientedImageryView
             _display.DisplayBackgroundColor = displayBackgroundColor;
     }
 
+    /// <summary>
+    /// Gets or sets the oriented imagery layer associated with this view.
+    /// </summary>
+    /// <remarks>
+    /// This is a thin wrapper over the <see cref="OrientedImageryViewModel.OrientedImageryLayer"/> property.
+    /// </remarks>
     public OrientedImageryLayer OrientedImageryLayer
     {
         get => ViewModel.OrientedImageryLayer;
         set { ViewModel.OrientedImageryLayer = value; }
     }
 
+    /// <summary>
+    /// Gets or sets the <see cref="Esri.ArcGISRuntime.UI.Controls.GeoView"/> on which marker graphics are displayed.
+    /// </summary>
     public GeoView? GeoView
     {
         get => (GeoView?)GetValue(GeoViewProperty);
         set => SetValue(GeoViewProperty, value);
     }
 
+    /// <summary>
+    /// Identifies the <see cref="GeoView"/> dependency property.
+    /// </summary>
     public static readonly DependencyProperty GeoViewProperty =
         PropertyHelper.CreateProperty<GeoView?, OrientedImageryView>(nameof(GeoView), null, (s, oldValue, newValue) => s.UpdateGeoView(oldValue, newValue));
 

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryView.cs
@@ -1,5 +1,6 @@
 #if WPF
 
+using Esri.ArcGISRuntime.Location;
 using Esri.ArcGISRuntime.Mapping;
 using Esri.ArcGISRuntime.Symbology;
 using Esri.ArcGISRuntime.Toolkit.Internal;
@@ -154,13 +155,18 @@ public partial class OrientedImageryView
     // This should be overridable, probably as an Action dependency property or something. Or maybe it should be its own event with this as the default handler.
     private async void Display_ImageClicked(object? sender, OrientedImageDisplay.ImageClickedEventArgs e)
     {
-        if (e.Marker != null)
-            return; // do not add a new marker if there is already one in proximity to the click location
+        // Do not add a new marker if there is already one in proximity to the click location
+        if (sender is not OrientedImageDisplay display || e.Marker != null)
+            return;
 
-        if (sender is OrientedImageDisplay display)
+        try
         {
             var location = await display.Footprint!.OrientedImage.ImageToLocationAsync(e.ImagePoint);
             ViewModel.AddMarkerLocation(location);
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"Error converting image point to location: {ex.Message}");
         }
     }
 

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryView.cs
@@ -1,13 +1,8 @@
 #if WPF
 
-using Esri.ArcGISRuntime.Geometry;
-using Esri.ArcGISRuntime.Location;
 using Esri.ArcGISRuntime.Mapping;
-using Esri.ArcGISRuntime.Symbology;
 using Esri.ArcGISRuntime.Toolkit.Internal;
 using Esri.ArcGISRuntime.UI;
-using System.Collections.ObjectModel;
-using static System.Net.Mime.MediaTypeNames;
 
 namespace Esri.ArcGISRuntime.Toolkit.UI.Controls;
 
@@ -16,19 +11,14 @@ public partial class OrientedImageryView
     private const string ImageDisplayName = "PART_ImageDisplay";
 
     private OrientedImageDisplay? _display;
-    private List<OrientedImage> _images;
-    private ObservableCollection<OrientedImageMarker> _markers;
-    private GraphicsOverlay _markersOverlay;
+    private OrientedImageryViewModel _viewModel;
 
     public OrientedImageryView() : base()
     {
-        _markersOverlay = new GraphicsOverlay() { Id = "OrientedImageryView_Markers_Overlay" };
         _display = new OrientedImageDisplay();
-        AutoUpdateFootprint = true;
-        NewMarkerSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.X, System.Drawing.Color.Red, 20);
-        SearchPointMarkerSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Circle, System.Drawing.Color.Blue, 20);
-        _markers = new ObservableCollection<OrientedImageMarker>();
-        _markers.CollectionChanged += (_, _) => UpdateMarkerGraphics();
+
+        ViewModel = new OrientedImageryViewModel();
+        ViewModel.PropertyChanged += ViewModel_PropertyChanged;
 
 #if MAUI
         // MAUI layout containers are not tab stops by default, so no IsTabStop is needed here.
@@ -47,6 +37,8 @@ public partial class OrientedImageryView
     {
         base.OnApplyTemplate();
 
+        DataContext = _viewModel;
+
         if (_display != null)
             _display.ImageClicked -= Display_ImageClicked;
 
@@ -55,39 +47,39 @@ public partial class OrientedImageryView
         if (_display == null)
             return;
 
-        _display.AutoUpdateFootprint = AutoUpdateFootprint;
-        _display.Markers = _markers;
-        _display.Footprint = SelectedImage == null ? null : new OrientedImageFootprint(SelectedImage);
-        UpdateVisibleFootprints();
+        // These should probably be proper bindings
+        _display.AutoUpdateFootprint = ViewModel.AutoUpdateFootprint;
+        _display.Markers = ViewModel.Markers;
+        _display.Footprint = ViewModel.SelectedImageFootprint;
         _display.ImageClicked += Display_ImageClicked;
     }
 
+    // Setter should eventually be public and handle event wiring
+    public OrientedImageryViewModel ViewModel
+    {
+        get { return _viewModel; }
+        private set { _viewModel = value; }
+    }
+
+    // This should be overridable, probably as an Action dependency property or something. Or maybe it should be its own event with this as the default handler.
     private async void Display_ImageClicked(object? sender, OrientedImageDisplay.ImageClickedEventArgs e)
     {
         if (e.Marker != null)
             return; // do not add a new marker if there is already one in proximity to the click location
 
-        var location = await SelectedImage!.ImageToLocationAsync(e.ImagePoint);
-        _markers.Add(new OrientedImageMarker(OrientedImageMarkerPosition.FromLocation(location), NewMarkerSymbol));
+        if (sender is OrientedImageDisplay display)
+        {
+            var location = await display.Footprint!.OrientedImage.ImageToLocationAsync(e.ImagePoint);
+            ViewModel.AddMarkerLocation(location);
+        }
     }
 
-    #region GeoViewStuff
-    private OrientedImageryLayer _oiLayer;
+    #region GisProperties
+    // This should be made a dependency property
     public OrientedImageryLayer OrientedImageryLayer
     {
-        get => _oiLayer;
-        set
-        {
-            if (_oiLayer == value) return;
-
-            if (_oiLayer != null)
-            {
-                _oiLayer.VisibleFootprints.Clear();
-            }
-
-            _oiLayer = value;
-            UpdateVisibleFootprints();
-        }
+        get => ViewModel.OrientedImageryLayer;
+        set { ViewModel.OrientedImageryLayer = value; }
     }
 
     public GeoView? GeoView
@@ -105,175 +97,38 @@ public partial class OrientedImageryView
 
         if (oldGeoView != null)
         {
-            oldGeoView.GraphicsOverlays?.Remove(_markersOverlay);
+            oldGeoView.GraphicsOverlays?.Remove(ViewModel.MarkersOverlay);
         }
 
         if (newGeoView != null)
         {
             if (newGeoView.GraphicsOverlays == null)
                 newGeoView.GraphicsOverlays = new GraphicsOverlayCollection();
-            newGeoView.GraphicsOverlays.Add(_markersOverlay);
+            newGeoView.GraphicsOverlays.Add(ViewModel.MarkersOverlay);
         }
     }
-    #endregion
+    #endregion GisProperties
 
-    #region ImageManagement
-    /// <summary>
-    /// Sets the images to display in the control. Optionally, a search point can be provided to indicate the origin of the search.
-    /// </summary>
-    public void SetImages(Collection<OrientedImage> images, MapPoint? searchPoint = null)
+    #region ViewModelPropertyHandling
+    private void ViewModel_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
     {
-        UpdateSearchPointMarker(searchPoint);
-
-        _images = images.ToList();
-        _footprints = _images.Select((img) => new OrientedImageFootprint(img)).ToList();
-        UpdateVisibleFootprints();
-    }
-
-    private OrientedImage? _selectedImage;
-    public OrientedImage? SelectedImage
-    {
-        get => _selectedImage;
-        set
+        switch (e.PropertyName)
         {
-            if (value == _selectedImage) return;
-
-            _selectedImage = value;
-
-            if (_display == null) return;
-
-            if (_selectedImage != null)
-            {
-                var footprint = _footprints.FirstOrDefault((fpt) => fpt.OrientedImage == _selectedImage);
-                _display.Footprint = footprint ?? new OrientedImageFootprint(_selectedImage);
-            }
-            else
-            {
-                _display.Footprint = null;
-            }
-            UpdateVisibleFootprints();
+            case nameof(OrientedImageryViewModel.SelectedImageFootprint):
+                if (_display != null)
+                    _display.Footprint = ViewModel.SelectedImageFootprint;
+                break;
+            case nameof(OrientedImageryViewModel.AutoUpdateFootprint):
+                if (_display != null)
+                    _display.AutoUpdateFootprint = ViewModel.AutoUpdateFootprint;
+                break;
+            case nameof(OrientedImageryViewModel.Markers):
+                if (_display != null)
+                    _display.Markers = ViewModel.Markers;
+                break;
         }
     }
-
-    // Commands for move to next/previous image. Use Images.IndexOf, no need to track index as a field
-    #endregion ImageManagement
-
-    #region FootprintManagement
-    private List<OrientedImageFootprint> _footprints = new();
-
-    // These booleans need to be bindable
-    public bool ShowSelectedFootprint = true;
-    public bool ShowUnselectedFootprints = false;
-
-    private bool _autoUpdateFootprint;
-    public bool AutoUpdateFootprint
-    {
-        get => _autoUpdateFootprint;
-        set
-        {
-            _autoUpdateFootprint = value;
-            if (_display != null)
-            {
-                _display.AutoUpdateFootprint = value;
-            }
-        }
-    }
-
-    // These colors should be bindable
-    public System.Drawing.Color SelectedFootprintFillColor = System.Drawing.Color.Orange;
-    public System.Drawing.Color SelectedFootprintOutlineColor = System.Drawing.Color.Black;
-    public System.Drawing.Color UnselectedFootprintFillColor = System.Drawing.Color.Blue;
-    public System.Drawing.Color UnselectedFootprintOutlineColor = System.Drawing.Color.Orange;
-
-    private void UpdateVisibleFootprints()
-    {
-        if (OrientedImageryLayer == null) return;
-
-        // Not performant but simple
-        bool selectedFootprintInFootprints = false;
-        foreach (var ftp in _footprints)
-        {
-            if (ftp != _display?.Footprint)
-            {
-                ftp.FillColor = SelectedFootprintFillColor;
-                ftp.OutlineColor = SelectedFootprintOutlineColor;
-            }
-            else
-            {
-                ftp.FillColor = UnselectedFootprintFillColor;
-                ftp.OutlineColor = UnselectedFootprintOutlineColor;
-                selectedFootprintInFootprints = true;
-            }
-        }
-
-        OrientedImageryLayer.VisibleFootprints.Clear();
-        if (ShowUnselectedFootprints)
-        {
-            foreach (var ftp in _footprints)
-            {
-                if (ftp == _display?.Footprint && !ShowSelectedFootprint)
-                    continue;
-
-                OrientedImageryLayer.VisibleFootprints.Add(ftp);
-            }
-        }
-        if (ShowSelectedFootprint && (!selectedFootprintInFootprints && _display?.Footprint != null))
-            OrientedImageryLayer.VisibleFootprints.Add(_display.Footprint);
-    }
-    #endregion FootprintManagement
-
-    #region Markers
-    /// <summary>
-    /// Gets or sets the default symbology to use when adding new markers.
-    /// </summary>
-    public MarkerSymbol NewMarkerSymbol { get; set; }
-
-
-    /// <summary>
-    /// Gets or sets the symbol to use for the search point marker.
-    /// </summary>
-    public MarkerSymbol SearchPointMarkerSymbol { get; set; }
-
-    private const string SearchPointMarkerTag = "SearchPointMarker";
-    private void UpdateSearchPointMarker(MapPoint? location)
-    {
-        var existingMarker = _markers.FirstOrDefault((marker) => marker?.Tag is string tag && tag == SearchPointMarkerTag, null);
-
-        if (existingMarker != null)
-            _markers.Remove(existingMarker);
-
-        if (location != null)
-        {
-            _markers.Add(new OrientedImageMarker(OrientedImageMarkerPosition.FromLocation(location), SearchPointMarkerSymbol) { Tag = SearchPointMarkerTag });
-        }
-    }
-
-    /// <summary>
-    /// Add a marker from a geographic location. The new marker is added uses the <cref="NewMarkerSymbol"/> unless
-    /// overriden using the <paramref name="symbol"/> parameter.
-    /// </summary>
-    public void AddMarkerLocation(MapPoint location, MarkerSymbol? symbol)
-    {
-        _markers.Add(new OrientedImageMarker(OrientedImageMarkerPosition.FromLocation(location), symbol ?? NewMarkerSymbol));
-    }
-
-    /// <summary>
-    /// Clears all markers on the image. Saves the search point marker if it exists.
-    /// </summary>
-    public void ClearMarkers()
-    {
-        var searchPointMarker = _markers.FirstOrDefault((marker) => marker.Tag is string tag && tag == SearchPointMarkerTag);
-        _markers.Clear();
-        if (searchPointMarker != null)
-            _markers.Add(searchPointMarker);
-    }
-
-    private void UpdateMarkerGraphics()
-    {
-        _markersOverlay.Graphics.Clear();
-        _markersOverlay.Graphics.AddRange(_markers.Select((mk) => new Graphic(mk.Position.Location!, mk.Symbol)));
-    }
-    #endregion Markers
+    #endregion ViewModelPropertyHandling
 }
 
 #endif

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryView.cs
@@ -15,8 +15,6 @@ public partial class OrientedImageryView
 {
     private const string ImageDisplayName = "PART_ImageDisplay";
 
-    private OrientedImageDisplay? _display;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="OrientedImageryView"/> class.
     /// </summary>
@@ -59,6 +57,7 @@ public partial class OrientedImageryView
         WireDisplayProperties();
     }
 
+#region ViewModel
     /// <summary>
     /// Gets the default toolbar items for the OrientedImageryView.
     /// </summary>
@@ -118,6 +117,29 @@ public partial class OrientedImageryView
         WireDisplayProperties();
     }
 
+    private void ViewModel_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        switch (e.PropertyName)
+        {
+            case nameof(OrientedImageryViewModel.SelectedImageFootprint):
+                if (_display != null)
+                    _display.Footprint = ViewModel.SelectedImageFootprint;
+                break;
+            case nameof(OrientedImageryViewModel.AutoUpdateFootprint):
+                if (_display != null)
+                    _display.AutoUpdateFootprint = ViewModel.AutoUpdateFootprint;
+                break;
+            case nameof(OrientedImageryViewModel.Markers):
+                if (_display != null)
+                    _display.Markers = ViewModel.Markers;
+                break;
+        }
+    }
+#endregion ViewModel
+
+#region Display
+    private OrientedImageDisplay? _display;
+
     private void WireDisplayProperties()
     {
         if (_display == null)
@@ -142,7 +164,6 @@ public partial class OrientedImageryView
         }
     }
 
-    #region GisProperties
     /// <summary>
     /// Gets or sets the background color shown where the image does not fill the display.
     /// </summary>
@@ -164,13 +185,16 @@ public partial class OrientedImageryView
             _display.DisplayBackgroundColor = displayBackgroundColor;
     }
 
+#endregion Display
+
+#region GeoModel
     /// <summary>
     /// Gets or sets the oriented imagery layer associated with this view.
     /// </summary>
     /// <remarks>
     /// This is a thin wrapper over the <see cref="OrientedImageryViewModel.OrientedImageryLayer"/> property.
     /// </remarks>
-    public OrientedImageryLayer OrientedImageryLayer
+    public OrientedImageryLayer? OrientedImageryLayer
     {
         get => ViewModel.OrientedImageryLayer;
         set { ViewModel.OrientedImageryLayer = value; }
@@ -207,28 +231,7 @@ public partial class OrientedImageryView
             newGeoView.GraphicsOverlays.Add(ViewModel.MarkersOverlay);
         }
     }
-    #endregion GisProperties
-
-    #region ViewModelPropertyHandling
-    private void ViewModel_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
-    {
-        switch (e.PropertyName)
-        {
-            case nameof(OrientedImageryViewModel.SelectedImageFootprint):
-                if (_display != null)
-                    _display.Footprint = ViewModel.SelectedImageFootprint;
-                break;
-            case nameof(OrientedImageryViewModel.AutoUpdateFootprint):
-                if (_display != null)
-                    _display.AutoUpdateFootprint = ViewModel.AutoUpdateFootprint;
-                break;
-            case nameof(OrientedImageryViewModel.Markers):
-                if (_display != null)
-                    _display.Markers = ViewModel.Markers;
-                break;
-        }
-    }
-    #endregion ViewModelPropertyHandling
+#endregion GeoModel
 }
 
 #endif

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryView.cs
@@ -68,7 +68,7 @@ public partial class OrientedImageryView
             new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Triangle, System.Drawing.Color.Yellow, 10),
             new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Diamond, System.Drawing.Color.Orange, 10)
         });
-        return new() { new AutoUpdateFootprintVM(), new ShowSelectedFootprintVM(), new ShowUnselectedFootprintsVM(), new ShowCameraMarkersVM(), new AllowAddingMarkersVM(), markerSymbolPickerVM, new ClearMarkersVM() };
+        return new() {new ShowSelectedFootprintVM(), new ShowUnselectedFootprintsVM(), new ShowCameraMarkersVM(), new AllowAddingMarkersVM(), markerSymbolPickerVM, new ClearMarkersVM() };
     }
 
     /// <summary>

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryView.cs
@@ -84,7 +84,6 @@ public partial class OrientedImageryView
         }
 
         newValue.PropertyChanged += ViewModel_PropertyChanged;
-        DataContext = newValue;
 
         if (GeoView != null)
         {

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryView.cs
@@ -38,27 +38,17 @@ public partial class OrientedImageryView
         base.OnApplyTemplate();
 
         if (_display != null)
-            _display.ImageClicked -= Display_ImageClicked;
+            UnwireDisplay(_display);
         if (_toolbarContainer != null)
-        {
-            _toolbarContainer.ItemTemplateSelector = null;
-            _toolbarContainer.ItemsSource = null;
-        }
+            UnwireToolbarContainer(_toolbarContainer);
 
         _display = GetTemplateChild(ImageDisplayName) as OrientedImageDisplay;
         _toolbarContainer = GetTemplateChild(ToolbarContainerName) as ItemsControl;
 
-        if (_display == null)
-            return;
+        if (_display != null)
+            WireDisplay(_display);
         if (_toolbarContainer != null)
-        {
-            _toolbarContainer.ItemTemplateSelector = ToolbarItemTemplateSelector;
-            _toolbarContainer.Items.Clear();
-            _toolbarContainer.ItemsSource = ViewModel?.ToolbarItems;
-        }
-
-    _display.ImageClicked += Display_ImageClicked;
-        WireDisplayProperties();
+            WireToolbarContainer(_toolbarContainer);
     }
 
 #region ViewModel
@@ -103,7 +93,8 @@ public partial class OrientedImageryView
             GeoView.GraphicsOverlays.Add(newValue.MarkersOverlay);
         }
 
-        WireDisplayProperties();
+        if (_display != null)
+            WireDisplayToViewModel(_display);
     }
 
     private void ViewModel_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
@@ -149,15 +140,27 @@ public partial class OrientedImageryView
     public static readonly DependencyProperty DisplayBackgroundColorProperty =
         PropertyHelper.CreateProperty<System.Drawing.Color, OrientedImageryView>(nameof(DisplayBackgroundColor), System.Drawing.Color.White, (s, oldValue, newValue) => s.UpdateDisplayBackgroundColor(newValue));
 
-    private void WireDisplayProperties()
+    private void WireDisplay(OrientedImageDisplay display)
     {
-        if (_display == null)
-            return;
+        display.ImageClicked += Display_ImageClicked;
+        display.AutoUpdateFootprint = ViewModel.AutoUpdateFootprint;
+        WireDisplayToViewModel(display);
+    }
 
-        _display.AutoUpdateFootprint = ViewModel.AutoUpdateFootprint;
-        _display.Markers = ViewModel.Markers;
-        _display.Footprint = ViewModel.SelectedImageFootprint;
-        _display.DisplayBackgroundColor = DisplayBackgroundColor;
+    private void WireDisplayToViewModel(OrientedImageDisplay display)
+    {
+        display.Markers = ViewModel.Markers;
+        display.Footprint = ViewModel.SelectedImageFootprint;
+        display.DisplayBackgroundColor = DisplayBackgroundColor;
+    }
+
+    private void UnwireDisplay(OrientedImageDisplay display)
+    {
+        display.ImageClicked -= Display_ImageClicked;
+        display.ClearValue(OrientedImageDisplay.AutoUpdateFootprintProperty);
+        display.ClearValue(OrientedImageDisplay.MarkersProperty);
+        display.ClearValue(OrientedImageDisplay.FootprintProperty);
+        display.ClearValue(OrientedImageDisplay.DisplayBackgroundColorProperty);
     }
 
     private async void Display_ImageClicked(object? sender, OrientedImageDisplay.ImageClickedEventArgs e) => ImageTapped?.Invoke(this, e);
@@ -242,6 +245,19 @@ public partial class OrientedImageryView
 
         if (_toolbarContainer != null)
             _toolbarContainer.ItemTemplateSelector = newSelector;
+    }
+
+    private void WireToolbarContainer(ItemsControl toolbarContainer)
+    {
+        toolbarContainer.ItemTemplateSelector = ToolbarItemTemplateSelector;
+        toolbarContainer.Items.Clear();
+        toolbarContainer.ItemsSource = ViewModel?.ToolbarItems;
+    }
+
+    private void UnwireToolbarContainer(ItemsControl toolbarContainer)
+    {
+        toolbarContainer.ClearValue(ItemsControl.ItemTemplateSelectorProperty);
+        toolbarContainer.ClearValue(ItemsControl.ItemsSourceProperty);
     }
 #endregion Toolbar
 }

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryView.cs
@@ -1,7 +1,5 @@
 #if WPF
 
-using Esri.ArcGISRuntime.Location;
-using Esri.ArcGISRuntime.Mapping;
 using Esri.ArcGISRuntime.Symbology;
 using Esri.ArcGISRuntime.Toolkit.Internal;
 using Esri.ArcGISRuntime.UI;
@@ -41,8 +39,6 @@ public partial class OrientedImageryView
 #endif
     {
         base.OnApplyTemplate();
-
-        DataContext = ViewModel;
 
         if (_display != null)
             _display.ImageClicked -= Display_ImageClicked;
@@ -191,19 +187,7 @@ public partial class OrientedImageryView
 
 #endregion Display
 
-#region GeoModel
-    /// <summary>
-    /// Gets or sets the oriented imagery layer associated with this view.
-    /// </summary>
-    /// <remarks>
-    /// This is a thin wrapper over the <see cref="OrientedImageryViewModel.OrientedImageryLayer"/> property.
-    /// </remarks>
-    public OrientedImageryLayer? OrientedImageryLayer
-    {
-        get => ViewModel.OrientedImageryLayer;
-        set { ViewModel.OrientedImageryLayer = value; }
-    }
-
+#region GeoView
     /// <summary>
     /// Gets or sets the <see cref="Esri.ArcGISRuntime.UI.Controls.GeoView"/> on which marker graphics are displayed.
     /// </summary>
@@ -235,7 +219,7 @@ public partial class OrientedImageryView
             newGeoView.GraphicsOverlays.Add(ViewModel.MarkersOverlay);
         }
     }
-#endregion GeoModel
+#endregion GeoView
 }
 
 #endif

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryView.cs
@@ -1,9 +1,7 @@
 #if WPF
 
-using Esri.ArcGISRuntime.Symbology;
 using Esri.ArcGISRuntime.Toolkit.Internal;
 using Esri.ArcGISRuntime.UI;
-using System.Collections.ObjectModel;
 
 namespace Esri.ArcGISRuntime.Toolkit.UI.Controls;
 
@@ -13,6 +11,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls;
 public partial class OrientedImageryView
 {
     private const string ImageDisplayName = "PART_ImageDisplay";
+    private const string ToolbarContainerName = "PART_ToolbarContainer";
 
     /// <summary>
     /// Initializes a new instance of the <see cref="OrientedImageryView"/> class.
@@ -20,8 +19,6 @@ public partial class OrientedImageryView
     public OrientedImageryView() : base()
     {
         ViewModel = new OrientedImageryViewModel();
-
-        ItemsSource = GetDefaultToolbarItems();
 
 #if MAUI
         // MAUI layout containers are not tab stops by default, so no IsTabStop is needed here.
@@ -42,31 +39,29 @@ public partial class OrientedImageryView
 
         if (_display != null)
             _display.ImageClicked -= Display_ImageClicked;
+        if (_toolbarContainer != null)
+        {
+            _toolbarContainer.ItemTemplateSelector = null;
+            _toolbarContainer.ItemsSource = null;
+        }
 
         _display = GetTemplateChild(ImageDisplayName) as OrientedImageDisplay;
+        _toolbarContainer = GetTemplateChild(ToolbarContainerName) as ItemsControl;
 
         if (_display == null)
             return;
+        if (_toolbarContainer != null)
+        {
+            _toolbarContainer.ItemTemplateSelector = ToolbarItemTemplateSelector;
+            _toolbarContainer.Items.Clear();
+            _toolbarContainer.ItemsSource = ViewModel?.ToolbarItems;
+        }
 
-        _display.ImageClicked += Display_ImageClicked;
+    _display.ImageClicked += Display_ImageClicked;
         WireDisplayProperties();
     }
 
 #region ViewModel
-    /// <summary>
-    /// Gets the default toolbar items for the OrientedImageryView.
-    /// </summary>
-    public static Collection<object> GetDefaultToolbarItems()
-    {
-        var markerSymbolPickerVM = new SelectNewMarkerSymbolVM(new Collection<MarkerSymbol>()
-        {
-            new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Square, System.Drawing.Color.Purple, 10),
-            new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Triangle, System.Drawing.Color.Yellow, 10),
-            new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Diamond, System.Drawing.Color.Orange, 10)
-        });
-        return new() {new ShowSelectedFootprintVM(), new ShowUnselectedFootprintsVM(), new ShowCameraMarkersVM(), new AllowAddingMarkersVM(), markerSymbolPickerVM, new ClearMarkersVM() };
-    }
-
     /// <summary>
     /// Gets or sets the view model for the oriented imagery view.
     /// </summary>
@@ -100,7 +95,6 @@ public partial class OrientedImageryView
 
         newValue.PropertyChanged += ViewModel_PropertyChanged;
         DataContext = newValue;
-        SetToolbarViewModels(newValue);
 
         if (GeoView != null)
         {
@@ -208,6 +202,48 @@ public partial class OrientedImageryView
         }
     }
 #endregion GeoView
+
+#region Toolbar
+    private ItemsControl? _toolbarContainer;
+    private OrientedImageryViewTemplateSelector? _defaultItemTemplateSelector;
+
+    /// <summary>
+    /// Gets or sets the <see cref="DataTemplateSelector"/> used by the toolbar <see cref="ItemsControl"/> to display the toolbar items in
+    /// <see cref="OrientedImageryViewModel.ToolbarItems"/>.
+    /// </summary>
+    public DataTemplateSelector? ToolbarItemTemplateSelector
+    {
+        get => (DataTemplateSelector)GetValue(ToolbarItemTemplateSelectorProperty);
+        set => SetValue(ToolbarItemTemplateSelectorProperty, value);
+    }
+
+    /// <summary>
+    /// Identifies the <see cref="ToolbarItemTemplateSelector" /> dependency property.
+    /// </summary>
+    public static readonly DependencyProperty ToolbarItemTemplateSelectorProperty =
+        PropertyHelper.CreateProperty<DataTemplateSelector?, OrientedImageryView>(nameof(ToolbarItemTemplateSelector), null, (s, oldValue, newValue) => s.OnItemTemplateSelectorChanged(oldValue, newValue));
+
+    private void OnItemTemplateSelectorChanged(DataTemplateSelector? oldItemTemplateSelector, DataTemplateSelector? newItemTemplateSelector)
+    {
+        if (newItemTemplateSelector is not OrientedImageryViewTemplateSelector newSelector)
+        {
+            return;
+        }
+
+        // Save and in the future merge the default selector so the default styles are always available unless overridden.
+        if (ReadLocalValue(ToolbarItemTemplateSelectorProperty) == DependencyProperty.UnsetValue)
+        {
+            _defaultItemTemplateSelector = newSelector;
+        }
+        else if (_defaultItemTemplateSelector is not null)
+        {
+            newSelector.Merge(_defaultItemTemplateSelector);
+        }
+
+        if (_toolbarContainer != null)
+            _toolbarContainer.ItemTemplateSelector = newSelector;
+    }
+#endregion Toolbar
 }
 
 #endif

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryView.cs
@@ -135,34 +135,10 @@ public partial class OrientedImageryView
 #region Display
     private OrientedImageDisplay? _display;
 
-    private void WireDisplayProperties()
-    {
-        if (_display == null)
-            return;
-
-        _display.AutoUpdateFootprint = ViewModel.AutoUpdateFootprint;
-        _display.Markers = ViewModel.Markers;
-        _display.Footprint = ViewModel.SelectedImageFootprint;
-        _display.DisplayBackgroundColor = DisplayBackgroundColor;
-    }
-
-    // This should be overridable, probably as an Action dependency property or something. Or maybe it should be its own event with this as the default handler.
-    private async void Display_ImageClicked(object? sender, OrientedImageDisplay.ImageClickedEventArgs e)
-    {
-        // Do not add a new marker if there is already one in proximity to the click location
-        if (sender is not OrientedImageDisplay display || e.Marker != null)
-            return;
-
-        try
-        {
-            var location = await display.Footprint!.OrientedImage.ImageToLocationAsync(e.ImagePoint);
-            ViewModel.AddMarkerLocation(location);
-        }
-        catch (Exception ex)
-        {
-            System.Diagnostics.Debug.WriteLine($"Error converting image point to location: {ex.Message}");
-        }
-    }
+    /// <summary>
+    /// Occurs whenever a user taps on the image display.
+    /// </summary>
+    public event EventHandler<OrientedImageDisplay.ImageClickedEventArgs>? ImageTapped;
 
     /// <summary>
     /// Gets or sets the background color shown where the image does not fill the display.
@@ -179,12 +155,24 @@ public partial class OrientedImageryView
     public static readonly DependencyProperty DisplayBackgroundColorProperty =
         PropertyHelper.CreateProperty<System.Drawing.Color, OrientedImageryView>(nameof(DisplayBackgroundColor), System.Drawing.Color.White, (s, oldValue, newValue) => s.UpdateDisplayBackgroundColor(newValue));
 
+    private void WireDisplayProperties()
+    {
+        if (_display == null)
+            return;
+
+        _display.AutoUpdateFootprint = ViewModel.AutoUpdateFootprint;
+        _display.Markers = ViewModel.Markers;
+        _display.Footprint = ViewModel.SelectedImageFootprint;
+        _display.DisplayBackgroundColor = DisplayBackgroundColor;
+    }
+
+    private async void Display_ImageClicked(object? sender, OrientedImageDisplay.ImageClickedEventArgs e) => ImageTapped?.Invoke(this, e);
+
     private void UpdateDisplayBackgroundColor(System.Drawing.Color displayBackgroundColor)
     {
         if (_display != null)
             _display.DisplayBackgroundColor = displayBackgroundColor;
     }
-
 #endregion Display
 
 #region GeoView

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewModel.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewModel.cs
@@ -9,6 +9,7 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Text;
+using System.Windows.Input;
 
 #if MAUI
 namespace Esri.ArcGISRuntime.Toolkit.Maui;
@@ -27,6 +28,13 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
         _markers = new ObservableCollection<OrientedImageMarker>();
         _markers.CollectionChanged += (_, _) => UpdateMarkerGraphics();
         _images = new List<OrientedImage>();
+
+        SelectNextImageCommand = new Command(
+            execute: () => SelectNextImage(),
+            canExecute: () => _images.Count > 0 && (SelectedImage == null || _images.IndexOf(SelectedImage) < _images.Count - 1));
+        SelectPreviousImageCommand = new Command(
+            execute: () => SelectPreviousImage(),
+            canExecute: () => _images.Count > 0 && (SelectedImage != null && _images.IndexOf(SelectedImage) > 0));
     }
 
     private async void Display_ImageClicked(object? sender, OrientedImageDisplay.ImageClickedEventArgs e)
@@ -71,6 +79,8 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
         _images = images.ToList();
         _footprints = _images.Select((img) => new OrientedImageFootprint(img)).ToList();
         UpdateVisibleFootprints();
+        ((Command)SelectNextImageCommand).ChangeCanExecute();
+        ((Command)SelectPreviousImageCommand).ChangeCanExecute();
     }
 
     private OrientedImage? _selectedImage;
@@ -93,6 +103,8 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
                 SelectedImageFootprint = null;
             }
             UpdateVisibleFootprints();
+            ((Command)SelectNextImageCommand).ChangeCanExecute();
+            ((Command)SelectPreviousImageCommand).ChangeCanExecute();
         }
     }
 
@@ -107,7 +119,46 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
         private set => SetProperty(ref _selectedImageFootprint, value);
     }
 
-    // Commands for move to next/previous image. Use Images.IndexOf, no need to track index as a field
+    /// <summary>
+    /// Selects the next image in the list of images.
+    /// </summary>
+    /// <remarks>
+    /// If the currently selected image is either <c>null</c> or not in the list, this command will select the first image in the list.
+    /// </remarks>
+    public ICommand SelectNextImageCommand { get; private set; }
+
+    /// <summary>
+    /// Selects the previous image in the list of images.
+    /// </summary>
+    /// <remarks>
+    /// This command will not select an image if the currently selected image is either <c>null</c> or not in the list.
+    /// </remarks>
+    public ICommand SelectPreviousImageCommand { get; private set; }
+
+    private void SelectNextImage()
+    {
+        if (_images.Count == 0)
+            return;
+
+        var currentIndex = SelectedImage != null ? _images.IndexOf(SelectedImage) : -1;
+        if (currentIndex < _images.Count - 1)
+        {
+            SelectedImage = _images[currentIndex + 1];
+        }
+    }
+
+    private void SelectPreviousImage()
+    {
+        if (_images.Count == 0)
+            return;
+
+        var currentIndex = SelectedImage != null ? _images.IndexOf(SelectedImage) : _images.Count;
+        if (currentIndex > 0)
+        {
+            SelectedImage = _images[currentIndex - 1];
+        }
+    }
+
     #endregion ImageManagement
 
     #region FootprintManagement

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewModel.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewModel.cs
@@ -35,7 +35,7 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
 
         _allowAddingMarkers = false;
         _markers = new ObservableCollection<OrientedImageMarker>();
-        _markers.CollectionChanged += (_, _) => UpdateMarkerGraphics();
+        _markers.CollectionChanged += (_, _) => UpdateGraphicsOverlay();
         _images = new List<OrientedImage>();
 
         SelectNextImageCommand = new Command(
@@ -110,6 +110,11 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
             }
             UpdateCameraMarkers();
             UpdateVisibleFootprints();
+            // UpdateCameraMarkers will not trigger a graphics overlay update if ShowSelectedCameraLocations is false.
+            // The function must trigger to update the selected camera location
+            if (!ShowCameraLocations)
+                UpdateGraphicsOverlay();
+
             ((Command)SelectNextImageCommand).ChangeCanExecute();
             ((Command)SelectPreviousImageCommand).ChangeCanExecute();
         }
@@ -344,40 +349,40 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
     /// Gets or sets the symbol to use for all camera markers.
     /// </summary>
     public MarkerSymbol AllCamerasMarkerSymbol { get; set; }
-    private const string SelectedCamerasMarkerTag = "SelectedCamerasMarker";
+    private const string AllCamerasMarkerTag = "AllSelectedCamerasMarker";
 
     /// <summary>
     /// Gets or sets a value indicating whether to show markers for the locations of the cameras associated with the images in the control.
     /// </summary>
-    public bool ShowSelectedCameraLocations
+    public bool ShowCameraLocations
     {
-        get => _showSelectedCameraLocations;
+        get => _showCameraLocations;
         set
         {
-            if (_showSelectedCameraLocations == value) { return; }
+            if (_showCameraLocations == value) { return; }
 
-            SetProperty(ref _showSelectedCameraLocations, value);
+            SetProperty(ref _showCameraLocations, value);
             UpdateCameraMarkers();
         }
     }
-    private bool _showSelectedCameraLocations = true;
+    private bool _showCameraLocations = true;
 
 
     /// <summary>
-    /// Gets or sets a value indicating whether to show camera locations on the display. This property only has an effect if <see cref="ShowSelectedCameraLocations"/> is set to <c>true</c>.
+    /// Gets or sets a value indicating whether to show camera locations on the display. This property only has an effect if <see cref="ShowCameraLocations"/> is set to <c>true</c>.
     /// </summary>
-    public bool ShowSelectedCameraLocationsOnDisplay
+    public bool ShowCameraLocationsOnDisplay
     {
-        get => _showSelectedCameraLocationsOnDisplay;
+        get => _showCameraLocationsOnDisplay;
         set
         {
-            if (_showSelectedCameraLocationsOnDisplay == value) { return; }
+            if (_showCameraLocationsOnDisplay == value) { return; }
 
-            SetProperty(ref _showSelectedCameraLocationsOnDisplay, value);
+            SetProperty(ref _showCameraLocationsOnDisplay, value);
             UpdateCameraMarkers();
         }
     }
-    private bool _showSelectedCameraLocationsOnDisplay = false;
+    private bool _showCameraLocationsOnDisplay = false;
 
     private void UpdateSearchPointMarker(MapPoint? location)
     {
@@ -418,26 +423,26 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
 
     private void UpdateCameraMarkers()
     {
-        var existingCameraMarkers = _markers.Where((marker) => marker.Tag is string tag && tag == SelectedCamerasMarkerTag).ToList();
+        var existingCameraMarkers = _markers.Where((marker) => marker.Tag is string tag && tag == AllCamerasMarkerTag).ToList();
         foreach (var mrk in existingCameraMarkers)
         {
             _markers.Remove(mrk);
         }
 
-        if (ShowSelectedCameraLocations)
+        if (ShowCameraLocations)
         {
             foreach (var img in _images.Where((img) => img.Geometry is MapPoint))
             {
                 _markers.Add(new OrientedImageMarker(OrientedImageMarkerPosition.FromLocation((MapPoint)img.Geometry!), AllCamerasMarkerSymbol)
                 {
-                    Tag = SelectedCamerasMarkerTag,
-                    IsVisible = ShowSelectedCameraLocationsOnDisplay
+                    Tag = AllCamerasMarkerTag,
+                    IsVisible = ShowCameraLocationsOnDisplay
                 });
             }
         }
     }
 
-    private void UpdateMarkerGraphics()
+    private void UpdateGraphicsOverlay()
     {
         _markersOverlay.Graphics.Clear();
         _markersOverlay.Graphics.AddRange(_markers.Select((mk) => new Graphic(mk.Position.Location!, mk.Symbol)));

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewModel.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewModel.cs
@@ -60,6 +60,7 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
 
 #region GeoModel
     private OrientedImageryLayer? _oiLayer;
+    private LayerSceneProperties? _oiLayerSceneProperties;
 
     /// <summary>
     /// Gets or sets the oriented imagery layer whose visible footprints are managed by this view model.
@@ -74,6 +75,8 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
             if (_oiLayer != null)
             {
                 _oiLayer.VisibleFootprints.Clear();
+                _oiLayer.PropertyChanged -= OrientedImageryLayer_PropertyChanged;
+                _oiLayerSceneProperties!.PropertyChanged -= OrientedImageryLayer_SceneProperties_PropertyChanged;
             }
 
             _images.Clear();
@@ -81,9 +84,39 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
             Markers.Clear();
 
             _oiLayer = value;
+            if (_oiLayer != null)
+            {
+                _oiLayer.PropertyChanged += OrientedImageryLayer_PropertyChanged;
+                _oiLayerSceneProperties = _oiLayer.SceneProperties;
+                _oiLayerSceneProperties.PropertyChanged += OrientedImageryLayer_SceneProperties_PropertyChanged;
+            }
+            MatchSceneProperties();
             UpdateVisibleFootprints();
         }
     }
+
+    private void MatchSceneProperties()
+    {
+        _markersOverlay.SceneProperties.SurfacePlacement = _oiLayer?.SceneProperties.SurfacePlacement ?? SurfacePlacement.Relative;
+        _markersOverlay.SceneProperties.AltitudeOffset = _oiLayer?.SceneProperties.AltitudeOffset ?? 0d;
+    }
+
+    private void OrientedImageryLayer_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(OrientedImageryLayer.SceneProperties))
+            return;
+
+        if (_oiLayerSceneProperties != null)
+            _oiLayerSceneProperties.PropertyChanged -= OrientedImageryLayer_SceneProperties_PropertyChanged;
+
+        _oiLayerSceneProperties = _oiLayer?.SceneProperties;
+        MatchSceneProperties();
+
+        if (_oiLayer != null)
+            _oiLayerSceneProperties!.PropertyChanged += OrientedImageryLayer_SceneProperties_PropertyChanged;
+    }
+
+    private void OrientedImageryLayer_SceneProperties_PropertyChanged(object? sender, PropertyChangedEventArgs e) => MatchSceneProperties();
 #endregion GeoModel
 
 #region Images

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewModel.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewModel.cs
@@ -35,6 +35,9 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
         SelectPreviousImageCommand = new Command(
             execute: () => SelectPreviousImage(),
             canExecute: () => _images.Count > 0 && (SelectedImage != null && _images.IndexOf(SelectedImage) > 0));
+        ClearMarkersCommand = new Command(
+            execute: () => ClearMarkers(),
+            canExecute: () => true);
     }
 
     private async void Display_ImageClicked(object? sender, OrientedImageDisplay.ImageClickedEventArgs e)
@@ -247,9 +250,11 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
     }
 
     /// <summary>
-    /// Clears all markers on the image. Saves the search point marker if it exists.
+    /// Clears all extant markers save the search point marker.
     /// </summary>
-    public void ClearMarkers()
+    public ICommand ClearMarkersCommand { get; private set; }
+
+    private void ClearMarkers()
     {
         var searchPointMarker = _markers.FirstOrDefault((marker) => marker.Tag is string tag && tag == SearchPointMarkerTag);
         _markers.Clear();

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewModel.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewModel.cs
@@ -41,9 +41,9 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
 
         _images = new List<OrientedImage>();
 
-        SelectedFootprintFillColor = System.Drawing.Color.FromArgb(128, System.Drawing.Color.Orange);
-        SelectedFootprintOutlineColor = System.Drawing.Color.Orange;
-        UnselectedFootprintFillColor = System.Drawing.Color.FromArgb(128, System.Drawing.Color.Blue);
+        SelectedFootprintFillColor = System.Drawing.Color.FromArgb(32, System.Drawing.Color.Red);
+        SelectedFootprintOutlineColor = System.Drawing.Color.Red;
+        UnselectedFootprintFillColor = System.Drawing.Color.FromArgb(16, System.Drawing.Color.Blue);
         UnselectedFootprintOutlineColor = System.Drawing.Color.Blue;
 
         SelectNextImageCommand = new Command(
@@ -352,7 +352,7 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
     private bool _showCameraLocationsOnDisplay = false;
     private static readonly MarkerTag SearchPointMarkerTag = new MarkerTag("SearchPointMarker");
     private static readonly MarkerTag SelectedImageMarkerTag = new MarkerTag("SelectedImageMarker", int.MaxValue);
-    private static readonly MarkerTag AllCamerasMarkerTag = new MarkerTag("AllSelectedCamerasMarker");
+    private static readonly MarkerTag AllCamerasMarkerTag = new MarkerTag("AllSelectedCamerasMarker", -1);
 
     /// <summary>
     /// Gets the collection of markers managed by this view model.

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewModel.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewModel.cs
@@ -33,6 +33,7 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
         UnselectedFootprintFillColor = System.Drawing.Color.FromArgb(128, System.Drawing.Color.Blue);
         UnselectedFootprintOutlineColor = System.Drawing.Color.Blue;
 
+        _allowAddingMarkers = false;
         _markers = new ObservableCollection<OrientedImageMarker>();
         _markers.CollectionChanged += (_, _) => UpdateMarkerGraphics();
         _images = new List<OrientedImage>();
@@ -46,15 +47,6 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
         ClearMarkersCommand = new Command(
             execute: () => ClearMarkers(),
             canExecute: () => true);
-    }
-
-    private async void Display_ImageClicked(object? sender, OrientedImageDisplay.ImageClickedEventArgs e)
-    {
-        if (e.Marker != null)
-            return; // do not add a new marker if there is already one in proximity to the click location
-
-        var location = await SelectedImage!.ImageToLocationAsync(e.ImagePoint);
-        _markers.Add(new OrientedImageMarker(OrientedImageMarkerPosition.FromLocation(location), NewMarkerSymbol));
     }
 
     #region GeoViewStuff
@@ -218,6 +210,17 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
     {
         get => _autoUpdateFootprint;
         set => SetProperty(ref _autoUpdateFootprint, value);
+    }
+
+    private bool _allowAddingMarkers;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether image clicks can add markers.
+    /// </summary>
+    public bool AllowAddingMarkers
+    {
+        get => _allowAddingMarkers;
+        set => SetProperty(ref _allowAddingMarkers, value);
     }
 
     private System.Drawing.Color _selectedFootprintFillColor;
@@ -390,12 +393,13 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
     }
 
     /// <summary>
-    /// Add a marker from a geographic location. The new marker is added uses the <cref="NewMarkerSymbol"/> unless
+    /// Add a marker from a geographic location. The new marker is added with <see cref="NewMarkerSymbol"/> unless
     /// overriden using the <paramref name="symbol"/> parameter.
     /// </summary>
     public void AddMarkerLocation(MapPoint location, MarkerSymbol? symbol = null)
     {
-        _markers.Add(new OrientedImageMarker(OrientedImageMarkerPosition.FromLocation(location), symbol ?? NewMarkerSymbol));
+        if (AllowAddingMarkers)
+            _markers.Add(new OrientedImageMarker(OrientedImageMarkerPosition.FromLocation(location), symbol ?? NewMarkerSymbol));
     }
 
     /// <summary>

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewModel.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewModel.cs
@@ -24,7 +24,7 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
     {
         _markersOverlay = new GraphicsOverlay() { Id = "OrientedImageryView_Markers_Overlay" };
         NewMarkerSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Diamond, System.Drawing.Color.Orange, 15);
-        SearchPointMarkerSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.X, System.Drawing.Color.Red, 20);
+        SearchPointMarkerSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.X, System.Drawing.Color.Red, 12);
         AllCamerasMarkerSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Circle, System.Drawing.Color.FromArgb(200,0,0,255), 15);
         CurrentCameraMarkerSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Circle, System.Drawing.Color.Yellow, 15);
 

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewModel.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewModel.cs
@@ -41,6 +41,7 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
 
         _images = new List<OrientedImage>();
 
+        AutoUpdateFootprint = true;
         SelectedFootprintFillColor = System.Drawing.Color.FromArgb(32, System.Drawing.Color.Red);
         SelectedFootprintOutlineColor = System.Drawing.Color.Red;
         UnselectedFootprintFillColor = System.Drawing.Color.FromArgb(16, System.Drawing.Color.Blue);

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewModel.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewModel.cs
@@ -6,6 +6,7 @@ using Esri.ArcGISRuntime.UI;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -24,13 +25,13 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
     {
         _allowAddingMarkers = false;
         _markers = new ObservableCollection<OrientedImageMarker>();
-        _markers.CollectionChanged -= Markers_CollectionChanged;
+        _markers.CollectionChanged += Markers_CollectionChanged;
 
         _markersOverlay = new GraphicsOverlay() { Id = "OrientedImageryView_Markers_Overlay" };
         NewMarkerSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Diamond, System.Drawing.Color.Orange, 15);
         SearchPointMarkerSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.X, System.Drawing.Color.Red, 12);
         AllCamerasMarkerSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Circle, System.Drawing.Color.FromArgb(200,0,0,255), 15);
-        CurrentCameraMarkerSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Circle, System.Drawing.Color.Yellow, 15);
+        SelectedCameraMarkerSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Circle, System.Drawing.Color.Yellow, 15);
 
         _images = new List<OrientedImage>();
 
@@ -95,6 +96,7 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
     }
 
     private OrientedImage? _selectedImage;
+
     public OrientedImage? SelectedImage
     {
         get => _selectedImage;
@@ -113,12 +115,8 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
             {
                 SelectedImageFootprint = null;
             }
-            UpdateCameraMarkers();
             UpdateVisibleFootprints();
-            // UpdateCameraMarkers will not trigger a graphics overlay update if ShowSelectedCameraLocations is false.
-            // The function must trigger to update the selected camera location
-            if (!ShowCameraLocations || !ShowCameraLocationsOnDisplay)
-                UpdateGraphicsOverlay();
+            UpdateSelectedCameraMarker();
 
             ((Command)SelectNextImageCommand).ChangeCanExecute();
             ((Command)SelectPreviousImageCommand).ChangeCanExecute();
@@ -332,19 +330,37 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
     public ObservableCollection<OrientedImageMarker> Markers
     {
         get { return _markers; }
-        private set
-        {
-            if (value == _markers)
-                return;
-            _markers.CollectionChanged -= Markers_CollectionChanged;
-            value.CollectionChanged += Markers_CollectionChanged;
-            SetProperty(ref _markers, value);
-        }
     }
 
     private void Markers_CollectionChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
     {
-        UpdateGraphicsOverlay();
+        switch (e.Action)
+        {
+            case NotifyCollectionChangedAction.Add:
+                var addMarker = (OrientedImageMarker)e!.NewItems![0]!;
+                _markersOverlay.Graphics.Insert(e.NewStartingIndex, new Graphic(addMarker.Position.Location!, addMarker.Symbol)
+                {
+                    ZIndex = addMarker.Tag is MarkerTag addMarkerTag ? addMarkerTag.ZIndex : 0
+                });
+                break;
+            case NotifyCollectionChangedAction.Replace:
+                var replaceMarker = (OrientedImageMarker)e!.NewItems![0]!;
+                _markersOverlay.Graphics[e.OldStartingIndex] = new Graphic(replaceMarker.Position.Location!, replaceMarker.Symbol)
+                {
+                    ZIndex = replaceMarker.Tag is MarkerTag replaceMarkerTag ? replaceMarkerTag.ZIndex : 0
+                };
+                break;
+            case NotifyCollectionChangedAction.Remove:
+                _markersOverlay.Graphics.RemoveAt(e.OldStartingIndex);
+                break;
+            case NotifyCollectionChangedAction.Move:
+                var moveMarker = (OrientedImageMarker)e!.NewItems![0]!;
+                _markersOverlay.Graphics.Move(e.OldStartingIndex, e.NewStartingIndex);
+                break;
+            case NotifyCollectionChangedAction.Reset:
+                _markersOverlay.Graphics.Clear();
+                break;
+        }
     }
 
     private GraphicsOverlay _markersOverlay;
@@ -359,18 +375,19 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
     /// Gets or sets the symbol to use for the search point marker.
     /// </summary>
     public MarkerSymbol SearchPointMarkerSymbol { get; set; }
-    private const string SearchPointMarkerTag = "SearchPointMarker";
+    private static readonly MarkerTag SearchPointMarkerTag = new MarkerTag("SearchPointMarker");
 
     /// <summary>
     /// Gets or sets the symbol to use for the current camera marker.
     /// </summary>
-    public MarkerSymbol CurrentCameraMarkerSymbol { get; set; }
+    public MarkerSymbol SelectedCameraMarkerSymbol { get; set; }
+    private static readonly MarkerTag SelectedImageMarkerTag = new MarkerTag("SelectedImageMarker", int.MaxValue);
 
     /// <summary>
     /// Gets or sets the symbol to use for all camera markers.
     /// </summary>
     public MarkerSymbol AllCamerasMarkerSymbol { get; set; }
-    private const string AllCamerasMarkerTag = "AllSelectedCamerasMarker";
+    private static readonly MarkerTag AllCamerasMarkerTag = new MarkerTag("AllSelectedCamerasMarker");
 
     /// <summary>
     /// Gets or sets a value indicating whether to show markers for the locations of the cameras associated with the images in the control.
@@ -405,19 +422,6 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
     }
     private bool _showCameraLocationsOnDisplay = false;
 
-    private void UpdateSearchPointMarker(MapPoint? location)
-    {
-        var existingMarker = Markers.FirstOrDefault((marker) => marker?.Tag is string tag && tag == SearchPointMarkerTag, null);
-
-        if (existingMarker != null)
-            Markers.Remove(existingMarker);
-
-        if (location != null)
-        {
-            Markers.Add(new OrientedImageMarker(OrientedImageMarkerPosition.FromLocation(location), SearchPointMarkerSymbol) { Tag = SearchPointMarkerTag });
-        }
-    }
-
     /// <summary>
     /// Add a marker from a geographic location. The new marker is added with <see cref="NewMarkerSymbol"/> unless
     /// overriden using the <paramref name="symbol"/> parameter.
@@ -435,40 +439,73 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
 
     private void ClearMarkers()
     {
-        var searchPointMarker = Markers.FirstOrDefault((marker) => marker.Tag is string tag && tag == SearchPointMarkerTag);
+        var searchPointMarker = Markers.FirstOrDefault((marker) => marker.Tag is MarkerTag tag && tag.Identifier == SearchPointMarkerTag.Identifier);
         Markers.Clear();
         UpdateCameraMarkers();
+        UpdateSelectedCameraMarker();
         if (searchPointMarker != null)
             Markers.Add(searchPointMarker);
     }
 
+    private void UpdateSearchPointMarker(MapPoint? location)
+    {
+        var existingMarker = Markers.FirstOrDefault((marker) => marker?.Tag is MarkerTag tag && tag.Identifier == SearchPointMarkerTag.Identifier, null);
+
+        if (existingMarker != null)
+            Markers.Remove(existingMarker);
+
+        if (location != null)
+        {
+            Markers.Add(new OrientedImageMarker(OrientedImageMarkerPosition.FromLocation(location), SearchPointMarkerSymbol) { Tag = SearchPointMarkerTag });
+        }
+    }
+
     private void UpdateCameraMarkers()
     {
-        var currentMarkers = Markers.ToList();
-        var existingCameraMarkers = currentMarkers.RemoveAll((marker) => marker.Tag is string tag && tag == AllCamerasMarkerTag);
+        foreach (var marker in Markers.Where(mk => mk.Tag is MarkerTag tag && tag.Identifier == AllCamerasMarkerTag.Identifier).ToArray())
+        {
+            Markers.Remove(marker);
+        }
 
         if (ShowCameraLocations)
         {
-            currentMarkers.AddRange(
-                _images.Where((img) => img.Geometry is MapPoint)
-                       .Select(img => new OrientedImageMarker(OrientedImageMarkerPosition.FromLocation((MapPoint)img.Geometry!), AllCamerasMarkerSymbol)
-                       {
-                           Tag = AllCamerasMarkerTag,
-                           IsVisible = ShowCameraLocationsOnDisplay
-                       }));
+            foreach (var image in _images)
+            {
+                Markers.Add(new OrientedImageMarker(OrientedImageMarkerPosition.FromLocation((MapPoint)image.Geometry!), AllCamerasMarkerSymbol)
+                {
+                    Tag = AllCamerasMarkerTag,
+                    IsVisible = ShowCameraLocationsOnDisplay
+                });
+            }
         }
-
-        Markers = new ObservableCollection<OrientedImageMarker>(currentMarkers);
-        UpdateGraphicsOverlay();
     }
 
-    private void UpdateGraphicsOverlay()
+    private void UpdateSelectedCameraMarker()
     {
-        _markersOverlay.Graphics.Clear();
-        _markersOverlay.Graphics.AddRange(Markers.Select((mk) => new Graphic(mk.Position.Location!, mk.Symbol)));
+        var currentMarker = Markers.FirstOrDefault(mk => mk.Tag is MarkerTag tag && tag.Identifier == SelectedImageMarkerTag.Identifier, null!);
 
-        if (SelectedImage?.Geometry is MapPoint currentImageLocation)
-            _markersOverlay.Graphics.Add(new Graphic(currentImageLocation, CurrentCameraMarkerSymbol) { ZIndex = int.MaxValue });
+        if (SelectedImage != null)
+        {
+            var newMarker = new OrientedImageMarker(OrientedImageMarkerPosition.FromLocation((MapPoint)SelectedImage.Geometry!), SelectedCameraMarkerSymbol)
+            {
+                Tag = SelectedImageMarkerTag,
+                IsVisible = false
+            };
+            if (currentMarker != null)
+                Markers[Markers.IndexOf(currentMarker)] = newMarker;
+            else
+                Markers.Add(newMarker);
+        }
+        else if (currentMarker != null)
+        {
+            Markers.Remove(currentMarker);
+        }
+    }
+
+    private struct MarkerTag(string identifier, int zIndex = 0)
+    {
+        public string Identifier = identifier;
+        public int ZIndex = zIndex;
     }
     #endregion Markers
 

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewModel.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewModel.cs
@@ -49,7 +49,7 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
             canExecute: () => true);
     }
 
-    #region GeoViewStuff
+    #region GeoModel
     private OrientedImageryLayer _oiLayer;
     public OrientedImageryLayer OrientedImageryLayer
     {
@@ -63,11 +63,15 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
                 _oiLayer.VisibleFootprints.Clear();
             }
 
+            _images.Clear();
+            SelectedImage = null;
+            _markers.Clear();
+
             _oiLayer = value;
             UpdateVisibleFootprints();
         }
     }
-    #endregion
+    #endregion GeoModel
 
     #region ImageManagement
     private List<OrientedImage> _images;

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewModel.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewModel.cs
@@ -116,7 +116,7 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
             UpdateVisibleFootprints();
             // UpdateCameraMarkers will not trigger a graphics overlay update if ShowSelectedCameraLocations is false.
             // The function must trigger to update the selected camera location
-            if (!ShowCameraLocations)
+            if (!ShowCameraLocations || !ShowCameraLocationsOnDisplay)
                 UpdateGraphicsOverlay();
 
             ((Command)SelectNextImageCommand).ChangeCanExecute();

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewModel.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewModel.cs
@@ -23,8 +23,10 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
     public OrientedImageryViewModel() : base()
     {
         _markersOverlay = new GraphicsOverlay() { Id = "OrientedImageryView_Markers_Overlay" };
-        NewMarkerSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.X, System.Drawing.Color.Red, 20);
-        SearchPointMarkerSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Circle, System.Drawing.Color.Blue, 20);
+        NewMarkerSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Diamond, System.Drawing.Color.Orange, 15);
+        SearchPointMarkerSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.X, System.Drawing.Color.Red, 20);
+        AllCamerasMarkerSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Circle, System.Drawing.Color.FromArgb(200,0,0,255), 15);
+        CurrentCameraMarkerSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Circle, System.Drawing.Color.Yellow, 15);
         _markers = new ObservableCollection<OrientedImageMarker>();
         _markers.CollectionChanged += (_, _) => UpdateMarkerGraphics();
         _images = new List<OrientedImage>();
@@ -77,11 +79,14 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
     /// </summary>
     public void SetImages(List<OrientedImage> images, MapPoint? searchPoint = null)
     {
-        UpdateSearchPointMarker(searchPoint);
 
         _images = images.ToList();
         _footprints = _images.Select((img) => new OrientedImageFootprint(img)).ToList();
+
+        UpdateSearchPointMarker(searchPoint);
+        UpdateCameraMarkers();
         UpdateVisibleFootprints();
+
         ((Command)SelectNextImageCommand).ChangeCanExecute();
         ((Command)SelectPreviousImageCommand).ChangeCanExecute();
     }
@@ -105,6 +110,7 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
             {
                 SelectedImageFootprint = null;
             }
+            UpdateCameraMarkers();
             UpdateVisibleFootprints();
             ((Command)SelectNextImageCommand).ChangeCanExecute();
             ((Command)SelectPreviousImageCommand).ChangeCanExecute();
@@ -224,8 +230,52 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
     /// Gets or sets the symbol to use for the search point marker.
     /// </summary>
     public MarkerSymbol SearchPointMarkerSymbol { get; set; }
-
     private const string SearchPointMarkerTag = "SearchPointMarker";
+
+    /// <summary>
+    /// Gets or sets the symbol to use for the current camera marker.
+    /// </summary>
+    public MarkerSymbol CurrentCameraMarkerSymbol { get; set; }
+    private const string CurrentCameraMarkerTag = "CurrentCamerasMarker";
+
+    /// <summary>
+    /// Gets or sets the symbol to use for all camera markers.
+    /// </summary>
+    public MarkerSymbol AllCamerasMarkerSymbol { get; set; }
+    private const string SelectedCamerasMarkerTag = "SelectedCamerasMarker";
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to show markers for the locations of the cameras associated with the images in the control.
+    /// </summary>
+    public bool ShowSelectedCameraLocations
+    {
+        get => _showSelectedCameraLocations;
+        set
+        {
+            if (_showSelectedCameraLocations == value) { return; }
+
+            SetProperty(ref _showSelectedCameraLocations, value);
+            UpdateCameraMarkers();
+        }
+    }
+    private bool _showSelectedCameraLocations = true;
+
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to show camera locations on the display. This property only has an effect if <see cref="ShowSelectedCameraLocations"/> is set to <c>true</c>.
+    /// </summary>
+    public bool ShowSelectedCameraLocationsOnDisplay
+    {
+        get => _showSelectedCameraLocationsOnDisplay;
+        set
+        {
+            if (_showSelectedCameraLocationsOnDisplay == value) { return; }
+
+            SetProperty(ref _showSelectedCameraLocationsOnDisplay, value);
+            UpdateCameraMarkers();
+        }
+    }
+    private bool _showSelectedCameraLocationsOnDisplay = false;
 
     private void UpdateSearchPointMarker(MapPoint? location)
     {
@@ -257,15 +307,58 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
     private void ClearMarkers()
     {
         var searchPointMarker = _markers.FirstOrDefault((marker) => marker.Tag is string tag && tag == SearchPointMarkerTag);
+        var currentCameraMarker = _markers.FirstOrDefault((marker) => marker.Tag is string tag && tag == CurrentCameraMarkerTag);
         _markers.Clear();
+        UpdateCameraMarkers();
         if (searchPointMarker != null)
             _markers.Add(searchPointMarker);
+        if (currentCameraMarker != null)
+            _markers.Add(currentCameraMarker);
+    }
+
+    private void UpdateCameraMarkers()
+    {
+        var existingCameraMarkers = _markers.Where((marker) => marker.Tag is string tag && tag == SelectedCamerasMarkerTag).ToList();
+        foreach (var mrk in existingCameraMarkers)
+        {
+            _markers.Remove(mrk);
+        }
+
+        if (ShowSelectedCameraLocations)
+        {
+            foreach (var img in _images.Where((img) => img.Geometry is MapPoint))
+            {
+                _markers.Add(new OrientedImageMarker( OrientedImageMarkerPosition.FromLocation((MapPoint)img.Geometry!), AllCamerasMarkerSymbol)
+                {
+                    Tag = SelectedCamerasMarkerTag,
+                    IsVisible = ShowSelectedCameraLocationsOnDisplay
+                });
+            }
+        }
+
+        UpdateSelectedImageMarker();
+    }
+
+    private void UpdateSelectedImageMarker()
+    {
+        var existingMarker = _markers.FirstOrDefault((marker) => marker?.Tag is string tag && tag == CurrentCameraMarkerTag, null);
+
+        if (existingMarker != null)
+            _markers.Remove(existingMarker);
+
+        if (SelectedImage?.Geometry is MapPoint point)
+        {
+            _markers.Add(new OrientedImageMarker(OrientedImageMarkerPosition.FromLocation(point), CurrentCameraMarkerSymbol) { Tag = CurrentCameraMarkerTag });
+        }
     }
 
     private void UpdateMarkerGraphics()
     {
         _markersOverlay.Graphics.Clear();
         _markersOverlay.Graphics.AddRange(_markers.Select((mk) => new Graphic(mk.Position.Location!, mk.Symbol)));
+
+        if (SelectedImage?.Geometry is MapPoint currentImageLocation)
+            _markersOverlay.Graphics.Add(new Graphic(currentImageLocation, CurrentCameraMarkerSymbol));
     }
     #endregion Markers
 

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewModel.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewModel.cs
@@ -57,13 +57,13 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
             canExecute: () => true);
     }
 
-    #region GeoModel
-    private OrientedImageryLayer _oiLayer;
+#region GeoModel
+    private OrientedImageryLayer? _oiLayer;
 
     /// <summary>
     /// Gets or sets the oriented imagery layer whose visible footprints are managed by this view model.
     /// </summary>
-    public OrientedImageryLayer OrientedImageryLayer
+    public OrientedImageryLayer? OrientedImageryLayer
     {
         get => _oiLayer;
         set
@@ -83,34 +83,12 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
             UpdateVisibleFootprints();
         }
     }
-    #endregion GeoModel
+#endregion GeoModel
 
-    #region ImageManagement
+#region Images
     private List<OrientedImage> _images;
-
-    /// <summary>
-    /// Sets the images to display in the control.
-    /// </summary>
-    /// <remarks>
-    /// Pass the <paramref name="searchPoint"/> parameter to display a marker at the location from which the images were searched.
-    /// </remarks>
-    /// <param name="images">The oriented images to display.</param>
-    /// <param name="searchPoint">The point from which the images were searched.</param>
-    public void SetImages(List<OrientedImage> images, MapPoint? searchPoint = null)
-    {
-
-        _images = images.ToList();
-        _footprints = _images.Select((img) => new OrientedImageFootprint(img)).ToList();
-
-        UpdateSearchPointMarker(searchPoint);
-        UpdateCameraMarkers();
-        UpdateVisibleFootprints();
-
-        ((Command)SelectNextImageCommand).ChangeCanExecute();
-        ((Command)SelectPreviousImageCommand).ChangeCanExecute();
-    }
-
     private OrientedImage? _selectedImage;
+    private OrientedImageFootprint? _selectedImageFootprint;
 
     /// <summary>
     /// Gets or sets the currently selected oriented image.
@@ -141,8 +119,6 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
         }
     }
 
-    private OrientedImageFootprint? _selectedImageFootprint;
-
     /// <summary>
     /// Gets the footprint of the currently selected image. This is updated based on the <see cref="SelectedImage"/> property.
     /// </summary>
@@ -168,6 +144,28 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
     /// </remarks>
     public ICommand SelectPreviousImageCommand { get; private set; }
 
+    /// <summary>
+    /// Sets the images to display in the control.
+    /// </summary>
+    /// <remarks>
+    /// Pass the <paramref name="searchPoint"/> parameter to display a marker at the location from which the images were searched.
+    /// </remarks>
+    /// <param name="images">The oriented images to display.</param>
+    /// <param name="searchPoint">The point from which the images were searched.</param>
+    public void SetImages(List<OrientedImage> images, MapPoint? searchPoint = null)
+    {
+
+        _images = images.ToList();
+        _footprints = _images.Select((img) => new OrientedImageFootprint(img)).ToList();
+
+        UpdateSearchPointMarker(searchPoint);
+        UpdateCameraMarkers();
+        UpdateVisibleFootprints();
+
+        ((Command)SelectNextImageCommand).ChangeCanExecute();
+        ((Command)SelectPreviousImageCommand).ChangeCanExecute();
+    }
+
     private void SelectNextImage()
     {
         if (_images.Count == 0)
@@ -192,9 +190,9 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
         }
     }
 
-    #endregion ImageManagement
+#endregion Images
 
-    #region FootprintManagement
+#region Footprints
     private List<OrientedImageFootprint> _footprints = new();
 
     private bool _showSelectedFootprint = true;
@@ -344,11 +342,17 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
             OrientedImageryLayer.VisibleFootprints.Add(SelectedImageFootprint);
         }
     }
-    #endregion FootprintManagement
+#endregion Footprints
 
-    #region Markers
+#region Markers
     // This viewmodel manages the markers collection and graphics overlay, the view is responsible for connecting them to displays
     private ObservableCollection<OrientedImageMarker> _markers;
+    private GraphicsOverlay _markersOverlay;
+    private bool _showCameraLocations = true;
+    private bool _showCameraLocationsOnDisplay = false;
+    private static readonly MarkerTag SearchPointMarkerTag = new MarkerTag("SearchPointMarker");
+    private static readonly MarkerTag SelectedImageMarkerTag = new MarkerTag("SelectedImageMarker", int.MaxValue);
+    private static readonly MarkerTag AllCamerasMarkerTag = new MarkerTag("AllSelectedCamerasMarker");
 
     /// <summary>
     /// Gets the collection of markers managed by this view model.
@@ -356,6 +360,84 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
     public ObservableCollection<OrientedImageMarker> Markers
     {
         get { return _markers; }
+    }
+
+    /// <summary>
+    /// Gets the graphics overlay that contains the marker graphics.
+    /// </summary>
+    public GraphicsOverlay MarkersOverlay => _markersOverlay;
+
+    /// <summary>
+    /// Gets or sets the default symbology to use when adding new markers.
+    /// </summary>
+    public MarkerSymbol NewMarkerSymbol { get; set; }
+
+    /// <summary>
+    /// Gets or sets the symbol to use for the search point marker.
+    /// </summary>
+    public MarkerSymbol SearchPointMarkerSymbol { get; set; }
+
+    /// <summary>
+    /// Gets or sets the symbol to use for the current camera marker.
+    /// </summary>
+    public MarkerSymbol SelectedCameraMarkerSymbol { get; set; }
+
+    /// <summary>
+    /// Gets or sets the symbol to use for all camera markers.
+    /// </summary>
+    public MarkerSymbol AllCamerasMarkerSymbol { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to show markers for the locations of the cameras associated with the images in the control.
+    /// </summary>
+    public bool ShowCameraLocations
+    {
+        get => _showCameraLocations;
+        set
+        {
+            if (_showCameraLocations == value) { return; }
+
+            SetProperty(ref _showCameraLocations, value);
+            UpdateCameraMarkers();
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to show camera locations on the display.
+    /// </summary>
+    /// <remarks>
+    /// This property only has an effect if <see cref="ShowCameraLocations"/> is set to <c>true</c>.
+    /// </remarks>
+    public bool ShowCameraLocationsOnDisplay
+    {
+        get => _showCameraLocationsOnDisplay;
+        set
+        {
+            if (_showCameraLocationsOnDisplay == value) { return; }
+
+            SetProperty(ref _showCameraLocationsOnDisplay, value);
+            UpdateCameraMarkers();
+        }
+    }
+
+    /// <summary>
+    /// Clears all extant markers save the search point marker.
+    /// </summary>
+    public ICommand ClearMarkersCommand { get; private set; }
+
+    /// <summary>
+    /// Adds a marker at a geographic location. The marker uses <see cref="NewMarkerSymbol"/> unless
+    /// overridden using the <paramref name="symbol"/> parameter.
+    /// </summary>
+    /// <remarks>
+    /// New markers will be discarded if <see cref="AllowAddingMarkers"/> is <c>false</c>.
+    /// </remarks>
+    /// <param name="location">The geographic location of the marker.</param>
+    /// <param name="symbol">The optional symbol to use for the marker.</param>
+    public void AddMarkerLocation(MapPoint location, MarkerSymbol? symbol = null)
+    {
+        if (AllowAddingMarkers)
+            Markers.Add(new OrientedImageMarker(OrientedImageMarkerPosition.FromLocation(location), symbol ?? NewMarkerSymbol));
     }
 
     private void Markers_CollectionChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
@@ -388,92 +470,6 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
                 break;
         }
     }
-
-    private GraphicsOverlay _markersOverlay;
-
-    /// <summary>
-    /// Gets the graphics overlay that contains the marker graphics.
-    /// </summary>
-    public GraphicsOverlay MarkersOverlay => _markersOverlay;
-
-    /// <summary>
-    /// Gets or sets the default symbology to use when adding new markers.
-    /// </summary>
-    public MarkerSymbol NewMarkerSymbol { get; set; }
-
-    /// <summary>
-    /// Gets or sets the symbol to use for the search point marker.
-    /// </summary>
-    public MarkerSymbol SearchPointMarkerSymbol { get; set; }
-    private static readonly MarkerTag SearchPointMarkerTag = new MarkerTag("SearchPointMarker");
-
-    /// <summary>
-    /// Gets or sets the symbol to use for the current camera marker.
-    /// </summary>
-    public MarkerSymbol SelectedCameraMarkerSymbol { get; set; }
-    private static readonly MarkerTag SelectedImageMarkerTag = new MarkerTag("SelectedImageMarker", int.MaxValue);
-
-    /// <summary>
-    /// Gets or sets the symbol to use for all camera markers.
-    /// </summary>
-    public MarkerSymbol AllCamerasMarkerSymbol { get; set; }
-    private static readonly MarkerTag AllCamerasMarkerTag = new MarkerTag("AllSelectedCamerasMarker");
-
-    /// <summary>
-    /// Gets or sets a value indicating whether to show markers for the locations of the cameras associated with the images in the control.
-    /// </summary>
-    public bool ShowCameraLocations
-    {
-        get => _showCameraLocations;
-        set
-        {
-            if (_showCameraLocations == value) { return; }
-
-            SetProperty(ref _showCameraLocations, value);
-            UpdateCameraMarkers();
-        }
-    }
-    private bool _showCameraLocations = true;
-
-
-    /// <summary>
-    /// Gets or sets a value indicating whether to show camera locations on the display.
-    /// </summary>
-    /// <remarks>
-    /// This property only has an effect if <see cref="ShowCameraLocations"/> is set to <c>true</c>.
-    /// </remarks>
-    public bool ShowCameraLocationsOnDisplay
-    {
-        get => _showCameraLocationsOnDisplay;
-        set
-        {
-            if (_showCameraLocationsOnDisplay == value) { return; }
-
-            SetProperty(ref _showCameraLocationsOnDisplay, value);
-            UpdateCameraMarkers();
-        }
-    }
-    private bool _showCameraLocationsOnDisplay = false;
-
-    /// <summary>
-    /// Adds a marker at a geographic location. The marker uses <see cref="NewMarkerSymbol"/> unless
-    /// overridden using the <paramref name="symbol"/> parameter.
-    /// </summary>
-    /// <remarks>
-    /// New markers will be discarded if <see cref="AllowAddingMarkers"/> is <c>false</c>.
-    /// </remarks>
-    /// <param name="location">The geographic location of the marker.</param>
-    /// <param name="symbol">The optional symbol to use for the marker.</param>
-    public void AddMarkerLocation(MapPoint location, MarkerSymbol? symbol = null)
-    {
-        if (AllowAddingMarkers)
-            Markers.Add(new OrientedImageMarker(OrientedImageMarkerPosition.FromLocation(location), symbol ?? NewMarkerSymbol));
-    }
-
-    /// <summary>
-    /// Clears all extant markers save the search point marker.
-    /// </summary>
-    public ICommand ClearMarkersCommand { get; private set; }
 
     private void ClearMarkers()
     {
@@ -545,9 +541,9 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
         public string Identifier = identifier;
         public int ZIndex = zIndex;
     }
-    #endregion Markers
+#endregion Markers
 
-    #region INotifyPropertyChanged
+#region INotifyPropertyChanged
     /// <inheritdoc/>
     public event PropertyChangedEventHandler? PropertyChanged;
 
@@ -559,6 +555,6 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
     }
-    #endregion INotifyPropertyChanged
+#endregion INotifyPropertyChanged
 }
 #endif

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewModel.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewModel.cs
@@ -22,21 +22,22 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
 {
     public OrientedImageryViewModel() : base()
     {
+        _allowAddingMarkers = false;
+        _markers = new ObservableCollection<OrientedImageMarker>();
+        _markers.CollectionChanged -= Markers_CollectionChanged;
+
         _markersOverlay = new GraphicsOverlay() { Id = "OrientedImageryView_Markers_Overlay" };
         NewMarkerSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Diamond, System.Drawing.Color.Orange, 15);
         SearchPointMarkerSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.X, System.Drawing.Color.Red, 12);
         AllCamerasMarkerSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Circle, System.Drawing.Color.FromArgb(200,0,0,255), 15);
         CurrentCameraMarkerSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Circle, System.Drawing.Color.Yellow, 15);
 
+        _images = new List<OrientedImage>();
+
         SelectedFootprintFillColor = System.Drawing.Color.FromArgb(128, System.Drawing.Color.Orange);
         SelectedFootprintOutlineColor = System.Drawing.Color.Orange;
         UnselectedFootprintFillColor = System.Drawing.Color.FromArgb(128, System.Drawing.Color.Blue);
         UnselectedFootprintOutlineColor = System.Drawing.Color.Blue;
-
-        _allowAddingMarkers = false;
-        _markers = new ObservableCollection<OrientedImageMarker>();
-        _markers.CollectionChanged += (_, _) => UpdateGraphicsOverlay();
-        _images = new List<OrientedImage>();
 
         SelectNextImageCommand = new Command(
             execute: () => SelectNextImage(),
@@ -65,7 +66,7 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
 
             _images.Clear();
             SelectedImage = null;
-            _markers.Clear();
+            Markers.Clear();
 
             _oiLayer = value;
             UpdateVisibleFootprints();
@@ -328,7 +329,23 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
     #region Markers
     // This viewmodel manages the markers collection and graphics overlay, the view is responsible for connecting them to displays
     private ObservableCollection<OrientedImageMarker> _markers;
-    public ObservableCollection<OrientedImageMarker> Markers => _markers;
+    public ObservableCollection<OrientedImageMarker> Markers
+    {
+        get { return _markers; }
+        private set
+        {
+            if (value == _markers)
+                return;
+            _markers.CollectionChanged -= Markers_CollectionChanged;
+            value.CollectionChanged += Markers_CollectionChanged;
+            SetProperty(ref _markers, value);
+        }
+    }
+
+    private void Markers_CollectionChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+    {
+        UpdateGraphicsOverlay();
+    }
 
     private GraphicsOverlay _markersOverlay;
     public GraphicsOverlay MarkersOverlay => _markersOverlay;
@@ -390,14 +407,14 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
 
     private void UpdateSearchPointMarker(MapPoint? location)
     {
-        var existingMarker = _markers.FirstOrDefault((marker) => marker?.Tag is string tag && tag == SearchPointMarkerTag, null);
+        var existingMarker = Markers.FirstOrDefault((marker) => marker?.Tag is string tag && tag == SearchPointMarkerTag, null);
 
         if (existingMarker != null)
-            _markers.Remove(existingMarker);
+            Markers.Remove(existingMarker);
 
         if (location != null)
         {
-            _markers.Add(new OrientedImageMarker(OrientedImageMarkerPosition.FromLocation(location), SearchPointMarkerSymbol) { Tag = SearchPointMarkerTag });
+            Markers.Add(new OrientedImageMarker(OrientedImageMarkerPosition.FromLocation(location), SearchPointMarkerSymbol) { Tag = SearchPointMarkerTag });
         }
     }
 
@@ -408,7 +425,7 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
     public void AddMarkerLocation(MapPoint location, MarkerSymbol? symbol = null)
     {
         if (AllowAddingMarkers)
-            _markers.Add(new OrientedImageMarker(OrientedImageMarkerPosition.FromLocation(location), symbol ?? NewMarkerSymbol));
+            Markers.Add(new OrientedImageMarker(OrientedImageMarkerPosition.FromLocation(location), symbol ?? NewMarkerSymbol));
     }
 
     /// <summary>
@@ -418,38 +435,37 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
 
     private void ClearMarkers()
     {
-        var searchPointMarker = _markers.FirstOrDefault((marker) => marker.Tag is string tag && tag == SearchPointMarkerTag);
-        _markers.Clear();
+        var searchPointMarker = Markers.FirstOrDefault((marker) => marker.Tag is string tag && tag == SearchPointMarkerTag);
+        Markers.Clear();
         UpdateCameraMarkers();
         if (searchPointMarker != null)
-            _markers.Add(searchPointMarker);
+            Markers.Add(searchPointMarker);
     }
 
     private void UpdateCameraMarkers()
     {
-        var existingCameraMarkers = _markers.Where((marker) => marker.Tag is string tag && tag == AllCamerasMarkerTag).ToList();
-        foreach (var mrk in existingCameraMarkers)
-        {
-            _markers.Remove(mrk);
-        }
+        var currentMarkers = Markers.ToList();
+        var existingCameraMarkers = currentMarkers.RemoveAll((marker) => marker.Tag is string tag && tag == AllCamerasMarkerTag);
 
         if (ShowCameraLocations)
         {
-            foreach (var img in _images.Where((img) => img.Geometry is MapPoint))
-            {
-                _markers.Add(new OrientedImageMarker(OrientedImageMarkerPosition.FromLocation((MapPoint)img.Geometry!), AllCamerasMarkerSymbol)
-                {
-                    Tag = AllCamerasMarkerTag,
-                    IsVisible = ShowCameraLocationsOnDisplay
-                });
-            }
+            currentMarkers.AddRange(
+                _images.Where((img) => img.Geometry is MapPoint)
+                       .Select(img => new OrientedImageMarker(OrientedImageMarkerPosition.FromLocation((MapPoint)img.Geometry!), AllCamerasMarkerSymbol)
+                       {
+                           Tag = AllCamerasMarkerTag,
+                           IsVisible = ShowCameraLocationsOnDisplay
+                       }));
         }
+
+        Markers = new ObservableCollection<OrientedImageMarker>(currentMarkers);
+        UpdateGraphicsOverlay();
     }
 
     private void UpdateGraphicsOverlay()
     {
         _markersOverlay.Graphics.Clear();
-        _markersOverlay.Graphics.AddRange(_markers.Select((mk) => new Graphic(mk.Position.Location!, mk.Symbol)));
+        _markersOverlay.Graphics.AddRange(Markers.Select((mk) => new Graphic(mk.Position.Location!, mk.Symbol)));
 
         if (SelectedImage?.Geometry is MapPoint currentImageLocation)
             _markersOverlay.Graphics.Add(new Graphic(currentImageLocation, CurrentCameraMarkerSymbol) { ZIndex = int.MaxValue });

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewModel.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewModel.cs
@@ -173,9 +173,39 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
     #region FootprintManagement
     private List<OrientedImageFootprint> _footprints = new();
 
-    // These booleans need to be bindable
-    public bool ShowSelectedFootprint = true;
-    public bool ShowUnselectedFootprints = false;
+    private bool _showSelectedFootprint = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to show the footprint for the selected oriented image.
+    /// </summary>
+    public bool ShowSelectedFootprint
+    {
+        get => _showSelectedFootprint;
+        set
+        {
+            if (_showSelectedFootprint == value) { return; }
+
+            SetProperty(ref _showSelectedFootprint, value);
+            UpdateVisibleFootprints();
+        }
+    }
+
+    private bool _showUnselectedFootprints;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to show footprints for non-selected oriented images.
+    /// </summary>
+    public bool ShowUnselectedFootprints
+    {
+        get => _showUnselectedFootprints;
+        set
+        {
+            if (_showUnselectedFootprints == value) { return; }
+
+            SetProperty(ref _showUnselectedFootprints, value);
+            UpdateVisibleFootprints();
+        }
+    }
 
     private bool _autoUpdateFootprint;
     public bool AutoUpdateFootprint

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewModel.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewModel.cs
@@ -27,6 +27,12 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
         SearchPointMarkerSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.X, System.Drawing.Color.Red, 20);
         AllCamerasMarkerSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Circle, System.Drawing.Color.FromArgb(200,0,0,255), 15);
         CurrentCameraMarkerSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Circle, System.Drawing.Color.Yellow, 15);
+
+        SelectedFootprintFillColor = System.Drawing.Color.FromArgb(128, System.Drawing.Color.Orange);
+        SelectedFootprintOutlineColor = System.Drawing.Color.Orange;
+        UnselectedFootprintFillColor = System.Drawing.Color.FromArgb(128, System.Drawing.Color.Blue);
+        UnselectedFootprintOutlineColor = System.Drawing.Color.Blue;
+
         _markers = new ObservableCollection<OrientedImageMarker>();
         _markers.CollectionChanged += (_, _) => UpdateMarkerGraphics();
         _images = new List<OrientedImage>();
@@ -214,11 +220,73 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
         set => SetProperty(ref _autoUpdateFootprint, value);
     }
 
-    // These colors should be bindable
-    public System.Drawing.Color SelectedFootprintFillColor = System.Drawing.Color.Orange;
-    public System.Drawing.Color SelectedFootprintOutlineColor = System.Drawing.Color.Black;
-    public System.Drawing.Color UnselectedFootprintFillColor = System.Drawing.Color.Blue;
-    public System.Drawing.Color UnselectedFootprintOutlineColor = System.Drawing.Color.Orange;
+    private System.Drawing.Color _selectedFootprintFillColor;
+
+    /// <summary>
+    /// Gets or sets the fill color used for the selected image footprint.
+    /// </summary>
+    public System.Drawing.Color SelectedFootprintFillColor
+    {
+        get => _selectedFootprintFillColor;
+        set
+        {
+            if (_selectedFootprintFillColor == value) { return; }
+
+            SetProperty(ref _selectedFootprintFillColor, value);
+            UpdateVisibleFootprints();
+        }
+    }
+
+    private System.Drawing.Color _selectedFootprintOutlineColor;
+
+    /// <summary>
+    /// Gets or sets the outline color used for the selected image footprint.
+    /// </summary>
+    public System.Drawing.Color SelectedFootprintOutlineColor
+    {
+        get => _selectedFootprintOutlineColor;
+        set
+        {
+            if (_selectedFootprintOutlineColor == value) { return; }
+
+            SetProperty(ref _selectedFootprintOutlineColor, value);
+            UpdateVisibleFootprints();
+        }
+    }
+
+    private System.Drawing.Color _unselectedFootprintFillColor;
+
+    /// <summary>
+    /// Gets or sets the fill color used for unselected image footprints.
+    /// </summary>
+    public System.Drawing.Color UnselectedFootprintFillColor
+    {
+        get => _unselectedFootprintFillColor;
+        set
+        {
+            if (_unselectedFootprintFillColor == value) { return; }
+
+            SetProperty(ref _unselectedFootprintFillColor, value);
+            UpdateVisibleFootprints();
+        }
+    }
+
+    private System.Drawing.Color _unselectedFootprintOutlineColor;
+
+    /// <summary>
+    /// Gets or sets the outline color used for unselected image footprints.
+    /// </summary>
+    public System.Drawing.Color UnselectedFootprintOutlineColor
+    {
+        get => _unselectedFootprintOutlineColor;
+        set
+        {
+            if (_unselectedFootprintOutlineColor == value) { return; }
+
+            SetProperty(ref _unselectedFootprintOutlineColor, value);
+            UpdateVisibleFootprints();
+        }
+    }
 
     private void UpdateVisibleFootprints()
     {
@@ -238,6 +306,8 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
 
         if (ShowSelectedFootprint && SelectedImageFootprint != null)
         {
+            SelectedImageFootprint.FillColor = SelectedFootprintFillColor;
+            SelectedImageFootprint.OutlineColor = SelectedFootprintOutlineColor;
             OrientedImageryLayer.VisibleFootprints.Add(SelectedImageFootprint);
         }
     }

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewModel.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewModel.cs
@@ -64,7 +64,7 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
     /// <summary>
     /// Sets the images to display in the control. Optionally, a search point can be provided to indicate the origin of the search.
     /// </summary>
-    public void SetImages(Collection<OrientedImage> images, MapPoint? searchPoint = null)
+    public void SetImages(List<OrientedImage> images, MapPoint? searchPoint = null)
     {
         UpdateSearchPointMarker(searchPoint);
 

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewModel.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewModel.cs
@@ -19,8 +19,14 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls;
 #endif
 
 #if WPF
+/// <summary>
+/// Manages oriented imagery selection, footprints, and map markers for an oriented imagery view.
+/// </summary>
 public class OrientedImageryViewModel : INotifyPropertyChanged
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OrientedImageryViewModel"/> class.
+    /// </summary>
     public OrientedImageryViewModel() : base()
     {
         _allowAddingMarkers = false;
@@ -53,6 +59,10 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
 
     #region GeoModel
     private OrientedImageryLayer _oiLayer;
+
+    /// <summary>
+    /// Gets or sets the oriented imagery layer whose visible footprints are managed by this view model.
+    /// </summary>
     public OrientedImageryLayer OrientedImageryLayer
     {
         get => _oiLayer;
@@ -79,8 +89,13 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
     private List<OrientedImage> _images;
 
     /// <summary>
-    /// Sets the images to display in the control. Optionally, a search point can be provided to indicate the origin of the search.
+    /// Sets the images to display in the control.
     /// </summary>
+    /// <remarks>
+    /// Pass the <paramref name="searchPoint"/> parameter to display a marker at the location from which the images were searched.
+    /// </remarks>
+    /// <param name="images">The oriented images to display.</param>
+    /// <param name="searchPoint">The point from which the images were searched.</param>
     public void SetImages(List<OrientedImage> images, MapPoint? searchPoint = null)
     {
 
@@ -97,6 +112,9 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
 
     private OrientedImage? _selectedImage;
 
+    /// <summary>
+    /// Gets or sets the currently selected oriented image.
+    /// </summary>
     public OrientedImage? SelectedImage
     {
         get => _selectedImage;
@@ -214,6 +232,10 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
     }
 
     private bool _autoUpdateFootprint;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the selected image footprint is automatically updated.
+    /// </summary>
     public bool AutoUpdateFootprint
     {
         get => _autoUpdateFootprint;
@@ -223,7 +245,7 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
     private bool _allowAddingMarkers;
 
     /// <summary>
-    /// Gets or sets a value indicating whether image clicks can add markers.
+    /// Gets or sets a value indicating whether new markers may be added.
     /// </summary>
     public bool AllowAddingMarkers
     {
@@ -327,6 +349,10 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
     #region Markers
     // This viewmodel manages the markers collection and graphics overlay, the view is responsible for connecting them to displays
     private ObservableCollection<OrientedImageMarker> _markers;
+
+    /// <summary>
+    /// Gets the collection of markers managed by this view model.
+    /// </summary>
     public ObservableCollection<OrientedImageMarker> Markers
     {
         get { return _markers; }
@@ -364,6 +390,10 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
     }
 
     private GraphicsOverlay _markersOverlay;
+
+    /// <summary>
+    /// Gets the graphics overlay that contains the marker graphics.
+    /// </summary>
     public GraphicsOverlay MarkersOverlay => _markersOverlay;
 
     /// <summary>
@@ -407,8 +437,11 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
 
 
     /// <summary>
-    /// Gets or sets a value indicating whether to show camera locations on the display. This property only has an effect if <see cref="ShowCameraLocations"/> is set to <c>true</c>.
+    /// Gets or sets a value indicating whether to show camera locations on the display.
     /// </summary>
+    /// <remarks>
+    /// This property only has an effect if <see cref="ShowCameraLocations"/> is set to <c>true</c>.
+    /// </remarks>
     public bool ShowCameraLocationsOnDisplay
     {
         get => _showCameraLocationsOnDisplay;
@@ -423,9 +456,14 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
     private bool _showCameraLocationsOnDisplay = false;
 
     /// <summary>
-    /// Add a marker from a geographic location. The new marker is added with <see cref="NewMarkerSymbol"/> unless
-    /// overriden using the <paramref name="symbol"/> parameter.
+    /// Adds a marker at a geographic location. The marker uses <see cref="NewMarkerSymbol"/> unless
+    /// overridden using the <paramref name="symbol"/> parameter.
     /// </summary>
+    /// <remarks>
+    /// New markers will be discarded if <see cref="AllowAddingMarkers"/> is <c>false</c>.
+    /// </remarks>
+    /// <param name="location">The geographic location of the marker.</param>
+    /// <param name="symbol">The optional symbol to use for the marker.</param>
     public void AddMarkerLocation(MapPoint location, MarkerSymbol? symbol = null)
     {
         if (AllowAddingMarkers)

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewModel.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewModel.cs
@@ -336,7 +336,6 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
     /// Gets or sets the symbol to use for the current camera marker.
     /// </summary>
     public MarkerSymbol CurrentCameraMarkerSymbol { get; set; }
-    private const string CurrentCameraMarkerTag = "CurrentCamerasMarker";
 
     /// <summary>
     /// Gets or sets the symbol to use for all camera markers.
@@ -407,13 +406,10 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
     private void ClearMarkers()
     {
         var searchPointMarker = _markers.FirstOrDefault((marker) => marker.Tag is string tag && tag == SearchPointMarkerTag);
-        var currentCameraMarker = _markers.FirstOrDefault((marker) => marker.Tag is string tag && tag == CurrentCameraMarkerTag);
         _markers.Clear();
         UpdateCameraMarkers();
         if (searchPointMarker != null)
             _markers.Add(searchPointMarker);
-        if (currentCameraMarker != null)
-            _markers.Add(currentCameraMarker);
     }
 
     private void UpdateCameraMarkers()
@@ -428,27 +424,12 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
         {
             foreach (var img in _images.Where((img) => img.Geometry is MapPoint))
             {
-                _markers.Add(new OrientedImageMarker( OrientedImageMarkerPosition.FromLocation((MapPoint)img.Geometry!), AllCamerasMarkerSymbol)
+                _markers.Add(new OrientedImageMarker(OrientedImageMarkerPosition.FromLocation((MapPoint)img.Geometry!), AllCamerasMarkerSymbol)
                 {
                     Tag = SelectedCamerasMarkerTag,
                     IsVisible = ShowSelectedCameraLocationsOnDisplay
                 });
             }
-        }
-
-        UpdateSelectedImageMarker();
-    }
-
-    private void UpdateSelectedImageMarker()
-    {
-        var existingMarker = _markers.FirstOrDefault((marker) => marker?.Tag is string tag && tag == CurrentCameraMarkerTag, null);
-
-        if (existingMarker != null)
-            _markers.Remove(existingMarker);
-
-        if (SelectedImage?.Geometry is MapPoint point)
-        {
-            _markers.Add(new OrientedImageMarker(OrientedImageMarkerPosition.FromLocation(point), CurrentCameraMarkerSymbol) { Tag = CurrentCameraMarkerTag });
         }
     }
 
@@ -458,7 +439,7 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
         _markersOverlay.Graphics.AddRange(_markers.Select((mk) => new Graphic(mk.Position.Location!, mk.Symbol)));
 
         if (SelectedImage?.Geometry is MapPoint currentImageLocation)
-            _markersOverlay.Graphics.Add(new Graphic(currentImageLocation, CurrentCameraMarkerSymbol));
+            _markersOverlay.Graphics.Add(new Graphic(currentImageLocation, CurrentCameraMarkerSymbol) { ZIndex = int.MaxValue });
     }
     #endregion Markers
 

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewModel.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewModel.cs
@@ -1,0 +1,230 @@
+﻿using Esri.ArcGISRuntime.Geometry;
+using Esri.ArcGISRuntime.Mapping;
+using Esri.ArcGISRuntime.Symbology;
+using Esri.ArcGISRuntime.Toolkit.Internal;
+using Esri.ArcGISRuntime.UI;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+#if MAUI
+namespace Esri.ArcGISRuntime.Toolkit.Maui;
+#else
+namespace Esri.ArcGISRuntime.Toolkit.UI.Controls;
+#endif
+
+#if WPF
+public class OrientedImageryViewModel : INotifyPropertyChanged
+{
+    public OrientedImageryViewModel() : base()
+    {
+        _markersOverlay = new GraphicsOverlay() { Id = "OrientedImageryView_Markers_Overlay" };
+        NewMarkerSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.X, System.Drawing.Color.Red, 20);
+        SearchPointMarkerSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Circle, System.Drawing.Color.Blue, 20);
+        _markers = new ObservableCollection<OrientedImageMarker>();
+        _markers.CollectionChanged += (_, _) => UpdateMarkerGraphics();
+        _images = new List<OrientedImage>();
+    }
+
+    private async void Display_ImageClicked(object? sender, OrientedImageDisplay.ImageClickedEventArgs e)
+    {
+        if (e.Marker != null)
+            return; // do not add a new marker if there is already one in proximity to the click location
+
+        var location = await SelectedImage!.ImageToLocationAsync(e.ImagePoint);
+        _markers.Add(new OrientedImageMarker(OrientedImageMarkerPosition.FromLocation(location), NewMarkerSymbol));
+    }
+
+    #region GeoViewStuff
+    private OrientedImageryLayer _oiLayer;
+    public OrientedImageryLayer OrientedImageryLayer
+    {
+        get => _oiLayer;
+        set
+        {
+            if (_oiLayer == value) return;
+
+            if (_oiLayer != null)
+            {
+                _oiLayer.VisibleFootprints.Clear();
+            }
+
+            _oiLayer = value;
+            UpdateVisibleFootprints();
+        }
+    }
+    #endregion
+
+    #region ImageManagement
+    private List<OrientedImage> _images;
+
+    /// <summary>
+    /// Sets the images to display in the control. Optionally, a search point can be provided to indicate the origin of the search.
+    /// </summary>
+    public void SetImages(Collection<OrientedImage> images, MapPoint? searchPoint = null)
+    {
+        UpdateSearchPointMarker(searchPoint);
+
+        _images = images.ToList();
+        _footprints = _images.Select((img) => new OrientedImageFootprint(img)).ToList();
+        UpdateVisibleFootprints();
+    }
+
+    private OrientedImage? _selectedImage;
+    public OrientedImage? SelectedImage
+    {
+        get => _selectedImage;
+        set
+        {
+            if (value == _selectedImage) return;
+
+            SetProperty(ref _selectedImage, value);
+
+            if (_selectedImage != null)
+            {
+                var footprint = _footprints.FirstOrDefault((fpt) => fpt.OrientedImage == _selectedImage);
+                SelectedImageFootprint = footprint ?? new OrientedImageFootprint(_selectedImage);
+            }
+            else
+            {
+                SelectedImageFootprint = null;
+            }
+            UpdateVisibleFootprints();
+        }
+    }
+
+    private OrientedImageFootprint? _selectedImageFootprint;
+
+    /// <summary>
+    /// Gets the footprint of the currently selected image. This is updated based on the <see cref="SelectedImage"/> property.
+    /// </summary>
+    public OrientedImageFootprint? SelectedImageFootprint
+    {
+        get => _selectedImageFootprint;
+        private set => SetProperty(ref _selectedImageFootprint, value);
+    }
+
+    // Commands for move to next/previous image. Use Images.IndexOf, no need to track index as a field
+    #endregion ImageManagement
+
+    #region FootprintManagement
+    private List<OrientedImageFootprint> _footprints = new();
+
+    // These booleans need to be bindable
+    public bool ShowSelectedFootprint = true;
+    public bool ShowUnselectedFootprints = false;
+
+    private bool _autoUpdateFootprint;
+    public bool AutoUpdateFootprint
+    {
+        get => _autoUpdateFootprint;
+        set => SetProperty(ref _autoUpdateFootprint, value);
+    }
+
+    // These colors should be bindable
+    public System.Drawing.Color SelectedFootprintFillColor = System.Drawing.Color.Orange;
+    public System.Drawing.Color SelectedFootprintOutlineColor = System.Drawing.Color.Black;
+    public System.Drawing.Color UnselectedFootprintFillColor = System.Drawing.Color.Blue;
+    public System.Drawing.Color UnselectedFootprintOutlineColor = System.Drawing.Color.Orange;
+
+    private void UpdateVisibleFootprints()
+    {
+        if (OrientedImageryLayer == null) return;
+
+        OrientedImageryLayer.VisibleFootprints.Clear();
+
+        foreach (var ftp in _footprints)
+        {
+            if (ftp != SelectedImageFootprint && ShowUnselectedFootprints)
+            {
+                ftp.FillColor = UnselectedFootprintFillColor;
+                ftp.OutlineColor = UnselectedFootprintOutlineColor;
+                OrientedImageryLayer.VisibleFootprints.Add(ftp);
+            }
+        }
+
+        if (ShowSelectedFootprint && SelectedImageFootprint != null)
+        {
+            OrientedImageryLayer.VisibleFootprints.Add(SelectedImageFootprint);
+        }
+    }
+    #endregion FootprintManagement
+
+    #region Markers
+    // This viewmodel manages the markers collection and graphics overlay, the view is responsible for connecting them to displays
+    private ObservableCollection<OrientedImageMarker> _markers;
+    public ObservableCollection<OrientedImageMarker> Markers => _markers;
+
+    private GraphicsOverlay _markersOverlay;
+    public GraphicsOverlay MarkersOverlay => _markersOverlay;
+
+    /// <summary>
+    /// Gets or sets the default symbology to use when adding new markers.
+    /// </summary>
+    public MarkerSymbol NewMarkerSymbol { get; set; }
+
+    /// <summary>
+    /// Gets or sets the symbol to use for the search point marker.
+    /// </summary>
+    public MarkerSymbol SearchPointMarkerSymbol { get; set; }
+
+    private const string SearchPointMarkerTag = "SearchPointMarker";
+
+    private void UpdateSearchPointMarker(MapPoint? location)
+    {
+        var existingMarker = _markers.FirstOrDefault((marker) => marker?.Tag is string tag && tag == SearchPointMarkerTag, null);
+
+        if (existingMarker != null)
+            _markers.Remove(existingMarker);
+
+        if (location != null)
+        {
+            _markers.Add(new OrientedImageMarker(OrientedImageMarkerPosition.FromLocation(location), SearchPointMarkerSymbol) { Tag = SearchPointMarkerTag });
+        }
+    }
+
+    /// <summary>
+    /// Add a marker from a geographic location. The new marker is added uses the <cref="NewMarkerSymbol"/> unless
+    /// overriden using the <paramref name="symbol"/> parameter.
+    /// </summary>
+    public void AddMarkerLocation(MapPoint location, MarkerSymbol? symbol = null)
+    {
+        _markers.Add(new OrientedImageMarker(OrientedImageMarkerPosition.FromLocation(location), symbol ?? NewMarkerSymbol));
+    }
+
+    /// <summary>
+    /// Clears all markers on the image. Saves the search point marker if it exists.
+    /// </summary>
+    public void ClearMarkers()
+    {
+        var searchPointMarker = _markers.FirstOrDefault((marker) => marker.Tag is string tag && tag == SearchPointMarkerTag);
+        _markers.Clear();
+        if (searchPointMarker != null)
+            _markers.Add(searchPointMarker);
+    }
+
+    private void UpdateMarkerGraphics()
+    {
+        _markersOverlay.Graphics.Clear();
+        _markersOverlay.Graphics.AddRange(_markers.Select((mk) => new Graphic(mk.Position.Location!, mk.Symbol)));
+    }
+    #endregion Markers
+
+    #region INotifyPropertyChanged
+    /// <inheritdoc/>
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    private void SetProperty<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+    {
+        if (!EqualityComparer<T>.Default.Equals(field, value))
+        {
+            field = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+    #endregion INotifyPropertyChanged
+}
+#endif

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewModel.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewModel.cs
@@ -47,6 +47,9 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
         UnselectedFootprintFillColor = System.Drawing.Color.FromArgb(16, System.Drawing.Color.Blue);
         UnselectedFootprintOutlineColor = System.Drawing.Color.Blue;
 
+        ToolbarItems = GetDefaultToolbarItems();
+        ToolbarItems.CollectionChanged += ToolbarItems_CollectionChanged;
+
         SelectNextImageCommand = new Command(
             execute: () => SelectNextImage(),
             canExecute: () => _images.Count > 0 && (SelectedImage == null || _images.IndexOf(SelectedImage) < _images.Count - 1));
@@ -576,6 +579,44 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
         public int ZIndex = zIndex;
     }
 #endregion Markers
+
+#region ToolbarItems
+    /// <summary>
+    /// The collection of toolbar items to be displayed on the containing <see cref="OrientedImageryView"/>.
+    /// </summary>
+    /// <remarks>
+    /// Each toolbar items is an <see cref="OrientedImageryToolbarItemBase"/> object with a reference to the containing <see cref="OrientedImageryViewModel"/>.
+    /// The list is initially populated with a set of default toolbar items for the base control.
+    /// </remarks>
+    public ObservableCollection<OrientedImageryToolbarItemBase> ToolbarItems { get; private set; }
+
+    /// <summary>
+    /// Gets the default toolbar items for a <see cref="OrientedImageryViewModel"/>.
+    /// </summary>
+    private static ObservableCollection<OrientedImageryToolbarItemBase> GetDefaultToolbarItems()
+    {
+        var markerSymbolPickerVM = new SelectNewMarkerSymbolVM(new Collection<MarkerSymbol>()
+        {
+            new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Square, System.Drawing.Color.Purple, 10),
+            new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Triangle, System.Drawing.Color.Yellow, 10),
+            new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Diamond, System.Drawing.Color.Orange, 10)
+        });
+        return [new ShowSelectedFootprintVM(), new ShowUnselectedFootprintsVM(), new ShowCameraMarkersVM(), new AllowAddingMarkersVM(), markerSymbolPickerVM, new ClearMarkersVM()];
+    }
+
+    private void ToolbarItems_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        foreach (var removedItem in e.OldItems?.OfType<OrientedImageryToolbarItemBase>() ?? [])
+        {
+            removedItem.ViewModel = null;
+        }
+
+        foreach (var newItem in ToolbarItems)
+        {
+            newItem.ViewModel = this;
+        }
+    }
+#endregion ToolbarItems
 
 #region INotifyPropertyChanged
     /// <inheritdoc/>

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewModel.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewModel.cs
@@ -83,6 +83,7 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
             }
 
             _images.Clear();
+            _footprints.Clear();
             SelectedImage = null;
             Markers.Clear();
 
@@ -189,7 +190,7 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
     /// </remarks>
     /// <param name="images">The oriented images to display.</param>
     /// <param name="searchPoint">The point from which the images were searched.</param>
-    public void SetImages(List<OrientedImage> images, MapPoint? searchPoint = null)
+    public void SetImages(IEnumerable<OrientedImage> images, MapPoint? searchPoint = null)
     {
 
         _images = images.ToList();

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewModel.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewModel.cs
@@ -593,7 +593,7 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
     /// <summary>
     /// Gets the default toolbar items for a <see cref="OrientedImageryViewModel"/>.
     /// </summary>
-    private static ObservableCollection<OrientedImageryToolbarItemBase> GetDefaultToolbarItems()
+    private ObservableCollection<OrientedImageryToolbarItemBase> GetDefaultToolbarItems()
     {
         var markerSymbolPickerVM = new SelectNewMarkerSymbolVM(new Collection<MarkerSymbol>()
         {
@@ -601,7 +601,21 @@ public class OrientedImageryViewModel : INotifyPropertyChanged
             new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Triangle, System.Drawing.Color.Yellow, 10),
             new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Diamond, System.Drawing.Color.Orange, 10)
         });
-        return [new ShowSelectedFootprintVM(), new ShowUnselectedFootprintsVM(), new ShowCameraMarkersVM(), new AllowAddingMarkersVM(), markerSymbolPickerVM, new ClearMarkersVM()];
+
+        ObservableCollection<OrientedImageryToolbarItemBase> items =
+        [
+            new ShowSelectedFootprintVM(),
+            new ShowUnselectedFootprintsVM(),
+            new ShowCameraMarkersVM(),
+            new AllowAddingMarkersVM(),
+            markerSymbolPickerVM,
+            new ClearMarkersVM()
+        ];
+
+        foreach (var item in items)
+            item.ViewModel = this;
+
+        return items;
     }
 
     private void ToolbarItems_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewTemplateSelector.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewTemplateSelector.cs
@@ -5,9 +5,39 @@ using System.Collections.ObjectModel;
 
 namespace Esri.ArcGISRuntime.Toolkit.UI.Controls;
 
+/// <summary>
+/// A <see cref="DataTemplateSelector"/> to define explicit type-template pairs for the toolbar view models used in the <see cref="OrientedImageryView"/>.
+/// </summary>
 [ContentProperty(nameof(TypeTemplatePairs))]
 public class OrientedImageryViewTemplateSelector : DataTemplateSelector
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OrientedImageryViewTemplateSelector"/> class.
+    /// </summary>
+    public OrientedImageryViewTemplateSelector()
+    {
+        TypeTemplatePairs = new ObservableCollection<OrientedImageryViewTemplateSelectorItem>();
+        ((ObservableCollection<OrientedImageryViewTemplateSelectorItem>)TypeTemplatePairs).CollectionChanged += (s, e) =>
+        {
+            foreach (var newItem in e.NewItems?.OfType<OrientedImageryViewTemplateSelectorItem>() ?? [])
+            {
+                if (TypeTemplatePairs.FirstOrDefault((item) => item.Type == newItem.Type) is OrientedImageryViewTemplateSelectorItem existingItem)
+                {
+                    existingItem.Template = newItem.Template;
+                }
+            }
+        };
+    }
+
+    /// <summary>
+    /// Gets the collection of type-template pairs used for selecting the appropriate DataTemplate based on the type of the item.
+    /// </summary>
+    /// <remarks>
+    /// Items with duplicate <see cref="OrientedImageryViewTemplateSelectorItem.Type"/> are not allowed in this collection. If an item with a duplicate type is added it will replace the existing item with the same type.
+    /// </remarks>
+    public Collection<OrientedImageryViewTemplateSelectorItem> TypeTemplatePairs { get; private set; }
+
+    /// <inheritdoc/>
     public override DataTemplate SelectTemplate(object item, DependencyObject container)
     {
         foreach (var pair in TypeTemplatePairs)
@@ -20,13 +50,21 @@ public class OrientedImageryViewTemplateSelector : DataTemplateSelector
 
         return base.SelectTemplate(item, container);
     }
-
-    public Collection<OrientedImageryViewTemplateSelectorItem> TypeTemplatePairs { get; set; } = new Collection<OrientedImageryViewTemplateSelectorItem>();
 }
+
+/// <summary>
+/// Represents a pair of a <see cref="System.Type"/> and its corresponding <see cref="DataTemplate"/> for use in an <see cref="OrientedImageryViewTemplateSelector"/>.
+/// </summary>
 public class OrientedImageryViewTemplateSelectorItem
 {
+    /// <summary>
+    /// Gets or sets the type associated with this template.
+    /// </summary>
     public Type Type { get; set; } = typeof(object);
+
+    /// <summary>
+    /// Gets or sets the template associated with this type.
+    /// </summary>
     public DataTemplate Template { get; set; } = new DataTemplate();
 }
-
 #endif

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewTemplateSelector.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewTemplateSelector.cs
@@ -8,6 +8,10 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls;
 /// <summary>
 /// A <see cref="DataTemplateSelector"/> to define explicit type-template pairs for the toolbar view models used in the <see cref="OrientedImageryView"/>.
 /// </summary>
+/// <remarks>
+/// An <see cref="OrientedImageryView"/> ensures that its <see cref="OrientedImageryViewTemplateSelector"/> always contains the type-template pairs
+/// for the default toolbar items unless they have been overridden by the user.
+/// </remarks>
 [ContentProperty(nameof(TypeTemplatePairs))]
 public class OrientedImageryViewTemplateSelector : DataTemplateSelector
 {
@@ -49,6 +53,23 @@ public class OrientedImageryViewTemplateSelector : DataTemplateSelector
         }
 
         return base.SelectTemplate(item, container);
+    }
+
+    /// <summary>
+    /// Merges the type-template pairs from another <see cref="OrientedImageryViewTemplateSelector"/> into this instance.
+    /// </summary>
+    /// <remarks>
+    /// If a type on <paramref name="other"/> is already registered on this instance, it will be skipped.
+    /// </remarks>
+    public void Merge(OrientedImageryViewTemplateSelector other)
+    {
+        foreach (var pair in other.TypeTemplatePairs)
+        {
+            if (!TypeTemplatePairs.Any(p => p.Type == pair.Type))
+            {
+                TypeTemplatePairs.Add(pair);
+            }
+        }
     }
 }
 

--- a/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewTemplateSelector.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OrientedImagery/OrientedImageryViewTemplateSelector.cs
@@ -1,0 +1,32 @@
+#if WPF
+
+using System.Windows.Markup;
+using System.Collections.ObjectModel;
+
+namespace Esri.ArcGISRuntime.Toolkit.UI.Controls;
+
+[ContentProperty(nameof(TypeTemplatePairs))]
+public class OrientedImageryViewTemplateSelector : DataTemplateSelector
+{
+    public override DataTemplate SelectTemplate(object item, DependencyObject container)
+    {
+        foreach (var pair in TypeTemplatePairs)
+        {
+            if (pair.Type.IsInstanceOfType(item))
+            {
+                return pair.Template;
+            }
+        }
+
+        return base.SelectTemplate(item, container);
+    }
+
+    public Collection<OrientedImageryViewTemplateSelectorItem> TypeTemplatePairs { get; set; } = new Collection<OrientedImageryViewTemplateSelectorItem>();
+}
+public class OrientedImageryViewTemplateSelectorItem
+{
+    public Type Type { get; set; } = typeof(object);
+    public DataTemplate Template { get; set; } = new DataTemplate();
+}
+
+#endif


### PR DESCRIPTION
Adds the upcoming `OrientedImageryView` control. This control builds on the `OrientedImageDisplay`, from the `dev/orientedimageryview` branch. Where the `OrientedImageDisplay` class handles the low-level details of displaying an oriented image (either planar or 360), the `OrientedImageryView` provides a default preconfigured workflow for users mimicking the oriented imagery UIs provided by Online and Pro.

## Notes
- See the sample for how this control is meant to be used. Also see the [documentation file](https://github.com/Esri/arcgis-maps-sdk-dotnet-toolkit/blob/ian/orientedimageryview-green/docs/oriented-imagery-view.md)
- Includes extracting the custom FeatureFormView.Command class and renaming its members to better align with the definition of the equivalent Maui class

## Data for testing
Esri Campus (Planar): https://services.arcgis.com/2Pv4ow3pE6NFC9SW/arcgis/rest/services/EsriCampus_GoProSample/FeatureServer/0

Hopeful Heights (Panoramic): https://services8.arcgis.com/joda3ARQ9znLf0hf/ArcGIS/rest/services/HopefulHeights_360/FeatureServer/1

There are many more OrientedImageryLayers on AGOL if you filter by layer type. Video and some raster formats are not supported.