### PR TITLE
[Feature Form] [Attachments]:  AllowUserRename changes

### DIFF
--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FormAttachmentView.Maui.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FormAttachmentView.Maui.cs
@@ -69,6 +69,16 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
 
         [SupportedOSPlatform("windows")]
         [SupportedOSPlatform("maccatalyst")]
+        private void FormAttachmentView_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(Element))
+            {
+                ConfigureFlyout();
+            }
+        }
+
+        [SupportedOSPlatform("windows")]
+        [SupportedOSPlatform("maccatalyst")]
         private void ConfigureFlyout()
         {
             MenuFlyout flyout = new MenuFlyout();
@@ -77,15 +87,19 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
                 Text = Properties.Resources.GetString("FeatureFormRemoveAttachmentMenuItem"),
                 IconImageSource = new FontImageSource { Glyph = ToolkitIcons.Trash, FontFamily = ToolkitIcons.FontFamilyName, Size = 32, Color = Colors.Gray }
             });
-            flyout.Add(new MenuFlyoutItem()
+            var renameItem = new MenuFlyoutItem()
             {
                 Text = Properties.Resources.GetString("FeatureFormRenameAttachmentMenuItem"),
                 IconImageSource = new FontImageSource { Glyph = ToolkitIcons.Pencil, FontFamily = ToolkitIcons.FontFamilyName, Size = 32, Color = Colors.Gray }
-            });
+            };
+            if (Element?.AllowUserRename == true)
+            {
+                flyout.Add(renameItem);
+            }
 
             ((MenuFlyoutItem)flyout[0]).Clicked += (s, e) => DeleteAttachment();
 
-            ((MenuFlyoutItem)flyout[1]).Clicked += async (s, e) =>
+            renameItem.Clicked += async (s, e) =>
             {
                 if (Attachment is not null && Element is not null && GetPage() is Page page)
                 {
@@ -233,14 +247,16 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
             if (page is null) return false;
 
             string delete = Properties.Resources.GetString("FeatureFormRemoveAttachmentMenuItem")!;
-            string rename = Properties.Resources.GetString("FeatureFormRenameAttachmentMenuItem")!;
             string open = Properties.Resources.GetString("FeatureFormOpenAttachmentMenuItem")!;
-            var result = await page.DisplayActionSheet(Attachment.Name, null, null, delete, rename, open);
+            string? rename = Element?.AllowUserRename == true ? Properties.Resources.GetString("FeatureFormRenameAttachmentMenuItem")! : null;
+            var result = rename is not null
+                ? await page.DisplayActionSheet(Attachment.Name, null, null, delete, rename, open)
+                : await page.DisplayActionSheet(Attachment.Name, null, null, delete, open);
             if (result == delete)
             {
                 DeleteAttachment();
             }
-            else if(result == rename)
+            else if(rename is not null && result == rename)
             {
                 try
                 {

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FormAttachmentView.Maui.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FormAttachmentView.Maui.cs
@@ -249,7 +249,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
             string delete = Properties.Resources.GetString("FeatureFormRemoveAttachmentMenuItem")!;
             string open = Properties.Resources.GetString("FeatureFormOpenAttachmentMenuItem")!;
             string? rename = Element?.AllowUserRename == true ? Properties.Resources.GetString("FeatureFormRenameAttachmentMenuItem")! : null;
-            var result = rename is not null
+            var result = Element?.AllowUserRename == true
                 ? await page.DisplayActionSheetAsync(Attachment.Name, null, null, delete, rename, open)
                 : await page.DisplayActionSheetAsync(Attachment.Name, null, null, delete, open);
 

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FormAttachmentView.Windows.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FormAttachmentView.Windows.cs
@@ -92,54 +92,58 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                 Header = Properties.Resources.GetString("FeatureFormRemoveAttachmentMenuItem"),
                 Icon = new TextBlock() { Text = "\uE74D", HorizontalAlignment = HorizontalAlignment.Center, VerticalAlignment = VerticalAlignment.Center, FontFamily = new FontFamily("Segoe MDL2 Assets") }
             });
-            contextMenu.Items.Add(new MenuItem()
-            {
-                Header = Properties.Resources.GetString("FeatureFormRenameAttachmentMenuItem"),
-                Icon = new TextBlock() { Text = "\uE70F", HorizontalAlignment = HorizontalAlignment.Center, VerticalAlignment = VerticalAlignment.Center, FontFamily = new FontFamily("Segoe MDL2 Assets") }
-            });
             
             ((MenuItem)contextMenu.Items[0]).Click += (s, e) =>
             {
                 DeleteAttachment();
             };
-            
-            ((MenuItem)contextMenu.Items[1]).Click += (s, e) =>
+
+            if (Element?.AllowUserRename == true)
             {
-                if (Attachment is not null && Element is not null)
+                var renameItem = new MenuItem()
                 {
-                    Window renameDialog = new Window()
+                    Header = Properties.Resources.GetString("FeatureFormRenameAttachmentMenuItem"),
+                    Icon = new TextBlock() { Text = "\uE70F", HorizontalAlignment = HorizontalAlignment.Center, VerticalAlignment = VerticalAlignment.Center, FontFamily = new FontFamily("Segoe MDL2 Assets") }
+                };
+                renameItem.Click += (s, e) =>
+                {
+                    if (Attachment is not null && Element is not null)
                     {
-                        SizeToContent = SizeToContent.Height,
-                        WindowStartupLocation = WindowStartupLocation.CenterOwner,
-                        Owner = Window.GetWindow(this),
-                        WindowStyle = WindowStyle.ToolWindow, Width = 250,
-                        Title = Properties.Resources.GetString("FeatureFormRenameAttachmentWindowTitle")
-                    };
-                    StackPanel panel = new StackPanel() { Margin = new Thickness(10) };
-                    TextBox textBox = new TextBox() { Text = Attachment.Name };
-                    panel.Children.Add(textBox);
+                        Window renameDialog = new Window()
+                        {
+                            SizeToContent = SizeToContent.Height,
+                            WindowStartupLocation = WindowStartupLocation.CenterOwner,
+                            Owner = Window.GetWindow(this),
+                            WindowStyle = WindowStyle.ToolWindow, Width = 250,
+                            Title = Properties.Resources.GetString("FeatureFormRenameAttachmentWindowTitle")
+                        };
+                        StackPanel panel = new StackPanel() { Margin = new Thickness(10) };
+                        TextBox textBox = new TextBox() { Text = Attachment.Name };
+                        panel.Children.Add(textBox);
 
-                    StackPanel panel2 = new StackPanel() { Orientation = Orientation.Horizontal, HorizontalAlignment = HorizontalAlignment.Right, Margin = new Thickness(0, 10, 0, 0) };
-                    Button okButton = new Button() { Content = Properties.Resources.GetString("FeatureFormRenameAttachmentDialogOK"), MinWidth = 75, IsDefault = true, Margin = new Thickness(0, 0, 10, 0), IsEnabled = false };
-                    okButton.Click += (s,e) => renameDialog.DialogResult = true;
-                    Button cancelButton = new Button() { Content = Properties.Resources.GetString("FeatureFormRenameAttachmentDialogCancel"), MinWidth = 75, IsCancel = true };
-                    panel2.Children.Add(okButton);
-                    panel2.Children.Add(cancelButton);
-                    panel.Children.Add(panel2);
-                    renameDialog.Content = panel;
+                        StackPanel panel2 = new StackPanel() { Orientation = Orientation.Horizontal, HorizontalAlignment = HorizontalAlignment.Right, Margin = new Thickness(0, 10, 0, 0) };
+                        Button okButton = new Button() { Content = Properties.Resources.GetString("FeatureFormRenameAttachmentDialogOK"), MinWidth = 75, IsDefault = true, Margin = new Thickness(0, 0, 10, 0), IsEnabled = false };
+                        okButton.Click += (s,e) => renameDialog.DialogResult = true;
+                        Button cancelButton = new Button() { Content = Properties.Resources.GetString("FeatureFormRenameAttachmentDialogCancel"), MinWidth = 75, IsCancel = true };
+                        panel2.Children.Add(okButton);
+                        panel2.Children.Add(cancelButton);
+                        panel.Children.Add(panel2);
+                        renameDialog.Content = panel;
 
-                    textBox.TextChanged += (s, e) =>
-                    {
-                        okButton.IsEnabled = !string.IsNullOrEmpty(textBox.Text.Trim()) && textBox.Text.Trim() != Attachment.Name;
-                    };
-                    bool? ok = renameDialog.ShowDialog();
+                        textBox.TextChanged += (s, e) =>
+                        {
+                            okButton.IsEnabled = !string.IsNullOrEmpty(textBox.Text.Trim()) && textBox.Text.Trim() != Attachment.Name;
+                        };
+                        bool? ok = renameDialog.ShowDialog();
 
-                    if(ok.HasValue && ok.Value == true && !string.IsNullOrEmpty(textBox.Text.Trim()))
-                    {
-                        RenameAttachment(textBox.Text.Trim());
+                        if(ok.HasValue && ok.Value == true && !string.IsNullOrEmpty(textBox.Text.Trim()))
+                        {
+                            RenameAttachment(textBox.Text.Trim());
+                        }
                     }
-                }
-            };
+                };
+                contextMenu.Items.Add(renameItem);
+            }
             contextMenu.PlacementTarget = this;
             contextMenu.IsOpen = true;
 #elif WINDOWS_XAML
@@ -151,38 +155,41 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
             };
             delete.Click += (s, e) => DeleteAttachment();
             contextMenu.Items.Add(delete);
-            var rename = new MenuFlyoutItem()
+            if (Element?.AllowUserRename == true)
             {
-                Text = Properties.Resources.GetString("FeatureFormRenameAttachmentMenuItem"),
-                Icon = new SymbolIcon(Symbol.Rename),
-            };
-            contextMenu.Items.Add(rename);
-            rename.Click += (s,e) => {
-                if (Attachment is not null && Element is not null)
+                var rename = new MenuFlyoutItem()
                 {
-                    var dialog = new ContentDialog()
+                    Text = Properties.Resources.GetString("FeatureFormRenameAttachmentMenuItem"),
+                    Icon = new SymbolIcon(Symbol.Rename),
+                };
+                contextMenu.Items.Add(rename);
+                rename.Click += (s,e) => {
+                    if (Attachment is not null && Element is not null)
                     {
-                        Title = Properties.Resources.GetString("FeatureFormRenameAttachmentWindowTitle"),
-                        PrimaryButtonText = Properties.Resources.GetString("FeatureFormRenameAttachmentDialogOK"),
-                        SecondaryButtonText = Properties.Resources.GetString("FeatureFormRenameAttachmentDialogCancel"),
-                        DefaultButton = ContentDialogButton.Primary,
-                        Content = new TextBox() { Text = Attachment.Name },
+                        var dialog = new ContentDialog()
+                        {
+                            Title = Properties.Resources.GetString("FeatureFormRenameAttachmentWindowTitle"),
+                            PrimaryButtonText = Properties.Resources.GetString("FeatureFormRenameAttachmentDialogOK"),
+                            SecondaryButtonText = Properties.Resources.GetString("FeatureFormRenameAttachmentDialogCancel"),
+                            DefaultButton = ContentDialogButton.Primary,
+                            Content = new TextBox() { Text = Attachment.Name },
 #if WINDOWS_XAML
-                        XamlRoot = this.XamlRoot
+                            XamlRoot = this.XamlRoot
 #endif
-                    };
-                    var textBox = (TextBox)dialog.Content;
-                    textBox.TextChanged += (s, e) =>
-                    {
-                        dialog.IsPrimaryButtonEnabled = !string.IsNullOrEmpty(textBox.Text.Trim()) && textBox.Text.Trim() != Attachment.Name;
-                    };
-                    dialog.PrimaryButtonClick += (s, e) =>
-                    {
-                        RenameAttachment(textBox.Text.Trim());
-                    };
-                    _ = dialog.ShowAsync();
-                }
-            };
+                        };
+                        var textBox = (TextBox)dialog.Content;
+                        textBox.TextChanged += (s, e) =>
+                        {
+                            dialog.IsPrimaryButtonEnabled = !string.IsNullOrEmpty(textBox.Text.Trim()) && textBox.Text.Trim() != Attachment.Name;
+                        };
+                        dialog.PrimaryButtonClick += (s, e) =>
+                        {
+                            RenameAttachment(textBox.Text.Trim());
+                        };
+                        _ = dialog.ShowAsync();
+                    }
+                };
+            }
 
             contextMenu.ShowAt(this);
 #endif

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FormAttachmentView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FormAttachmentView.cs
@@ -55,6 +55,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
             tapGestureRecognizer.Tapped += TapGestureRecognizer_Tapped;
             GestureRecognizers.Add(tapGestureRecognizer);
 #if WINDOWS || MACCATALYST
+            PropertyChanged += FormAttachmentView_PropertyChanged;
             ConfigureFlyout();
 #endif
 #else
@@ -109,7 +110,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
 
         private void RenameAttachment(string newName)
         {
-            if (Attachment != null && Attachment.Name != newName)
+            if (Element?.AllowUserRename == true && Attachment != null && Attachment.Name != newName)
             {
                 Attachment.Name = newName;
                 var view = FeatureFormView.GetFeatureFormViewParent(this);


### PR DESCRIPTION
Changes are related to the [recent attachment enhancements](https://devtopia.esri.com/runtime/dotnet-api/issues/14577). Creating small feature wise PRs for easy review

Shows/ allows the user to rename the attachments only if `AllowUserRename` value is true

Note:
Webmap used for testing - https://runtimecoretest.maps.arcgis.com/home/item.html?id=7064081d2d1a4af6b871d35954417e5e
The changes from https://github.com/Esri/arcgis-maps-sdk-dotnet-toolkit/pull/793 should be merged into the current branch for testing. Also, there is a binding issue in WinUI which is fixed in [this PR](https://github.com/Esri/arcgis-maps-sdk-dotnet-toolkit/pull/798)


https://github.com/user-attachments/assets/dd1a5c15-1cce-484f-aaf4-4dad4616b230

