### PR TITLE
UITests: Fix screenshot rotation on iOS and increase color tolerance for identifying Compass north arrow

### DIFF
--- a/src/Tests/UITests/Toolkit.UITests.Shared/Appium/AppiumTestBase.ImageAnalysis.cs
+++ b/src/Tests/UITests/Toolkit.UITests.Shared/Appium/AppiumTestBase.ImageAnalysis.cs
@@ -16,7 +16,12 @@ public abstract partial class AppiumTestBase
     protected MagickImage GetScreenshot(AppiumElement element)
     {
         var screenshot = element.GetScreenshot();
-        return new MagickImage(screenshot.AsByteArray);
+        var magickScreenshot = new MagickImage(screenshot.AsByteArray);
+
+        // Make sure exif rotation metadata does not skew results
+        magickScreenshot.AutoOrient();
+
+        return magickScreenshot;
     }
 
     /// <summary>

--- a/src/Tests/UITests/Toolkit.UITests.Shared/Tests/Compass/CompassTests.cs
+++ b/src/Tests/UITests/Toolkit.UITests.Shared/Tests/Compass/CompassTests.cs
@@ -125,7 +125,7 @@ public class CompassTests : AppiumTestBase
     private static CompassAnalysis AnalyzeCompassOrientation(MagickImage compassScreenshot)
     {
         // Mask to only red pixels (aka the north arrow).
-        compassScreenshot.ColorThreshold(new MagickColor(128, 0, 0), new MagickColor(255, 80, 80));
+        compassScreenshot.ColorThreshold(new MagickColor(100, 0, 0), new MagickColor(255, 80, 80));
 
         var connectedComponents = compassScreenshot.ConnectedComponents(4);
         var componentCount = Math.Max(0, connectedComponents.Count - 1);

--- a/src/Tests/UITests/Toolkit.UITests.Shared/Tests/Compass/CompassTests.cs
+++ b/src/Tests/UITests/Toolkit.UITests.Shared/Tests/Compass/CompassTests.cs
@@ -124,9 +124,6 @@ public class CompassTests : AppiumTestBase
 
     private static CompassAnalysis AnalyzeCompassOrientation(MagickImage compassScreenshot)
     {
-        // Make sure exif rotation metadata does not skew results
-        compassScreenshot.AutoOrient();
-
         // Mask to only red pixels (aka the north arrow).
         compassScreenshot.ColorThreshold(new MagickColor(100, 0, 0), new MagickColor(255, 80, 80));
 

--- a/src/Tests/UITests/Toolkit.UITests.Shared/Tests/Compass/CompassTests.cs
+++ b/src/Tests/UITests/Toolkit.UITests.Shared/Tests/Compass/CompassTests.cs
@@ -124,6 +124,9 @@ public class CompassTests : AppiumTestBase
 
     private static CompassAnalysis AnalyzeCompassOrientation(MagickImage compassScreenshot)
     {
+        // Make sure exif rotation metadata does not skew results
+        compassScreenshot.AutoOrient();
+
         // Mask to only red pixels (aka the north arrow).
         compassScreenshot.ColorThreshold(new MagickColor(100, 0, 0), new MagickColor(255, 80, 80));
 


### PR DESCRIPTION
The Compass_Rotates (Heading Bound) test was failing consistently on Mac in the daily tests. Increasing the tolerance helped the test pass on the CI machine. In the process of testing, it seemed that iOS was failing all compass tests on a particular device. This was apparently due to problems with rotation metadata, hence the fix being to call AutoOrient.