### PR TITLE
Address a couple UI test nullability warnings

### DIFF
--- a/src/Tests/UITests/Toolkit.UITests.TestPages.Shared/SearchView/SearchViewCustomization.xaml.cs
+++ b/src/Tests/UITests/Toolkit.UITests.TestPages.Shared/SearchView/SearchViewCustomization.xaml.cs
@@ -120,8 +120,8 @@ public partial class SearchViewCustomization : TestPage
             _onDeselected = onDeselected;
         }
         public string DisplayName { get => "Event tester"; set => throw new NotImplementedException(); }
-        public string Placeholder { get => "Test placeholder"; set => throw new NotImplementedException(); }
-        public CalloutDefinition DefaultCalloutDefinition { get => null; set => throw new NotImplementedException(); }
+        public string? Placeholder { get => "Test placeholder"; set => throw new NotImplementedException(); }
+        public CalloutDefinition? DefaultCalloutDefinition { get => null; set => throw new NotImplementedException(); }
         public double DefaultZoomScale { get => 1000; set => throw new NotImplementedException(); }
         public int MaximumResults { get => 3; set => throw new NotImplementedException(); }
         public int MaximumSuggestions { get => 3; set => throw new NotImplementedException(); }


### PR DESCRIPTION
The `ISearchSource` interface was complaining about nullable types