### PR TITLE
[Feature Form] [Attachments]: Display Min/ Max count and related errors below the description

### DIFF
--- a/src/Toolkit/Toolkit.WPF/UI/Controls/FeatureForm/FeatureFormView.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/FeatureForm/FeatureFormView.Theme.xaml
@@ -457,7 +457,17 @@
                                 <ColumnDefinition Width="Auto" />
                             </Grid.ColumnDefinitions>
                             <TextBlock Text="{Binding Label}" Visibility="{Binding Label, Converter={StaticResource FeatureFormViewVisibilityConverter}}" Style="{StaticResource FeatureFormViewTitleStyle}" />
-                            <TextBlock Text="{Binding Description}" Visibility="{Binding Description, Converter={StaticResource FeatureFormViewVisibilityConverter}}" Opacity=".7" Style="{StaticResource FeatureFormViewCaptionStyle}" />
+                            <StackPanel Grid.Row="1">
+                                <TextBlock Text="{Binding Description}" Visibility="{Binding Description, Converter={StaticResource FeatureFormViewVisibilityConverter}}" Opacity=".7" Style="{StaticResource FeatureFormViewCaptionStyle}" />
+                              <StackPanel Orientation="Horizontal" Margin="0,2,0,0">
+                                <Border x:Name="MinAttachmentBadge" Background="Transparent" BorderBrush="Gray" BorderThickness="1" CornerRadius="8" Padding="8,2" Visibility="Collapsed" Margin="0,0,6,0">
+                                  <TextBlock x:Name="MinAttachmentBadgeText" FontSize="11" Foreground="Black" Opacity=".7"/>
+                                </Border>
+                                    <Border x:Name="MaxAttachmentBadge" Background="Transparent" BorderBrush="Gray" BorderThickness="1" CornerRadius="8" Padding="8,2" Visibility="Collapsed">
+                                        <TextBlock x:Name="MaxAttachmentBadgeText" FontSize="11" Foreground="Black" Opacity=".7"/>
+                                </Border>
+                              </StackPanel>
+                            </StackPanel>
                             <Button x:Name="AddAttachmentButton" BorderThickness="0" Background="Transparent" HorizontalAlignment="Stretch" HorizontalContentAlignment="Left" 
                                     Visibility="{Binding IsEditable, Converter={StaticResource FeatureFormViewVisibilityConverter}}" Padding="5" Cursor="Hand" Grid.Column="1" Grid.RowSpan="2">
                                     <TextBlock Text="" FontFamily="Segoe MDL2 Assets" />

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/FeatureForm/FeatureFormView.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/FeatureForm/FeatureFormView.Theme.xaml
@@ -474,7 +474,7 @@
                             </Button>
                         </Grid>
                         <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Disabled" x:Name="ItemsScrollView">
-                            <ItemsControl ItemsSource="{Binding Attachments}" IsEnabled="{Binding IsEditable}">
+                          <ItemsControl MinHeight="75" ItemsSource="{Binding Attachments}" IsEnabled="{Binding IsEditable}">
                                 <ItemsControl.ItemsPanel>
                                     <ItemsPanelTemplate>
                                         <StackPanel Orientation="Horizontal" />

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/FeatureForm/FeatureFormView.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/FeatureForm/FeatureFormView.Theme.xaml
@@ -467,6 +467,7 @@
                                         <TextBlock x:Name="MaxAttachmentBadgeText" FontSize="11" Foreground="Black" Opacity=".7"/>
                                 </Border>
                               </StackPanel>
+                                <TextBlock x:Name="AttachmentErrorLabel" Foreground="Red" Margin="0,2,0,0" TextWrapping="Wrap" Visibility="Collapsed" />
                             </StackPanel>
                             <Button x:Name="AddAttachmentButton" BorderThickness="0" Background="Transparent" HorizontalAlignment="Stretch" HorizontalContentAlignment="Left" 
                                     Visibility="{Binding IsEditable, Converter={StaticResource FeatureFormViewVisibilityConverter}}" Padding="5" Cursor="Hand" Grid.Column="1" Grid.RowSpan="2">

--- a/src/Toolkit/Toolkit.WinUI/UI/Controls/FeatureForm/FeatureForm.Theme.xaml
+++ b/src/Toolkit/Toolkit.WinUI/UI/Controls/FeatureForm/FeatureForm.Theme.xaml
@@ -308,7 +308,17 @@
                                 <ColumnDefinition Width="Auto" />
                             </Grid.ColumnDefinitions>
                             <TextBlock Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Element.Label}" Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Element.Label, Converter={StaticResource FeatureFormViewVisibilityConverter}}" Style="{StaticResource FeatureFormViewTitleStyle}" />
-                            <TextBlock Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Element.Description}" Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Element.Description, Converter={StaticResource FeatureFormViewVisibilityConverter}}" Opacity=".7" Style="{StaticResource FeatureFormViewCaptionStyle}" />
+                            <StackPanel Grid.Row="1">
+                                <TextBlock Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Element.Description}" Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Element.Description, Converter={StaticResource FeatureFormViewVisibilityConverter}}" Opacity=".7" Style="{StaticResource FeatureFormViewCaptionStyle}" />
+                                <StackPanel Orientation="Horizontal" Spacing="6" Margin="0,2,0,0">
+                                    <Border x:Name="MinAttachmentBadge" Background="Transparent" BorderBrush="Gray" BorderThickness="1" CornerRadius="8" Padding="8,2" Visibility="Collapsed">
+                                        <TextBlock x:Name="MinAttachmentBadgeText" FontSize="11" Foreground="{ThemeResource TextFillColorPrimaryBrush}" Opacity=".7"/>
+                                    </Border>
+                                    <Border x:Name="MaxAttachmentBadge" Background="Transparent" BorderBrush="Gray" BorderThickness="1" CornerRadius="8" Padding="8,2" Visibility="Collapsed">
+                                        <TextBlock x:Name="MaxAttachmentBadgeText" FontSize="11" Foreground="{ThemeResource TextFillColorPrimaryBrush}" Opacity=".7"/>
+                                    </Border>
+                                </StackPanel>
+                            </StackPanel>
                             <Button x:Name="AddAttachmentButton" BorderThickness="0" Background="Transparent" HorizontalAlignment="Stretch" HorizontalContentAlignment="Left" 
                                  Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Element.IsEditable, Converter={StaticResource FeatureFormViewVisibilityConverter}}" Padding="5" Grid.Column="1" Grid.RowSpan="2">
                                 <TextBlock Text="" FontFamily="Segoe MDL2 Assets" />

--- a/src/Toolkit/Toolkit.WinUI/UI/Controls/FeatureForm/FeatureForm.Theme.xaml
+++ b/src/Toolkit/Toolkit.WinUI/UI/Controls/FeatureForm/FeatureForm.Theme.xaml
@@ -325,7 +325,7 @@
                             </Button>
                         </Grid>
                         <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Disabled" x:Name="ItemsScrollView">
-                            <ItemsControl ItemsSource="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Element.Attachments}" IsEnabled="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Element.IsEditable}">
+                            <ItemsControl x:Name="AttachmentItemsControl" MinHeight="75" ItemsSource="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Element.Attachments}" IsEnabled="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Element.IsEditable}">
                                 <ItemsControl.ItemsPanel>
                                     <ItemsPanelTemplate>
                                         <StackPanel Orientation="Horizontal" />

--- a/src/Toolkit/Toolkit.WinUI/UI/Controls/FeatureForm/FeatureForm.Theme.xaml
+++ b/src/Toolkit/Toolkit.WinUI/UI/Controls/FeatureForm/FeatureForm.Theme.xaml
@@ -318,6 +318,7 @@
                                         <TextBlock x:Name="MaxAttachmentBadgeText" FontSize="11" Foreground="{ThemeResource TextFillColorPrimaryBrush}" Opacity=".7"/>
                                     </Border>
                                 </StackPanel>
+                                <TextBlock x:Name="AttachmentErrorLabel" Foreground="Red" Margin="0,2,0,0" TextWrapping="Wrap" Visibility="Collapsed" />
                             </StackPanel>
                             <Button x:Name="AddAttachmentButton" BorderThickness="0" Background="Transparent" HorizontalAlignment="Stretch" HorizontalContentAlignment="Left" 
                                  Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Element.IsEditable, Converter={StaticResource FeatureFormViewVisibilityConverter}}" Padding="5" Grid.Column="1" Grid.RowSpan="2">

--- a/src/Toolkit/Toolkit/LocalizedStrings/Resources.resx
+++ b/src/Toolkit/Toolkit/LocalizedStrings/Resources.resx
@@ -193,6 +193,22 @@
     <value>Less than minimum value</value>
     <comment>Input validation of entered number is below the minimum require value</comment>
   </data>
+  <data name="FeatureFormMaximumAttachmentCountAllowed" xml:space="preserve">
+    <value>The maximum number of attachments allowed is {0}.</value>
+    <comment>Validation error shown when the number of attachments exceeds the allowed maximum of {0}.</comment>
+  </data>
+  <data name="FeatureFormMaximumAttachmentCountLabel" xml:space="preserve">
+    <value>Max: {0}</value>
+    <comment>Caption badge showing the maximum allowed number of attachments, where {0} is the count.</comment>
+  </data>
+  <data name="FeatureFormMinimumAttachmentCountLabel" xml:space="preserve">
+    <value>Min: {0}</value>
+    <comment>Caption badge showing the minimum required number of attachments, where {0} is the count.</comment>
+  </data>
+  <data name="FeatureFormMinimumAttachmentCountRequired" xml:space="preserve">
+    <value>At least {0} attachment(s) required.</value>
+    <comment>Validation error shown when fewer than the minimum required attachments are present, where {0} is the required count.</comment>
+  </data>
   <data name="FeatureFormNoAttachments" xml:space="preserve">
     <value>No attachments</value>
     <comment>The text displayed in the attachment list when there are no attachments.</comment>

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/AttachmentsFormElementView.Maui.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/AttachmentsFormElementView.Maui.cs
@@ -129,6 +129,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
             root.Children.Add(header);
             root.Children.Add(label);
             root.Children.Add(chipRow);
+            root.Children.Add(errorLabel);
 
             CollectionView itemsView = new CollectionView()
             {

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/AttachmentsFormElementView.Maui.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/AttachmentsFormElementView.Maui.cs
@@ -24,6 +24,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Controls.Shapes;
 
 namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
 {
@@ -32,8 +33,14 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
         private static readonly ControlTemplate DefaultControlTemplate;
         private const string AttachmentsListViewName = "AttachmentsListView";
         private const string AddAttachmentButtonName = "AddAttachmentButton";
+        private const string MinAttachmentBadgeName = "MinAttachmentBadge";
+        private const string MaxAttachmentBadgeName = "MaxAttachmentBadge";
+        private static readonly Color EnabledAddAttachmentColor = Colors.CornflowerBlue;
+        private static readonly Color DisabledAddAttachmentColor = Colors.Gray;
 
         private Button? _addAttachmentButton;
+        private Label? _minAttachmentBadge;
+        private Label? _maxAttachmentBadge;
 
         static AttachmentsFormElementView()
         {
@@ -66,12 +73,39 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
             label.SetBinding(View.IsVisibleProperty, static (Label label) => label.Text, source: RelativeBindingSource.Self, converter: EmptyStringToBoolConverter.Instance);
             label.Style = FeatureFormView.GetFeatureFormTitleStyle();
             header.Children.Add(label);
+
             label = new Label();
             label.SetBinding(Label.TextProperty, static (AttachmentsFormElementView view) => view.Element?.Description, source: RelativeBindingSource.TemplatedParent);
             label.SetBinding(Label.IsVisibleProperty, static (Label label) => label.Text, source: RelativeBindingSource.Self, converter: EmptyStringToBoolConverter.Instance);
             label.Style = FeatureFormView.GetFeatureFormCaptionStyle();
-            Grid.SetRow(label, 1);
-            header.Children.Add(label);
+
+            var chipRow = new HorizontalStackLayout() { Spacing = 6, Margin = new Thickness(0, 2, 0, 0) };
+            var minBadge = new Label() { Style = FeatureFormView.GetFeatureFormCaptionStyle(), IsVisible = false };
+            var maxBadge = new Label() { Style = FeatureFormView.GetFeatureFormCaptionStyle(), IsVisible = false };
+            var minBadgeBorder = new Border()
+            {
+                Stroke = new SolidColorBrush(Colors.Gray),
+                StrokeThickness = 1,
+                StrokeShape = new RoundRectangle() { CornerRadius = 8 },
+                Padding = new Thickness(8, 2),
+                BackgroundColor = Colors.Transparent,
+                Content = minBadge,
+            };
+            minBadgeBorder.SetBinding(IsVisibleProperty, static (Label value) => value.IsVisible, source: minBadge);
+
+            var maxBadgeBorder = new Border()
+            {
+                Stroke = new SolidColorBrush(Colors.Gray),
+                StrokeThickness = 1,
+                StrokeShape = new RoundRectangle() { CornerRadius = 8 },
+                Padding = new Thickness(8, 2),
+                BackgroundColor = Colors.Transparent,
+                Content = maxBadge,
+            };
+            maxBadgeBorder.SetBinding(IsVisibleProperty, static (Label value) => value.IsVisible, source: maxBadge);
+
+            chipRow.Children.Add(minBadgeBorder);
+            chipRow.Children.Add(maxBadgeBorder);
             Button addButton = new Button()
             {
                 Margin = new Thickness(0, -5, 0, 0),
@@ -88,11 +122,12 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
            
             
             Grid.SetColumn(addButton, 1);
-            Grid.SetRowSpan(addButton, 2);
             addButton.SetBinding(VisualElement.IsVisibleProperty, static (AttachmentsFormElementView view) => view.Element?.IsEditable, source: RelativeBindingSource.TemplatedParent, converter: BoolOrNullToBoolConverter.Instance);
             header.Children.Add(addButton);
 
             root.Children.Add(header);
+            root.Children.Add(label);
+            root.Children.Add(chipRow);
 
             CollectionView itemsView = new CollectionView()
             {
@@ -122,6 +157,8 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
             NameScope.SetNameScope(root, nameScope);
             nameScope.RegisterName(AddAttachmentButtonName, addButton);
             nameScope.RegisterName(AttachmentsListViewName, itemsView);
+            nameScope.RegisterName(MinAttachmentBadgeName, minBadge);
+            nameScope.RegisterName(MaxAttachmentBadgeName, maxBadge);
             return root;
         }
 
@@ -139,6 +176,10 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
             {
                 _addAttachmentButton.Clicked += AddAttachmentButton_Click;
             }
+            _minAttachmentBadge = GetTemplateChild(MinAttachmentBadgeName) as Label;
+            _maxAttachmentBadge = GetTemplateChild(MaxAttachmentBadgeName) as Label;
+            UpdateAddAttachmentButtonState();
+            UpdateMinMaxAttachmentText();
             UpdateVisibility();
         }
 
@@ -228,6 +269,33 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
             catch (System.Exception ex)
             {
                 System.Diagnostics.Trace.WriteLine("Failed to add attachment: " + ex.Message);
+            }
+        }
+
+        private partial void UpdateAddAttachmentButtonState()
+        {
+            if (_addAttachmentButton is not null)
+            {
+                bool canAddAttachment = CanAddAttachment();
+                _addAttachmentButton.IsEnabled = canAddAttachment;
+                _addAttachmentButton.Opacity = canAddAttachment ? 1.0 : 0.45;
+                _addAttachmentButton.TextColor = canAddAttachment ? EnabledAddAttachmentColor : DisabledAddAttachmentColor;
+            }
+        }
+
+        private partial void UpdateMinMaxAttachmentTextCore(uint minAttachmentCount, uint maxAttachmentCount)
+        {
+
+            if (_minAttachmentBadge is not null)
+            {
+                _minAttachmentBadge.Text = $"Min: {minAttachmentCount}";
+                _minAttachmentBadge.IsVisible = minAttachmentCount > 0;
+            }
+
+            if (_maxAttachmentBadge is not null)
+            {
+                _maxAttachmentBadge.Text = $"Max: {maxAttachmentCount}";
+                _maxAttachmentBadge.IsVisible = HasConfiguredMaxAttachmentCount(maxAttachmentCount);
             }
         }
     }

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/AttachmentsFormElementView.Maui.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/AttachmentsFormElementView.Maui.cs
@@ -35,12 +35,14 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
         private const string AddAttachmentButtonName = "AddAttachmentButton";
         private const string MinAttachmentBadgeName = "MinAttachmentBadge";
         private const string MaxAttachmentBadgeName = "MaxAttachmentBadge";
+        private const string AttachmentErrorLabelName = "AttachmentErrorLabel";
         private static readonly Color EnabledAddAttachmentColor = Colors.CornflowerBlue;
         private static readonly Color DisabledAddAttachmentColor = Colors.Gray;
 
         private Button? _addAttachmentButton;
         private Label? _minAttachmentBadge;
         private Label? _maxAttachmentBadge;
+        private Label? _attachmentErrorLabel;
 
         static AttachmentsFormElementView()
         {
@@ -83,6 +85,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
             var chipRow = new HorizontalStackLayout() { Spacing = 6, Margin = new Thickness(0, 2, 0, 0) };
             var minBadge = new Label() { Style = FeatureFormView.GetFeatureFormCaptionStyle(), IsVisible = false, Opacity = .7 };
             var maxBadge = new Label() { Style = FeatureFormView.GetFeatureFormCaptionStyle(), IsVisible = false, Opacity = .7 };
+            var errorLabel = new Label() { Style = FeatureFormView.GetFeatureFormCaptionStyle(), IsVisible = false, TextColor = Colors.Red, Margin = new Thickness(0, 2, 0, 0), LineBreakMode = LineBreakMode.WordWrap };
             var minBadgeBorder = new Border()
             {
                 Stroke = new SolidColorBrush(Colors.Gray),
@@ -161,6 +164,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
             nameScope.RegisterName(AttachmentsListViewName, itemsView);
             nameScope.RegisterName(MinAttachmentBadgeName, minBadge);
             nameScope.RegisterName(MaxAttachmentBadgeName, maxBadge);
+            nameScope.RegisterName(AttachmentErrorLabelName, errorLabel);
             return root;
         }
 
@@ -180,6 +184,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
             }
             _minAttachmentBadge = GetTemplateChild(MinAttachmentBadgeName) as Label;
             _maxAttachmentBadge = GetTemplateChild(MaxAttachmentBadgeName) as Label;
+            _attachmentErrorLabel = GetTemplateChild(AttachmentErrorLabelName) as Label;
             UpdateAddAttachmentButtonState();
             UpdateMinMaxAttachmentText();
             UpdateVisibility();
@@ -285,19 +290,24 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
             }
         }
 
-        private partial void UpdateMinMaxAttachmentTextCore(uint minAttachmentCount, uint maxAttachmentCount)
+        private partial void UpdateMinMaxAttachmentTextCore(string minAttachmentText, bool minVisible, string maxAttachmentText, bool maxVisible, string errorText, bool errorVisible)
         {
-
             if (_minAttachmentBadge is not null)
             {
-                _minAttachmentBadge.Text = $"Min: {minAttachmentCount}";
-                _minAttachmentBadge.IsVisible = minAttachmentCount > 0;
+                _minAttachmentBadge.Text = minAttachmentText;
+                _minAttachmentBadge.IsVisible = minVisible;
             }
 
             if (_maxAttachmentBadge is not null)
             {
-                _maxAttachmentBadge.Text = $"Max: {maxAttachmentCount}";
-                _maxAttachmentBadge.IsVisible = HasConfiguredMaxAttachmentCount(maxAttachmentCount);
+                _maxAttachmentBadge.Text = maxAttachmentText;
+                _maxAttachmentBadge.IsVisible = maxVisible;
+            }
+
+            if (_attachmentErrorLabel is not null)
+            {
+                _attachmentErrorLabel.Text = errorText;
+                _attachmentErrorLabel.IsVisible = errorVisible;
             }
         }
     }

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/AttachmentsFormElementView.Maui.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/AttachmentsFormElementView.Maui.cs
@@ -78,10 +78,11 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
             label.SetBinding(Label.TextProperty, static (AttachmentsFormElementView view) => view.Element?.Description, source: RelativeBindingSource.TemplatedParent);
             label.SetBinding(Label.IsVisibleProperty, static (Label label) => label.Text, source: RelativeBindingSource.Self, converter: EmptyStringToBoolConverter.Instance);
             label.Style = FeatureFormView.GetFeatureFormCaptionStyle();
+            label.Opacity = 0.7;
 
             var chipRow = new HorizontalStackLayout() { Spacing = 6, Margin = new Thickness(0, 2, 0, 0) };
-            var minBadge = new Label() { Style = FeatureFormView.GetFeatureFormCaptionStyle(), IsVisible = false };
-            var maxBadge = new Label() { Style = FeatureFormView.GetFeatureFormCaptionStyle(), IsVisible = false };
+            var minBadge = new Label() { Style = FeatureFormView.GetFeatureFormCaptionStyle(), IsVisible = false, Opacity = .7 };
+            var maxBadge = new Label() { Style = FeatureFormView.GetFeatureFormCaptionStyle(), IsVisible = false, Opacity = .7 };
             var minBadgeBorder = new Border()
             {
                 Stroke = new SolidColorBrush(Colors.Gray),

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/AttachmentsFormElementView.Windows.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/AttachmentsFormElementView.Windows.cs
@@ -32,6 +32,10 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
     public partial class AttachmentsFormElementView : Control
     {
         private ButtonBase? _addAttachmentButton;
+        private FrameworkElement? _minAttachmentBadge;
+        private TextBlock? _minAttachmentBadgeText;
+        private FrameworkElement? _maxAttachmentBadge;
+        private TextBlock? _maxAttachmentBadgeText;
         private bool _scrollToEnd;
 
         /// <inheritdoc />
@@ -51,6 +55,12 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
             {
                 _addAttachmentButton.Click += AddAttachmentButton_Click;
             }
+            _minAttachmentBadge = GetTemplateChild("MinAttachmentBadge") as FrameworkElement;
+            _minAttachmentBadgeText = GetTemplateChild("MinAttachmentBadgeText") as TextBlock;
+            _maxAttachmentBadge = GetTemplateChild("MaxAttachmentBadge") as FrameworkElement;
+            _maxAttachmentBadgeText = GetTemplateChild("MaxAttachmentBadgeText") as TextBlock;
+            UpdateAddAttachmentButtonState();
+            UpdateMinMaxAttachmentText();
             if (GetTemplateChild("ItemsScrollView") is ScrollViewer scrollViewer)
             {
 #if WPF
@@ -135,6 +145,35 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
             catch (System.Exception ex)
             {
                 System.Diagnostics.Trace.WriteLine("Failed to add attachment: " + ex.Message);
+            }
+        }
+
+        private partial void UpdateAddAttachmentButtonState()
+        {
+            if (_addAttachmentButton is not null)
+            {
+                _addAttachmentButton.IsEnabled = CanAddAttachment();
+            }
+        }
+
+        private partial void UpdateMinMaxAttachmentTextCore(uint minAttachmentCount, uint maxAttachmentCount)
+        {
+            if (_minAttachmentBadge is not null)
+            {
+                _minAttachmentBadge.Visibility = minAttachmentCount > 0 ? Visibility.Visible : Visibility.Collapsed;
+            }
+            if (_minAttachmentBadgeText is not null)
+            {
+                _minAttachmentBadgeText.Text = $"Min: {minAttachmentCount}";
+            }
+
+            if (_maxAttachmentBadge is not null)
+            {
+                _maxAttachmentBadge.Visibility = HasConfiguredMaxAttachmentCount(maxAttachmentCount) ? Visibility.Visible : Visibility.Collapsed;
+            }
+            if (_maxAttachmentBadgeText is not null)
+            {
+                _maxAttachmentBadgeText.Text = $"Max: {maxAttachmentCount}";
             }
         }
     }

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/AttachmentsFormElementView.Windows.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/AttachmentsFormElementView.Windows.cs
@@ -36,6 +36,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
         private TextBlock? _minAttachmentBadgeText;
         private FrameworkElement? _maxAttachmentBadge;
         private TextBlock? _maxAttachmentBadgeText;
+        private TextBlock? _attachmentErrorLabel;
         private bool _scrollToEnd;
 
         /// <inheritdoc />
@@ -59,6 +60,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
             _minAttachmentBadgeText = GetTemplateChild("MinAttachmentBadgeText") as TextBlock;
             _maxAttachmentBadge = GetTemplateChild("MaxAttachmentBadge") as FrameworkElement;
             _maxAttachmentBadgeText = GetTemplateChild("MaxAttachmentBadgeText") as TextBlock;
+            _attachmentErrorLabel = GetTemplateChild("AttachmentErrorLabel") as TextBlock;
             UpdateAddAttachmentButtonState();
             UpdateMinMaxAttachmentText();
             if (GetTemplateChild("ItemsScrollView") is ScrollViewer scrollViewer)
@@ -156,24 +158,29 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
             }
         }
 
-        private partial void UpdateMinMaxAttachmentTextCore(uint minAttachmentCount, uint maxAttachmentCount)
+        private partial void UpdateMinMaxAttachmentTextCore(string minAttachmentText, bool minVisible, string maxAttachmentText, bool maxVisible, string errorText, bool errorVisible)
         {
             if (_minAttachmentBadge is not null)
             {
-                _minAttachmentBadge.Visibility = minAttachmentCount > 0 ? Visibility.Visible : Visibility.Collapsed;
+                _minAttachmentBadge.Visibility = minVisible ? Visibility.Visible : Visibility.Collapsed;
             }
             if (_minAttachmentBadgeText is not null)
             {
-                _minAttachmentBadgeText.Text = $"Min: {minAttachmentCount}";
+                _minAttachmentBadgeText.Text = minAttachmentText;
             }
 
             if (_maxAttachmentBadge is not null)
             {
-                _maxAttachmentBadge.Visibility = HasConfiguredMaxAttachmentCount(maxAttachmentCount) ? Visibility.Visible : Visibility.Collapsed;
+                _maxAttachmentBadge.Visibility = maxVisible ? Visibility.Visible : Visibility.Collapsed;
             }
             if (_maxAttachmentBadgeText is not null)
             {
-                _maxAttachmentBadgeText.Text = $"Max: {maxAttachmentCount}";
+                _maxAttachmentBadgeText.Text = maxAttachmentText;
+            }
+            if (_attachmentErrorLabel is not null)
+            {
+                _attachmentErrorLabel.Text = errorText;
+                _attachmentErrorLabel.Visibility = errorVisible ? Visibility.Visible : Visibility.Collapsed;
             }
         }
     }

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/AttachmentsFormElementView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/AttachmentsFormElementView.cs
@@ -94,6 +94,8 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                 inpcNew.PropertyChanged += _elementPropertyChangedListener.OnEvent;
             }
             UpdateVisibility();
+            UpdateAddAttachmentButtonState();
+            UpdateMinMaxAttachmentText();
             if (newValue != null)
             {
                 try
@@ -110,6 +112,34 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
             {
                 this.Dispatch(UpdateVisibility);
             }
+
+            if (e.PropertyName == nameof(AttachmentsFormElement.IsEditable) ||
+                e.PropertyName == nameof(AttachmentsFormElement.MaxAttachmentCount) ||
+                e.PropertyName == nameof(AttachmentsFormElement.Attachments))
+            {
+                this.Dispatch(UpdateAddAttachmentButtonState);
+            }
+
+            if (e.PropertyName == nameof(AttachmentsFormElement.MinAttachmentCount) ||
+                e.PropertyName == nameof(AttachmentsFormElement.MaxAttachmentCount))
+            {
+                this.Dispatch(UpdateMinMaxAttachmentText);
+            }
+        }
+
+        private void Attachments_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            this.Dispatch(UpdateAddAttachmentButtonState);
+        }
+
+        private bool CanAddAttachment()
+        {
+            if (Element is null || !Element.IsEditable)
+            {
+                return false;
+            }
+
+            return Element.MaxAttachmentCount < 0 || Element.Attachments.Count < Element.MaxAttachmentCount;
         }
 
         private void UpdateVisibility()
@@ -120,5 +150,25 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
             this.Visibility = Element?.IsVisible == true ? Visibility.Visible : Visibility.Collapsed;
 #endif
         }
+
+        private void UpdateMinMaxAttachmentText()
+        {
+            if (Element is null)
+            {
+                UpdateMinMaxAttachmentTextCore(0u, 0u);
+                return;
+            }
+
+            UpdateMinMaxAttachmentTextCore(Element.MinAttachmentCount, Element.MaxAttachmentCount);
+        }
+
+        private partial void UpdateAddAttachmentButtonState();
+
+        private static bool HasConfiguredMaxAttachmentCount(uint maxAttachmentCount)
+        {
+            return maxAttachmentCount > 0 && maxAttachmentCount < uint.MaxValue;
+        }
+
+        private partial void UpdateMinMaxAttachmentTextCore(uint minAttachmentCount, uint maxAttachmentCount);
     }
 }

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/AttachmentsFormElementView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/AttachmentsFormElementView.cs
@@ -18,6 +18,7 @@
 using Esri.ArcGISRuntime.Data;
 using Esri.ArcGISRuntime.Mapping.FeatureForms;
 using Esri.ArcGISRuntime.Toolkit.Internal;
+using System.Collections.Specialized;
 using System.ComponentModel;
 #if WPF || WINDOWS_XAML
 using Esri.ArcGISRuntime.Toolkit.UI.Controls;
@@ -79,6 +80,11 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
 
         private async void OnElementPropertyChanged(AttachmentsFormElement? oldValue, AttachmentsFormElement? newValue)
         {
+            if (oldValue?.Attachments is INotifyCollectionChanged oldAttachments)
+            {
+                oldAttachments.CollectionChanged -= Attachments_CollectionChanged;
+            }
+
             if (oldValue is INotifyPropertyChanged inpcOld)
             {
                 _elementPropertyChangedListener?.Detach();
@@ -93,6 +99,13 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                 };
                 inpcNew.PropertyChanged += _elementPropertyChangedListener.OnEvent;
             }
+
+            if (newValue?.Attachments is INotifyCollectionChanged newAttachments)
+            {
+                newAttachments.CollectionChanged -= Attachments_CollectionChanged;
+                newAttachments.CollectionChanged += Attachments_CollectionChanged;
+            }
+
             UpdateVisibility();
             UpdateAddAttachmentButtonState();
             UpdateMinMaxAttachmentText();
@@ -120,8 +133,24 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                 this.Dispatch(UpdateAddAttachmentButtonState);
             }
 
+            if (e.PropertyName == nameof(AttachmentsFormElement.Attachments))
+            {
+                if (sender is AttachmentsFormElement element && element.Attachments is INotifyCollectionChanged collection)
+                {
+                    collection.CollectionChanged -= Attachments_CollectionChanged;
+                    collection.CollectionChanged += Attachments_CollectionChanged;
+                }
+
+                this.Dispatch(UpdateMinMaxAttachmentText);
+            }
+
             if (e.PropertyName == nameof(AttachmentsFormElement.MinAttachmentCount) ||
                 e.PropertyName == nameof(AttachmentsFormElement.MaxAttachmentCount))
+            {
+                this.Dispatch(UpdateMinMaxAttachmentText);
+            }
+
+            if (e.PropertyName == "ValidationErrors")
             {
                 this.Dispatch(UpdateMinMaxAttachmentText);
             }
@@ -130,6 +159,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
         private void Attachments_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
             this.Dispatch(UpdateAddAttachmentButtonState);
+            this.Dispatch(UpdateMinMaxAttachmentText);
         }
 
         private bool CanAddAttachment()
@@ -155,11 +185,26 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
         {
             if (Element is null)
             {
-                UpdateMinMaxAttachmentTextCore(0u, 0u);
+                UpdateMinMaxAttachmentTextCore(string.Empty, false, string.Empty, false, string.Empty, false);
                 return;
             }
 
-            UpdateMinMaxAttachmentTextCore(Element.MinAttachmentCount, Element.MaxAttachmentCount);
+            uint minAttachmentCount = Element.MinAttachmentCount;
+            uint maxAttachmentCount = Element.MaxAttachmentCount;
+            uint attachmentCount = (uint)Element.Attachments.Count;
+            var validationErrors = GetValidationErrors(Element);
+
+            bool minVisible = minAttachmentCount > 0;
+            bool maxVisible = HasConfiguredMaxAttachmentCount(maxAttachmentCount);
+            bool hasMinError = minVisible && (HasMinimumAttachmentCountError(validationErrors) || attachmentCount < minAttachmentCount);
+            bool hasMaxError = maxVisible && (HasMaximumAttachmentCountError(validationErrors) || attachmentCount > maxAttachmentCount);
+            bool hasError = hasMinError || hasMaxError;
+
+            string minText = GetMinimumAttachmentCountLabel(minAttachmentCount);
+            string maxText = GetMaximumAttachmentCountLabel(maxAttachmentCount);
+            string errorText = GetAttachmentCountErrorMessage(hasMinError, minAttachmentCount, hasMaxError, maxAttachmentCount);
+
+            UpdateMinMaxAttachmentTextCore(minText, minVisible && !hasError, maxText, maxVisible && !hasError, errorText, hasError);
         }
 
         private partial void UpdateAddAttachmentButtonState();
@@ -169,6 +214,77 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
             return maxAttachmentCount > 0 && maxAttachmentCount < uint.MaxValue;
         }
 
-        private partial void UpdateMinMaxAttachmentTextCore(uint minAttachmentCount, uint maxAttachmentCount);
+        private static IEnumerable<Exception> GetValidationErrors(AttachmentsFormElement element)
+        {
+            return element.ValidationErrors;
+        }
+
+        private static bool HasMinimumAttachmentCountError(IEnumerable<Exception> errors)
+        {
+            foreach (var error in errors)
+            {
+                if (error is FeatureFormLessThanMinimumAttachmentCountException)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool HasMaximumAttachmentCountError(IEnumerable<Exception> errors)
+        {
+            foreach (var error in errors)
+            {
+                if (error is FeatureFormExceedsMaximumAttachmentCountException)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static string GetMinimumAttachmentCountErrorMessage(uint minAttachmentCount)
+        {
+            return string.Format(Properties.Resources.GetString("FeatureFormMinimumAttachmentCountRequired")!, minAttachmentCount);
+        }
+
+        private static string GetMaximumAttachmentCountErrorMessage(uint maxAttachmentCount)
+        {
+            return string.Format(Properties.Resources.GetString("FeatureFormMaximumAttachmentCountAllowed")!, maxAttachmentCount);
+        }
+
+        private static string GetMinimumAttachmentCountLabel(uint minAttachmentCount)
+        {
+            return string.Format(Properties.Resources.GetString("FeatureFormMinimumAttachmentCountLabel")!, minAttachmentCount);
+        }
+
+        private static string GetMaximumAttachmentCountLabel(uint maxAttachmentCount)
+        {
+            return string.Format(Properties.Resources.GetString("FeatureFormMaximumAttachmentCountLabel")!, maxAttachmentCount);
+        }
+
+        private static string GetAttachmentCountErrorMessage(bool hasMinError, uint minAttachmentCount, bool hasMaxError, uint maxAttachmentCount)
+        {
+            if (hasMinError && hasMaxError)
+            {
+                return $"{GetMinimumAttachmentCountErrorMessage(minAttachmentCount)} {GetMaximumAttachmentCountErrorMessage(maxAttachmentCount)}";
+            }
+
+            if (hasMinError)
+            {
+                return GetMinimumAttachmentCountErrorMessage(minAttachmentCount);
+            }
+
+            if (hasMaxError)
+            {
+                return GetMaximumAttachmentCountErrorMessage(maxAttachmentCount);
+            }
+
+            return string.Empty;
+        }
+
+        private partial void UpdateMinMaxAttachmentTextCore(string minAttachmentText, bool minVisible, string maxAttachmentText, bool maxVisible, string errorText, bool errorVisible);
     }
 }

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/AttachmentsFormElementView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/AttachmentsFormElementView.cs
@@ -126,6 +126,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                 {
                     _isAttachmentsLoaded = true;
                     UpdateAddAttachmentButtonState();
+                    UpdateMinMaxAttachmentText();
                 }
             }
         }
@@ -204,11 +205,12 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
             uint maxAttachmentCount = Element.MaxAttachmentCount;
             uint attachmentCount = (uint)Element.Attachments.Count;
             var (minErrorFromValidation, maxErrorFromValidation) = GetAttachmentCountValidationErrors(Element.ValidationErrors);
+            bool canEvaluateAttachmentCount = _isAttachmentsLoaded;
 
             bool minVisible = minAttachmentCount > 0;
             bool maxVisible = HasConfiguredMaxAttachmentCount(maxAttachmentCount);
-            bool hasMinError = minVisible && (minErrorFromValidation || attachmentCount < minAttachmentCount);
-            bool hasMaxError = maxVisible && (maxErrorFromValidation || attachmentCount > maxAttachmentCount);
+            bool hasMinError = canEvaluateAttachmentCount && minVisible && (minErrorFromValidation || attachmentCount < minAttachmentCount);
+            bool hasMaxError = canEvaluateAttachmentCount && maxVisible && (maxErrorFromValidation || attachmentCount > maxAttachmentCount);
             bool hasError = hasMinError || hasMaxError;
 
             string minText = GetMinimumAttachmentCountLabel(minAttachmentCount);

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/AttachmentsFormElementView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/AttachmentsFormElementView.cs
@@ -192,12 +192,12 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
             uint minAttachmentCount = Element.MinAttachmentCount;
             uint maxAttachmentCount = Element.MaxAttachmentCount;
             uint attachmentCount = (uint)Element.Attachments.Count;
-            var validationErrors = GetValidationErrors(Element);
+            var (minErrorFromValidation, maxErrorFromValidation) = GetAttachmentCountValidationErrors(Element.ValidationErrors);
 
             bool minVisible = minAttachmentCount > 0;
             bool maxVisible = HasConfiguredMaxAttachmentCount(maxAttachmentCount);
-            bool hasMinError = minVisible && (HasMinimumAttachmentCountError(validationErrors) || attachmentCount < minAttachmentCount);
-            bool hasMaxError = maxVisible && (HasMaximumAttachmentCountError(validationErrors) || attachmentCount > maxAttachmentCount);
+            bool hasMinError = minVisible && (minErrorFromValidation || attachmentCount < minAttachmentCount);
+            bool hasMaxError = maxVisible && (maxErrorFromValidation || attachmentCount > maxAttachmentCount);
             bool hasError = hasMinError || hasMaxError;
 
             string minText = GetMinimumAttachmentCountLabel(minAttachmentCount);
@@ -214,35 +214,29 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
             return maxAttachmentCount > 0 && maxAttachmentCount < uint.MaxValue;
         }
 
-        private static IEnumerable<Exception> GetValidationErrors(AttachmentsFormElement element)
+        private static (bool HasMinimumError, bool HasMaximumError) GetAttachmentCountValidationErrors(IEnumerable<Exception> errors)
         {
-            return element.ValidationErrors;
-        }
+            bool hasMinimumError = false;
+            bool hasMaximumError = false;
 
-        private static bool HasMinimumAttachmentCountError(IEnumerable<Exception> errors)
-        {
             foreach (var error in errors)
             {
                 if (error is FeatureFormLessThanMinimumAttachmentCountException)
                 {
-                    return true;
+                    hasMinimumError = true;
                 }
-            }
-
-            return false;
-        }
-
-        private static bool HasMaximumAttachmentCountError(IEnumerable<Exception> errors)
-        {
-            foreach (var error in errors)
-            {
-                if (error is FeatureFormExceedsMaximumAttachmentCountException)
+                else if (error is FeatureFormExceedsMaximumAttachmentCountException)
                 {
-                    return true;
+                    hasMaximumError = true;
+                }
+
+                if (hasMinimumError && hasMaximumError)
+                {
+                    break;
                 }
             }
 
-            return false;
+            return (hasMinimumError, hasMaximumError);
         }
 
         private static string GetMinimumAttachmentCountErrorMessage(uint minAttachmentCount)

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FeatureFormView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FeatureFormView.cs
@@ -492,13 +492,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
                 {
                     item.ResetValidationState();
                 }
-               ((Command)FinishEditingCommand).RaiseCanExecuteChanged();
-                if (requireAllErrorsResolved && HasAttachmentCountError())
-                {
-                    _ = ScrollToFirstError();
-
-                    return false;
-                }
+                ((Command)FinishEditingCommand).RaiseCanExecuteChanged();
 
                 if (requireAllErrorsResolved && ScrollToFirstError()) return false;
                 await FinishEditingAsync();

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FeatureFormView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FeatureFormView.cs
@@ -281,7 +281,9 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
 
         private void UpdateIsValidProperty()
         {
-            IsValid = CurrentFeatureForm?.ElementValidationErrors?.Any() != true;
+            bool hasElementErrors = CurrentFeatureForm?.ElementValidationErrors?.Any() == true;
+            bool hasAttachmentErrors = HasAttachmentCountError();
+            IsValid = !hasElementErrors && !hasAttachmentErrors;
         }
 
         /// <summary>
@@ -320,7 +322,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             return ErrorsVisibility == ValidationErrorVisibility.Visible || _wasFinishEditingAttempted;
         }
 
-        private IEnumerable<FieldFormElement> EnumerateVisibleElements(IEnumerable<FormElement>? elements)
+        private IEnumerable<FormElement> EnumerateVisibleElements(IEnumerable<FormElement>? elements)
         {
             if (elements is not null)
             {
@@ -328,11 +330,14 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
                 {
                     if (element.IsVisible)
                     {
-                        if (element is FieldFormElement field) yield return field;
-                        else if (element is GroupFormElement group)
+                        if (element is GroupFormElement group)
                         {
                             foreach (var elm in EnumerateVisibleElements(group.Elements))
                                 yield return elm;
+                        }
+                        else
+                        {
+                            yield return element;
                         }
                     }
                 }
@@ -347,13 +352,33 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         {
             foreach (var item in EnumerateVisibleElements(CurrentFeatureForm?.Elements))
             {
-                bool elementHasVisibleError = item.ValidationErrors.Any() && item.IsEditable == true;
-                if (elementHasVisibleError)
+                if (item is FieldFormElement fieldElement)
                 {
-                    ScrollTo(item);
-                    return true;
+                    bool elementHasVisibleError = fieldElement.ValidationErrors.Any() && fieldElement.IsEditable == true;
+                    if (elementHasVisibleError)
+                    {
+                        ScrollTo(fieldElement);
+                        return true;
+                    }
+                }
+                else if (item is AttachmentsFormElement attachmentsElement)
+                {
+                    if (HasAttachmentElementError(attachmentsElement))
+                    {
+                        ScrollTo(attachmentsElement);
+                        return true;
+                    }
                 }
             }
+
+            var defaultAttachmentsElement = CurrentFeatureForm?.DefaultAttachmentsElement;
+            if (defaultAttachmentsElement?.IsVisible == true &&
+                HasAttachmentElementError(defaultAttachmentsElement))
+            {
+                ScrollTo(defaultAttachmentsElement);
+                return true;
+            }
+
             return false;
         }
 
@@ -363,6 +388,8 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         /// <param name="element">Form element to scrollto.</param>
         public void ScrollTo(FormElement element)
         {
+            bool didScroll = false;
+
             foreach (var item in GetDescendentsOfType<FieldFormElementView>(this))
             {
                 if (item.Element == element)
@@ -377,8 +404,48 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
                         _ = subView.ScrollToAsync(item, ScrollToPosition.MakeVisible, true);
                     }
 #endif
+                    didScroll = true;
+                    break;
                 }
             }
+
+            foreach (var item in GetDescendentsOfType<AttachmentsFormElementView>(this))
+            {
+                if (item.Element == element)
+                {
+                    ScrollToAttachmentView(item);
+                    didScroll = true;
+                    break;
+                }
+            }
+
+            // Fallback: if reference matching fails for an attachment element, scroll to the first visible
+            // attachment view currently in an error state so the user still lands on actionable UI.
+            if (!didScroll && element is AttachmentsFormElement)
+            {
+                foreach (var item in GetDescendentsOfType<AttachmentsFormElementView>(this))
+                {
+                    if (item.Element is AttachmentsFormElement attachmentElement && HasAttachmentElementError(attachmentElement))
+                    {
+                        ScrollToAttachmentView(item);
+                        break;
+                    }
+                }
+            }
+        }
+
+        private void ScrollToAttachmentView(AttachmentsFormElementView item)
+        {
+#if WINDOWS_XAML
+            item.StartBringIntoView();
+#elif WPF
+            item.BringIntoView();
+#elif MAUI
+            if (GetTemplateChild("SubFrameView") is NavigationSubView subView)
+            {
+                _ = subView.ScrollToAsync(item, ScrollToPosition.MakeVisible, true);
+            }
+#endif
         }
 
         /// <summary>
@@ -426,10 +493,76 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
                     item.ResetValidationState();
                 }
                ((Command)FinishEditingCommand).RaiseCanExecuteChanged();
+                if (requireAllErrorsResolved && HasAttachmentCountError())
+                {
+                    _ = ScrollToFirstError();
+
+                    return false;
+                }
+
                 if (requireAllErrorsResolved && ScrollToFirstError()) return false;
                 await FinishEditingAsync();
                 return true;
             }
+            return false;
+        }
+
+        private bool HasAttachmentCountError()
+        {
+            foreach (var attachmentsElement in EnumerateVisibleAttachmentElements())
+            {
+                if (HasAttachmentElementError(attachmentsElement))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private IEnumerable<AttachmentsFormElement> EnumerateVisibleAttachmentElements()
+        {
+            foreach (var element in EnumerateVisibleElements(CurrentFeatureForm?.Elements))
+            {
+                if (element is AttachmentsFormElement attachmentsElement)
+                {
+                    yield return attachmentsElement;
+                }
+            }
+
+            if (CurrentFeatureForm?.DefaultAttachmentsElement is AttachmentsFormElement defaultAttachmentsElement &&
+                defaultAttachmentsElement.IsVisible)
+            {
+                yield return defaultAttachmentsElement;
+            }
+        }
+
+        private static bool HasAttachmentElementError(AttachmentsFormElement attachmentsElement)
+        {
+            if (!attachmentsElement.IsVisible)
+            {
+                return false;
+            }
+
+            if (attachmentsElement.ValidationErrors.Any(error =>
+                error is FeatureFormLessThanMinimumAttachmentCountException ||
+                error is FeatureFormExceedsMaximumAttachmentCountException))
+            {
+                return true;
+            }
+
+            uint count = (uint)attachmentsElement.Attachments.Count;
+            if (attachmentsElement.MinAttachmentCount > 0 && count < attachmentsElement.MinAttachmentCount)
+            {
+                return true;
+            }
+
+            bool hasConfiguredMax = attachmentsElement.MaxAttachmentCount > 0 && attachmentsElement.MaxAttachmentCount < uint.MaxValue;
+            if (hasConfiguredMax && count > attachmentsElement.MaxAttachmentCount)
+            {
+                return true;
+            }
+
             return false;
         }
 
@@ -672,7 +805,10 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
                     var result = await dialog.ShowAsync();
                     if (result == ContentDialogResult.Primary)
                     {
-                        await FinishEditingAsync();
+                        if (!await FinishEditingAsync(true))
+                        {
+                            e.Cancel = true;
+                        }
                     }
                     else if (result == ContentDialogResult.Secondary)
                     {
@@ -698,7 +834,10 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
                 {
                     try
                     {
-                        await FinishEditingAsync();
+                        if (!await FinishEditingAsync(true))
+                        {
+                            e.Cancel = true;
+                        }
                     }
                     catch(System.Exception ex)
                     {
@@ -722,7 +861,10 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
                         string action = await page.DisplayActionSheetAsync(title, cancelText, null, applyText, discardText);
                         if (action == applyText)
                         {
-                            await FinishEditingAsync();
+                            if (!await FinishEditingAsync(true))
+                            {
+                                e.Cancel = true;
+                            }
                         }
                         else if (action == discardText)
                         {


### PR DESCRIPTION
Changes are related to the [recent attachment enhancements](https://devtopia.esri.com/runtime/dotnet-api/issues/14577). Creating small feature wise PRs for easy review

With these changes, when the min/ max attachments are configured, it will be displayed in the UI below the description of the respective element. If there are any validation errors related to count (1. exceeding max count - ideally not possible as we disabled the add button but can happen if the attachments are first added and then the configuration is changed. 2. Not meeting the min requirement) then the min/ max count labels will be replaced by the respective error message (localized) in red color. Also, when the user tries to apply the edits when the form is in error state, then the form will scroll to the 1st element with the validation error (similar to a required text field element).

Additional changes: Set the Min height on Items control, opacity on description to have consistent UI across platforms

**Webmap used for testing:** https://runtimecoretest.maps.arcgis.com/home/item.html?id=5a6c6351dc4e44a189a6d56955fb4626

**Note:** In WPF, observed that the horizontal scroll of attachments is interfering with vertical scroll of the form, which is not caused by these changes but more evident now, as I have set the min height on the attachments. Will create a separate PR for that fix
Also, might need the binding fix in WinUI https://github.com/Esri/arcgis-maps-sdk-dotnet-toolkit/pull/798 for testing

https://github.com/user-attachments/assets/d90881ac-5dfa-45cf-b829-04105a55dea9

