### PR TITLE
Fix FeatureForm attachment element rendering and header layout in WPF, WinUI, and MAUI

### DIFF
--- a/src/Toolkit/Toolkit.WPF/UI/Controls/FeatureForm/FeatureFormView.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/FeatureForm/FeatureFormView.Theme.xaml
@@ -457,7 +457,7 @@
                                 <ColumnDefinition Width="Auto" />
                             </Grid.ColumnDefinitions>
                             <TextBlock Text="{Binding Label}" Visibility="{Binding Label, Converter={StaticResource FeatureFormViewVisibilityConverter}}" Style="{StaticResource FeatureFormViewTitleStyle}" />
-                            <TextBlock Text="{Binding Description}" Visibility="{Binding Description, Converter={StaticResource FeatureFormViewVisibilityConverter}}" Opacity=".7" Style="{StaticResource FeatureFormViewCaptionStyle}" />
+                            <TextBlock Text="{Binding Description}" Visibility="{Binding Description, Converter={StaticResource FeatureFormViewVisibilityConverter}}" Opacity=".7" Style="{StaticResource FeatureFormViewCaptionStyle}" Grid.Row="1" />
                             <Button x:Name="AddAttachmentButton" BorderThickness="0" Background="Transparent" HorizontalAlignment="Stretch" HorizontalContentAlignment="Left" 
                                     Visibility="{Binding IsEditable, Converter={StaticResource FeatureFormViewVisibilityConverter}}" Padding="5" Cursor="Hand" Grid.Column="1" Grid.RowSpan="2">
                                     <TextBlock Text="" FontFamily="Segoe MDL2 Assets" />
@@ -782,6 +782,11 @@
                                                 <primitives:UtilityAssociationsFormElementView Element="{Binding}" />
                                             </DataTemplate>
                                         </primitives:FormElementItemsControl.UtilityAssociationsFormElementTemplate>
+                                        <primitives:FormElementItemsControl.AttachmentsFormElementTemplate>
+                                          <DataTemplate>
+                                            <primitives:AttachmentsFormElementView Element="{Binding}" />
+                                          </DataTemplate>
+                                        </primitives:FormElementItemsControl.AttachmentsFormElementTemplate>
                                         <primitives:FormElementItemsControl.GroupFormElementTemplate>
                                             <DataTemplate>
                                                 <StackPanel Visibility="{Binding IsVisible, Converter={StaticResource FeatureFormViewVisibilityConverter}}" >
@@ -808,6 +813,11 @@
                                                                     <primitives:UtilityAssociationsFormElementView Element="{Binding}" />
                                                                 </DataTemplate>
                                                             </primitives:FormElementItemsControl.UtilityAssociationsFormElementTemplate>
+                                                            <primitives:FormElementItemsControl.AttachmentsFormElementTemplate>
+                                                              <DataTemplate>
+                                                                <primitives:AttachmentsFormElementView Element="{Binding}" />
+                                                              </DataTemplate>
+                                                            </primitives:FormElementItemsControl.AttachmentsFormElementTemplate>
                                                         </primitives:FormElementItemsControl>
                                                     </Expander>
                                                 </StackPanel>

--- a/src/Toolkit/Toolkit.WinUI/UI/Controls/FeatureForm/FeatureForm.Theme.xaml
+++ b/src/Toolkit/Toolkit.WinUI/UI/Controls/FeatureForm/FeatureForm.Theme.xaml
@@ -308,7 +308,7 @@
                                 <ColumnDefinition Width="Auto" />
                             </Grid.ColumnDefinitions>
                             <TextBlock Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Element.Label}" Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Element.Label, Converter={StaticResource FeatureFormViewVisibilityConverter}}" Style="{StaticResource FeatureFormViewTitleStyle}" />
-                            <TextBlock Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Element.Description}" Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Element.Description, Converter={StaticResource FeatureFormViewVisibilityConverter}}" Opacity=".7" Style="{StaticResource FeatureFormViewCaptionStyle}" />
+                            <TextBlock Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Element.Description}" Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Element.Description, Converter={StaticResource FeatureFormViewVisibilityConverter}}" Opacity=".7" Style="{StaticResource FeatureFormViewCaptionStyle}" Grid.Row="1" />
                             <Button x:Name="AddAttachmentButton" BorderThickness="0" Background="Transparent" HorizontalAlignment="Stretch" HorizontalContentAlignment="Left" 
                                  Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Element.IsEditable, Converter={StaticResource FeatureFormViewVisibilityConverter}}" Padding="5" Grid.Column="1" Grid.RowSpan="2">
                                 <TextBlock Text="" FontFamily="Segoe MDL2 Assets" />
@@ -623,6 +623,11 @@
                                                             <primitives:UtilityAssociationsFormElementView Element="{Binding}" />
                                                         </DataTemplate>
                                                     </primitives:FormElementItemsControl.UtilityAssociationsFormElementTemplate>
+                                                    <primitives:FormElementItemsControl.AttachmentsFormElementTemplate>
+                                                        <DataTemplate>
+                                                            <primitives:AttachmentsFormElementView Element="{Binding}" />
+                                                        </DataTemplate>
+                                                    </primitives:FormElementItemsControl.AttachmentsFormElementTemplate>
                                                     <primitives:FormElementItemsControl.GroupFormElementTemplate>
                                                         <DataTemplate>
                                                             <StackPanel Visibility="{Binding IsVisible, Converter={StaticResource FeatureFormViewVisibilityConverter}}" >
@@ -649,6 +654,11 @@
                                                                                 <primitives:UtilityAssociationsFormElementView Element="{Binding}" />
                                                                             </DataTemplate>
                                                                         </primitives:FormElementItemsControl.UtilityAssociationsFormElementTemplate>
+                                                                        <primitives:FormElementItemsControl.AttachmentsFormElementTemplate>
+                                                                            <DataTemplate>
+                                                                                <primitives:AttachmentsFormElementView Element="{Binding}" />
+                                                                            </DataTemplate>
+                                                                        </primitives:FormElementItemsControl.AttachmentsFormElementTemplate>
                                                                     </primitives:FormElementItemsControl>
                                                                 </Expander>
                                                             </StackPanel>

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FeatureFormElementTemplateSelector.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FeatureFormElementTemplateSelector.cs
@@ -28,6 +28,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui
         private static DataTemplate DefaultGroupElementTemplate;
         private static DataTemplate DefaultTextFormElementTemplate;
         private static DataTemplate DefaultUtilityAssociationsFormElementTemplate;
+        private static DataTemplate DefaultAttachmentsFormElementTemplate;
         private static DataTemplate UnsupportedFormElementTemplate;
 
         [DynamicDependency(nameof(Esri.ArcGISRuntime.Mapping.FeatureForms.FormElement.IsVisible), "Esri.ArcGISRuntime.Mapping.FeatureForms.FormElement", "Esri.ArcGISRuntime")]
@@ -62,6 +63,12 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui
                 view.SetBinding(UtilityAssociationsFormElementView.ElementProperty, Binding.SelfPath);
                 return view;
             });
+            DefaultAttachmentsFormElementTemplate = new DataTemplate(() =>
+            {
+                var view = new AttachmentsFormElementView() { Margin = new Thickness(0, 0, 0, 10) };
+                view.SetBinding(AttachmentsFormElementView.ElementProperty, Binding.SelfPath);
+                return view;
+            });
             UnsupportedFormElementTemplate = new DataTemplate(() =>
             {
                 return new Grid() { IsVisible = false };
@@ -74,6 +81,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui
             GroupFormElementTemplate = DefaultGroupElementTemplate;
             TextFormElementTemplate = DefaultTextFormElementTemplate;
             UtilityAssociationsFormElementTemplate = DefaultUtilityAssociationsFormElementTemplate;
+            AttachmentsFormElementTemplate = DefaultAttachmentsFormElementTemplate;
         }
 
         public DataTemplate FieldFormElementTemplate { get; set; }
@@ -83,6 +91,8 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui
         public DataTemplate TextFormElementTemplate { get; set; }
 
         public DataTemplate UtilityAssociationsFormElementTemplate { get; set; }
+
+        public DataTemplate AttachmentsFormElementTemplate { get; set; }
 
         protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
         {
@@ -101,6 +111,10 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui
             else if (item is UtilityAssociationsFormElement)
             {
                 return UtilityAssociationsFormElementTemplate;
+            }
+            else if (item is AttachmentsFormElement)
+            {
+                return AttachmentsFormElementTemplate;
             }
             return UnsupportedFormElementTemplate; // Renders empty / skips
         }

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FormElementItemsControl.Windows.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FormElementItemsControl.Windows.cs
@@ -50,6 +50,10 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                 {
                     presenter.ContentTemplate = UtilityAssociationsFormElementTemplate;
                 }
+                else if (item is AttachmentsFormElement)
+                {
+                    presenter.ContentTemplate = AttachmentsFormElementTemplate;
+                }
                 else
                 {
                     presenter.ContentTemplate = UnsupportedFormElementTemplate; // Renders empty / skips
@@ -122,6 +126,23 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
         /// </summary>
         public static readonly DependencyProperty UtilityAssociationsFormElementTemplateProperty =
             DependencyProperty.Register(nameof(UtilityAssociationsFormElementTemplate), typeof(DataTemplate), typeof(FormElementItemsControl), new PropertyMetadata(null));
+
+        /// <summary>
+        /// Template used for rendering an <see cref="AttachmentsFormElement"/>.
+        /// </summary>
+        /// <seealso cref="AttachmentsFormElement"/>
+        /// <seealso cref="AttachmentsFormElementView"/>
+        public DataTemplate AttachmentsFormElementTemplate
+        {
+            get { return (DataTemplate)GetValue(AttachmentsFormElementTemplateProperty); }
+            set { SetValue(AttachmentsFormElementTemplateProperty, value); }
+        }
+
+        /// <summary>
+        /// Identifies the <see cref="AttachmentsFormElementTemplate"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty AttachmentsFormElementTemplateProperty =
+            DependencyProperty.Register(nameof(AttachmentsFormElementTemplate), typeof(DataTemplate), typeof(FormElementItemsControl), new PropertyMetadata(null));
     }
 }
 #endif


### PR DESCRIPTION
Issue: Attachment form elements are not rendering on all platforms. 
Repro: Replace the map in feature form sample with https://runtimecoretest.maps.arcgis.com/home/item.html?id=7064081d2d1a4af6b871d35954417e5e and select the feature on map to open it's form

- Added explicit rendering support for `AttachmentsFormElement` in the Windows form-element host so attachment elements are no longer skipped.
- Wired attachment element templates into both top-level and grouped form element pipelines
- Added MAUI selector support for `AttachmentsFormElement`
- Fixed attachment header label/description overlap in WPF and WinUI attachment element templates.
