### PR TITLE
[Feature Form] [Attachments]: Disable add attachment button at max count

### DIFF
--- a/src/Toolkit/Toolkit.WinUI/UI/Controls/FeatureForm/FeatureForm.Theme.xaml
+++ b/src/Toolkit/Toolkit.WinUI/UI/Controls/FeatureForm/FeatureForm.Theme.xaml
@@ -309,7 +309,7 @@
                             </Grid.ColumnDefinitions>
                             <TextBlock Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Element.Label}" Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Element.Label, Converter={StaticResource FeatureFormViewVisibilityConverter}}" Style="{StaticResource FeatureFormViewTitleStyle}" />
                             <TextBlock Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Element.Description}" Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Element.Description, Converter={StaticResource FeatureFormViewVisibilityConverter}}" Opacity=".7" Style="{StaticResource FeatureFormViewCaptionStyle}" />
-                            <Button x:Name="AddAttachmentButton" BorderThickness="0" Background="Transparent" HorizontalAlignment="Stretch" HorizontalContentAlignment="Left" 
+                            <Button x:Name="AddAttachmentButton" BorderThickness="0" HorizontalAlignment="Stretch" HorizontalContentAlignment="Left" 
                                  Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Element.IsEditable, Converter={StaticResource FeatureFormViewVisibilityConverter}}" Padding="5" Grid.Column="1" Grid.RowSpan="2">
                                 <TextBlock Text="" FontFamily="Segoe MDL2 Assets" />
                             </Button>

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/AttachmentsFormElementView.Maui.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/AttachmentsFormElementView.Maui.cs
@@ -32,6 +32,8 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
         private static readonly ControlTemplate DefaultControlTemplate;
         private const string AttachmentsListViewName = "AttachmentsListView";
         private const string AddAttachmentButtonName = "AddAttachmentButton";
+        private static readonly Color EnabledAddAttachmentColor = Colors.CornflowerBlue;
+        private static readonly Color DisabledAddAttachmentColor = Colors.Gray;
 
         private Button? _addAttachmentButton;
 
@@ -80,7 +82,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
                 BorderWidth = 0,
                 FontSize = 24,
                 BackgroundColor = Colors.Transparent,
-                TextColor = Colors.CornflowerBlue,
+                TextColor = EnabledAddAttachmentColor,
                 HorizontalOptions = new LayoutOptions(LayoutAlignment.Start, true),
                 VerticalOptions = new LayoutOptions(LayoutAlignment.Start, true),
                 Padding = new Thickness(5)
@@ -139,11 +141,17 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
             {
                 _addAttachmentButton.Clicked += AddAttachmentButton_Click;
             }
+            UpdateAddAttachmentButtonState();
             UpdateVisibility();
         }
 
         private async void AddAttachmentButton_Click(object? sender, EventArgs e)
         {
+            if (!CanAddAttachment())
+            {
+                return;
+            }
+
             var page = GetParent<Page>();
             if(page != null && MediaPicker.IsCaptureSupported)
             {
@@ -183,6 +191,11 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
                         var photo = await MediaPicker.CapturePhotoAsync();
                         if (photo != null && Element != null)
                         {
+                            if (!CanAddAttachment())
+                            {
+                                return;
+                            }
+
                             using (var stream = await photo.OpenReadAsync())
                             {
                                 using var sr = new BinaryReader(stream);
@@ -195,6 +208,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
                                 await Element.AddAttachmentAsync(photo.FileName, contentType, data);
                             }
                             EvaluateExpressions();
+                            UpdateAddAttachmentButtonState();
                             (GetTemplateChild(AttachmentsListViewName) as CollectionView)?.ScrollTo(Element.Attachments.Last());
                         }
                     }
@@ -214,20 +228,32 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
 
         private async void AddAttachmentFromFile()
         {
-            if (Element is null) return;
+            if (!CanAddAttachment()) return;
             try
             {
                 var result = await FilePicker.Default.PickAsync(new());
-                if (result != null)
+                if (result != null && CanAddAttachment())
                 {
                     await Element.AddAttachmentAsync(result.FileName, MimeTypeMap.GetMimeType(new FileInfo(result.FileName).Extension), File.ReadAllBytes(result.FullPath));
                     EvaluateExpressions();
+                    UpdateAddAttachmentButtonState();
                     (GetTemplateChild(AttachmentsListViewName) as CollectionView)?.ScrollTo(Element.Attachments.Last());
                 }
             }
             catch (System.Exception ex)
             {
                 System.Diagnostics.Trace.WriteLine("Failed to add attachment: " + ex.Message);
+            }
+        }
+
+        private partial void UpdateAddAttachmentButtonState()
+        {
+            if (_addAttachmentButton is not null)
+            {
+                bool canAddAttachment = CanAddAttachment();
+                _addAttachmentButton.IsEnabled = canAddAttachment;
+                _addAttachmentButton.Opacity = canAddAttachment ? 1.0 : 0.45;
+                _addAttachmentButton.TextColor = canAddAttachment ? EnabledAddAttachmentColor : DisabledAddAttachmentColor;
             }
         }
     }

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/AttachmentsFormElementView.Windows.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/AttachmentsFormElementView.Windows.cs
@@ -51,6 +51,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
             {
                 _addAttachmentButton.Click += AddAttachmentButton_Click;
             }
+            UpdateAddAttachmentButtonState();
             if (GetTemplateChild("ItemsScrollView") is ScrollViewer scrollViewer)
             {
 #if WPF
@@ -89,7 +90,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
 
         private async void AddAttachmentButton_Click(object sender, RoutedEventArgs e)
         {
-            if (Element is null || !Element.IsEditable) return;
+            if (!CanAddAttachment()) return;
             try
             {
 #if WPF
@@ -97,11 +98,12 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                 if (openFileDialog.ShowDialog() == true)
                 {
                     var fileInfo = new FileInfo(openFileDialog.FileName);
-                    if (fileInfo.Exists)
+                    if (fileInfo.Exists && CanAddAttachment())
                     {
                         _scrollToEnd = true;
                         await Element.AddAttachmentAsync(fileInfo.Name, MimeTypeMap.GetMimeType(fileInfo.Extension), File.ReadAllBytes(fileInfo.FullName));
                         EvaluateExpressions();
+                        UpdateAddAttachmentButtonState();
                     }
                 }
 #elif WINDOWS_XAML
@@ -120,6 +122,10 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                 {
                     var fileInfo = new FileInfo(file.Path);
                     _scrollToEnd = true;
+                    if (!CanAddAttachment())
+                    {
+                        return;
+                    }
 #if WINDOWS_UWP
                     using var ms = new MemoryStream();
                     using var filestream = await file.OpenStreamForReadAsync();
@@ -129,12 +135,21 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                     await Element.AddAttachmentAsync(fileInfo.Name, MimeTypeMap.GetMimeType(fileInfo.Extension), File.ReadAllBytes(fileInfo.FullName));
 #endif
                     EvaluateExpressions();
+                    UpdateAddAttachmentButtonState();
                 }
 #endif
             }
             catch (System.Exception ex)
             {
                 System.Diagnostics.Trace.WriteLine("Failed to add attachment: " + ex.Message);
+            }
+        }
+
+        private partial void UpdateAddAttachmentButtonState()
+        {
+            if (_addAttachmentButton is not null)
+            {
+                _addAttachmentButton.IsEnabled = CanAddAttachment();
             }
         }
     }

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/AttachmentsFormElementView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/AttachmentsFormElementView.cs
@@ -40,6 +40,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
     {
         private WeakEventListener<AttachmentsFormElementView, INotifyPropertyChanged, object?, PropertyChangedEventArgs>? _elementPropertyChangedListener;
         private WeakEventListener<AttachmentsFormElementView, INotifyCollectionChanged, object?, NotifyCollectionChangedEventArgs>? _attachmentsCollectionChangedListener;
+        private bool _isAttachmentsLoaded;
 
         /// <summary>
         /// Initializes an instance of the <see cref="AttachmentsFormElementView"/> class.
@@ -81,6 +82,8 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
 
         private async void OnElementPropertyChanged(AttachmentsFormElement? oldValue, AttachmentsFormElement? newValue)
         {
+            _isAttachmentsLoaded = newValue is null;
+
             if (oldValue is INotifyPropertyChanged inpcOld)
             {
                 _elementPropertyChangedListener?.Detach();
@@ -118,6 +121,11 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                     await newValue.FetchAttachmentsAsync();
                 }
                 catch (System.Exception) { }
+                finally
+                {
+                    _isAttachmentsLoaded = true;
+                    UpdateAddAttachmentButtonState();
+                }
             }
         }
 
@@ -143,7 +151,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
 
         private bool CanAddAttachment()
         {
-            if (Element is null || !Element.IsEditable)
+            if (Element is null || !Element.IsEditable || !_isAttachmentsLoaded)
             {
                 return false;
             }

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/AttachmentsFormElementView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/AttachmentsFormElementView.cs
@@ -18,6 +18,7 @@
 using Esri.ArcGISRuntime.Data;
 using Esri.ArcGISRuntime.Mapping.FeatureForms;
 using Esri.ArcGISRuntime.Toolkit.Internal;
+using System.Collections.Specialized;
 using System.ComponentModel;
 #if WPF || WINDOWS_XAML
 using Esri.ArcGISRuntime.Toolkit.UI.Controls;
@@ -38,6 +39,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
     public partial class AttachmentsFormElementView
     {
         private WeakEventListener<AttachmentsFormElementView, INotifyPropertyChanged, object?, PropertyChangedEventArgs>? _elementPropertyChangedListener;
+        private WeakEventListener<AttachmentsFormElementView, INotifyCollectionChanged, object?, NotifyCollectionChangedEventArgs>? _attachmentsCollectionChangedListener;
 
         /// <summary>
         /// Initializes an instance of the <see cref="AttachmentsFormElementView"/> class.
@@ -84,6 +86,11 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                 _elementPropertyChangedListener?.Detach();
                 _elementPropertyChangedListener = null;
             }
+            if (oldValue?.Attachments is INotifyCollectionChanged oldAttachments)
+            {
+                _attachmentsCollectionChangedListener?.Detach();
+                _attachmentsCollectionChangedListener = null;
+            }
             if (newValue is INotifyPropertyChanged inpcNew)
             {
                 _elementPropertyChangedListener = new WeakEventListener<AttachmentsFormElementView, INotifyPropertyChanged, object?, PropertyChangedEventArgs>(this, inpcNew)
@@ -93,7 +100,17 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                 };
                 inpcNew.PropertyChanged += _elementPropertyChangedListener.OnEvent;
             }
+            if (newValue?.Attachments is INotifyCollectionChanged newAttachments)
+            {
+                _attachmentsCollectionChangedListener = new WeakEventListener<AttachmentsFormElementView, INotifyCollectionChanged, object?, NotifyCollectionChangedEventArgs>(this, newAttachments)
+                {
+                    OnEventAction = static (instance, source, eventArgs) => instance.Attachments_CollectionChanged(source, eventArgs),
+                    OnDetachAction = static (instance, source, weakEventListener) => source.CollectionChanged -= weakEventListener.OnEvent,
+                };
+                newAttachments.CollectionChanged += _attachmentsCollectionChangedListener.OnEvent;
+            }
             UpdateVisibility();
+            UpdateAddAttachmentButtonState();
             if (newValue != null)
             {
                 try
@@ -110,6 +127,28 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
             {
                 this.Dispatch(UpdateVisibility);
             }
+
+            if (e.PropertyName == nameof(AttachmentsFormElement.IsEditable) ||
+                e.PropertyName == nameof(AttachmentsFormElement.MaxAttachmentCount) ||
+                e.PropertyName == nameof(AttachmentsFormElement.Attachments))
+            {
+                this.Dispatch(UpdateAddAttachmentButtonState);
+            }
+        }
+
+        private void Attachments_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            this.Dispatch(UpdateAddAttachmentButtonState);
+        }
+
+        private bool CanAddAttachment()
+        {
+            if (Element is null || !Element.IsEditable)
+            {
+                return false;
+            }
+
+            return Element.MaxAttachmentCount < 0 || Element.Attachments.Count < Element.MaxAttachmentCount;
         }
 
         private void UpdateVisibility()
@@ -120,5 +159,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
             this.Visibility = Element?.IsVisible == true ? Visibility.Visible : Visibility.Collapsed;
 #endif
         }
+
+        private partial void UpdateAddAttachmentButtonState();
     }
 }


### PR DESCRIPTION
Changes are related to the [recent attachment enhancements](https://devtopia.esri.com/runtime/dotnet-api/issues/14577). Creating small feature wise PRs for easy review

According to the design doc, when the `MaxAttachmentCount` is reached the add attachment button should be disabled.
Also, fixes an unusual flickering of the add attachment button in WinUI when trying to move the mouse over it

Note:
Webmap used for testing - https://runtimecoretest.maps.arcgis.com/home/item.html?id=7064081d2d1a4af6b871d35954417e5e
The changes from https://github.com/Esri/arcgis-maps-sdk-dotnet-toolkit/pull/793 should be merged into the current branch for testing


https://github.com/user-attachments/assets/a1cdc647-4aaa-40ab-ac7f-321b9398112f

