### PR TITLE
Fix FeatureForm DateTimePicker shifting TimestampOffset values

### DIFF
--- a/src/Tests/Toolkit.Tests/DateTimePickerFormInputViewTests.cs
+++ b/src/Tests/Toolkit.Tests/DateTimePickerFormInputViewTests.cs
@@ -1,0 +1,50 @@
+using System;
+using Esri.ArcGISRuntime.Toolkit.Primitives;
+
+namespace Toolkit.Tests;
+
+// Regression tests for DateTimePickerFormInputView.ConvertToLocalDisplayValue (devtopia #14203).
+// A TimestampOffset field's value is a DateTimeOffset carrying a non-zero offset; the picker must display
+// its UTC instant, not the wall-clock reading. Assertions are time-zone independent: the local value shown
+// must map back to the stored instant.
+[TestClass]
+public sealed class DateTimePickerFormInputViewTests
+{
+    // A Date field returns a UTC DateTime; the display is its local-time projection.
+    [TestMethod]
+    public void DateTimeValue_ProjectsToLocalTime()
+    {
+        var utc = new DateTime(2024, 6, 15, 18, 0, 0, DateTimeKind.Utc);
+
+        DateTime? display = DateTimePickerFormInputView.ConvertToLocalDisplayValue(utc);
+
+        Assert.IsNotNull(display);
+        Assert.AreEqual(utc, display.Value.ToUniversalTime());
+    }
+
+    // The bug: a TimestampOffset value must display its stored instant. The old code used
+    // DateTimeOffset.DateTime and shifted the value by the offset. Rows cover the reported Pacific offset,
+    // UTC (no regression), and a fractional east offset.
+    [TestMethod]
+    [DataRow(-7.0)]
+    [DataRow(0.0)]
+    [DataRow(5.5)]
+    public void TimestampOffsetValue_DisplaysCorrectInstant_Issue14203(double offsetHours)
+    {
+        var offset = TimeSpan.FromHours(offsetHours);
+        var value = new DateTimeOffset(2024, 6, 15, 13, 30, 0, offset);
+
+        DateTime? display = DateTimePickerFormInputView.ConvertToLocalDisplayValue(value);
+
+        Assert.IsNotNull(display);
+        Assert.AreEqual(value.UtcDateTime, display.Value.ToUniversalTime(), $"Offset {offsetHours}h must display the stored instant.");
+        // The old projection differs from the fix by exactly the stored offset (zero when the offset is zero).
+        Assert.AreEqual(offset, value.DateTime.ToLocalTime() - display.Value, $"Offset {offsetHours}h regression guard.");
+    }
+
+    [TestMethod]
+    public void NullValue_ReturnsNull()
+    {
+        Assert.IsNull(DateTimePickerFormInputView.ConvertToLocalDisplayValue(null));
+    }
+}

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/DateTimePickerFormInputView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/DateTimePickerFormInputView.cs
@@ -169,16 +169,29 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
 
         private bool _rentrancyFlag;
 
+        // Converts a FieldFormElement.Value to a local-time DateTime for the pickers.
+        // A DateTimeOffset value (from a TimestampOffset field) is reduced to its UTC instant
+        // to avoid applying the offset twice during conversion to local time.
+        internal static DateTime? ConvertToLocalDisplayValue(object? value) // internal so it can be unit-tested
+        {
+            DateTime? utc = value switch
+            {
+                DateTime dt => dt,
+                DateTimeOffset dto => dto.UtcDateTime,
+                _ => null,
+            };
+            return utc?.ToLocalTime();
+        }
+
         private void ConfigurePickers()
         {
             if (_rentrancyFlag) return;
             _rentrancyFlag = true;
-            DateTime? selectedDate = Element?.Value as DateTime? ?? (Element?.Value as DateTimeOffset?)?.DateTime;
+            // Dates are always displayed in local time, even if IncludeTime is false.
+            DateTime? selectedDate = ConvertToLocalDisplayValue(Element?.Value);
 
             if (Element?.Input is DateTimePickerFormInput input)
             {
-                // Dates are always converted to local time, even if IncludeTime is false
-                selectedDate = selectedDate?.ToLocalTime();
                 if (_datePicker != null)
                 {
 #if MAUI


### PR DESCRIPTION
The date and time picker displayed a DateTimeOffset value using its [`.DateTime` property](https://learn.microsoft.com/en-us/dotnet/api/system.datetimeoffset.datetime?view=net-10.0). That property is the wall-clock reading at the field's stored offset, and its [Kind](https://learn.microsoft.com/en-us/dotnet/api/system.datetime.kind?view=net-10.0) is Unspecified. ToLocalTime() then treats it as UTC and shifts it by the offset. So when a TimestampOffset field carries a non-zero offset, its value was displayed several hours off (doubling the offset) and the date could roll near midnight.

Use the UTC instant (DateTimeOffset.UtcDateTime) instead, so ToLocalTime() converts correctly. Plain DateTime values and offset-zero DateTimeOffset values are unchanged. The fix is in shared code and applies to every platform head. I added unit test cases to cover conversion of DateTime, DateTimeOffset, and nulls.