### PR TITLE
UITests: Remove old automation workaround as it was breaking the ScaleLine tests on MauiWindows

### DIFF
--- a/src/Tests/UITests/Toolkit.UITests.Maui.App/AppBuilderExtensions.cs
+++ b/src/Tests/UITests/Toolkit.UITests.Maui.App/AppBuilderExtensions.cs
@@ -35,14 +35,14 @@ internal static class AppBuilderExtensions
     /// </summary>
     public static MauiAppBuilder UseWindowsAutomationTreeFix(this MauiAppBuilder builder)
     {
-#if WINDOWS
+#if NEED_WINDOWS_AUTOMATION_TREE_FIX
         Microsoft.Maui.Handlers.ViewHandler.ViewMapper.AppendToMapping(nameof(IView.AutomationId), MapAutomationId);
 #endif
         return builder;
     }
 
 
-#if WINDOWS
+#if NEED_WINDOWS_AUTOMATION_TREE_FIX
     private static void MapAutomationId(IViewHandler handler, IView view)
     {
         // Workaround for https://github.com/dotnet/maui/issues/4715; Layouts, Pages and ContentViews are not exposed in AutomationTree

--- a/src/Tests/UITests/Toolkit.UITests.Maui.App/MainPage.xaml
+++ b/src/Tests/UITests/Toolkit.UITests.Maui.App/MainPage.xaml
@@ -27,6 +27,11 @@
                            Text="undefined" FontSize="12" Margin="0,1,3,1"/>
                     <Label Text="(Runtime Version)" FontSize="12" Margin="1"/>
                 </StackLayout>
+                <StackLayout Orientation="Horizontal">
+                    <Label x:Name="MauiVersionLabel" AutomationId="MauiVersion"
+                           Text="undefined" FontSize="12" Margin="0,1,3,1"/>
+                    <Label Text="(Maui Version)" FontSize="12" Margin="1"/>
+                </StackLayout>
             </StackLayout>
         </ScrollView>
 

--- a/src/Tests/UITests/Toolkit.UITests.Maui.App/MainPage.xaml.cs
+++ b/src/Tests/UITests/Toolkit.UITests.Maui.App/MainPage.xaml.cs
@@ -54,6 +54,10 @@ public partial class MainPage : ContentPage
         var toolkitTypeInfo = typeof(Esri.ArcGISRuntime.Toolkit.Maui.ScaleLine).GetTypeInfo();
         var toolkitVersion = FileVersionInfo.GetVersionInfo(toolkitTypeInfo.Assembly.Location);
         ToolkitVersionLabel.Text = toolkitVersion.FileVersion;
+
+        var mauiTypeInfo = typeof(Microsoft.Maui.Controls.Application).GetTypeInfo();
+        var mauiVersion = FileVersionInfo.GetVersionInfo(mauiTypeInfo.Assembly.Location);
+        MauiVersionLabel.Text = mauiVersion.FileVersion;
 #pragma warning restore IL3000
 #else
         RuntimeVersionLabel.Text = "Not available in Android Release mode";

--- a/src/Tests/UITests/Toolkit.UITests.Maui.App/Toolkit.UITests.Maui.App.csproj
+++ b/src/Tests/UITests/Toolkit.UITests.Maui.App/Toolkit.UITests.Maui.App.csproj
@@ -19,6 +19,7 @@
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <DefineConstants>$(DefineConstants);MAUI_APP</DefineConstants>
+    <DefineConstants Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows' And $([MSBuild]::VersionLessThanOrEquals('$(MauiVersion)', '10.0.71'))">$(DefineConstants);NEED_WINDOWS_AUTOMATION_TREE_FIX</DefineConstants>
 
     <!-- Display name -->
     <ApplicationTitle>Toolkit.UITests.Maui.App</ApplicationTitle>


### PR DESCRIPTION
The [maui issue](https://github.com/dotnet/maui/issues/4715) was solved in 10.0.80, and the workaround seems to have broken the scale line tests once we started in MauiVersion 10.0.80. This PR avoids the automation fix when MauiVersion is >= 10.0.80. It also adds MauiVersion to the list of versions in the Maui app for help with manual troubleshooting