### PR TITLE
[Feature Form] [Attachments]: DisplayFilename changes

### DIFF
--- a/src/Toolkit/Toolkit.WPF/UI/Controls/FeatureForm/FeatureFormView.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/FeatureForm/FeatureFormView.Theme.xaml
@@ -430,7 +430,8 @@
                         </VisualStateManager.VisualStateGroups>
                         <Grid>
                             <Image x:Name="ThumbnailImage" />
-                            <Border x:Name="NameBackground" CornerRadius="0,0,4,4" Background="Transparent" VerticalAlignment="Bottom" Padding="2">
+                            <Border x:Name="NameBackground" CornerRadius="0,0,4,4" Background="Transparent" VerticalAlignment="Bottom" Padding="2"
+                                Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Element.DisplayFilename, Converter={StaticResource FeatureFormViewVisibilityConverter}}">
                                 <TextBlock x:Name="AttachmentName" Text="{Binding Name}" VerticalAlignment="Bottom" HorizontalAlignment="Center" FontSize="10" TextTrimming="CharacterEllipsis" />
                             </Border>
                             <TextBlock x:Name="FileSizeText" Text="{Binding Size, Converter={StaticResource FeatureFormFileSizeConverter}}" VerticalAlignment="Top" HorizontalAlignment="Center" FontSize="10" />

--- a/src/Toolkit/Toolkit.WinUI/UI/Controls/FeatureForm/FeatureForm.Theme.xaml
+++ b/src/Toolkit/Toolkit.WinUI/UI/Controls/FeatureForm/FeatureForm.Theme.xaml
@@ -280,7 +280,8 @@
                         </VisualStateManager.VisualStateGroups>
                         <Grid>
                             <Image x:Name="ThumbnailImage" />
-                            <Border x:Name="NameBackground" CornerRadius="0,0,4,4" Background="Transparent" VerticalAlignment="Bottom" Padding="2">
+                            <Border x:Name="NameBackground" CornerRadius="0,0,4,4" Background="Transparent" VerticalAlignment="Bottom" Padding="2"
+                                    Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Element.DisplayFilename, Converter={StaticResource FeatureFormViewVisibilityConverter}}">
                                 <TextBlock x:Name="AttachmentName" Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Attachment.Name}" VerticalAlignment="Bottom" HorizontalAlignment="Center" FontSize="10" TextTrimming="CharacterEllipsis" />
                             </Border>
                             <TextBlock x:Name="FileSizeText" Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Attachment.Size, Converter={StaticResource FeatureFormFileSizeConverter}}" VerticalAlignment="Top" HorizontalAlignment="Center" FontSize="10" />

--- a/src/Toolkit/Toolkit.WinUI/UI/Controls/FeatureForm/FeatureForm.Theme.xaml
+++ b/src/Toolkit/Toolkit.WinUI/UI/Controls/FeatureForm/FeatureForm.Theme.xaml
@@ -323,8 +323,8 @@
                                     </ItemsPanelTemplate>
                                 </ItemsControl.ItemsPanel>
                                 <ItemsControl.ItemTemplate>
-                                    <DataTemplate>
-                                        <primitives:FormAttachmentView Attachment="{Binding}" Element="{Binding ElementName=AttachmentItemsControl, Path=DataContext}" />
+                                    <DataTemplate x:DataType="forms:FormAttachment">
+                                        <primitives:FormAttachmentView Attachment="{x:Bind}" Element="{Binding ElementName=AttachmentItemsControl, Path=DataContext}" />
                                     </DataTemplate>
                                 </ItemsControl.ItemTemplate>
                             </ItemsControl>

--- a/src/Toolkit/Toolkit.WinUI/UI/Controls/FeatureForm/FeatureForm.Theme.xaml
+++ b/src/Toolkit/Toolkit.WinUI/UI/Controls/FeatureForm/FeatureForm.Theme.xaml
@@ -316,7 +316,7 @@
                             </Button>
                         </Grid>
                         <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Disabled" x:Name="ItemsScrollView">
-                            <ItemsControl ItemsSource="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Element.Attachments}" IsEnabled="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Element.IsEditable}">
+                            <ItemsControl x:Name="AttachmentItemsControl" ItemsSource="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Element.Attachments}" IsEnabled="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Element.IsEditable}">
                                 <ItemsControl.ItemsPanel>
                                     <ItemsPanelTemplate>
                                         <StackPanel Orientation="Horizontal" />
@@ -324,7 +324,7 @@
                                 </ItemsControl.ItemsPanel>
                                 <ItemsControl.ItemTemplate>
                                     <DataTemplate>
-                                        <primitives:FormAttachmentView Attachment="{Binding}" Element="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Element}" />
+                                        <primitives:FormAttachmentView Attachment="{Binding}" Element="{Binding ElementName=AttachmentItemsControl, Path=DataContext}" />
                                     </DataTemplate>
                                 </ItemsControl.ItemTemplate>
                             </ItemsControl>

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FormAttachmentView.Maui.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FormAttachmentView.Maui.cs
@@ -46,6 +46,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
             Border nameBackground = new Border() { BackgroundColor = Colors.Transparent, Padding = new Thickness(2), VerticalOptions = LayoutOptions.End, StrokeThickness = 0 };
             var nameLabel = new Label() { HorizontalOptions = LayoutOptions.Center, FontSize = 10, MaxLines = 1, LineBreakMode = LineBreakMode.TailTruncation };
             nameBackground.Content = nameLabel;
+            nameBackground.SetBinding(VisualElement.IsVisibleProperty, static (FormAttachmentView view) => view.Element?.DisplayFilename, source: RelativeBindingSource.TemplatedParent, converter: BoolOrNullToBoolConverter.Instance);
             nameLabel.SetBinding(Label.TextProperty, static (FormAttachmentView view) => view.Attachment?.Name, source: RelativeBindingSource.TemplatedParent);
             root.Children.Add(nameBackground);
             var sizeLabel = new Label() { VerticalOptions = LayoutOptions.Start, HorizontalOptions = LayoutOptions.Center, FontSize = 10, MaxLines = 1 };


### PR DESCRIPTION
Changes are related to the [recent attachment enhancements](https://devtopia.esri.com/runtime/dotnet-api/issues/14577). Creating small feature wise PRs for easy review

Displays the file name in attachments thumbnail only if `DisplayFilename` value is true

Note: 
Webmap used for testing - https://runtimecoretest.maps.arcgis.com/home/item.html?id=7064081d2d1a4af6b871d35954417e5e
The changes from [this PR](https://github.com/Esri/arcgis-maps-sdk-dotnet-toolkit/pull/793) should be merged into the current branch for testing

https://github.com/user-attachments/assets/78d015f4-c9e5-4b66-a92f-b573b1bc79f7



