### PR TITLE
[Feature Form] [Attachments]: Display alert/ dialog on attachment upload

### DIFF
--- a/src/Toolkit/Toolkit/LocalizedStrings/Resources.resx
+++ b/src/Toolkit/Toolkit/LocalizedStrings/Resources.resx
@@ -133,6 +133,22 @@
     <value>Take Photo</value>
     <comment>Menu text for adding an attachment by taking a photo</comment>
   </data>
+  <data name="FeatureFormAttachmentTypeValidationError" xml:space="preserve">
+    <value>This file type is not supported. Allowed types: {0}</value>
+    <comment>Validation error shown when the selected attachment file type is unsupported; {0} is a comma-separated list of allowed types.</comment>
+  </data>
+  <data name="FeatureFormAttachmentSizeValidationError" xml:space="preserve">
+    <value>This file is too large. Maximum allowed size is {0} MB.</value>
+    <comment>Validation error shown when the selected attachment exceeds the maximum allowed size; {0} is the maximum size in megabytes.</comment>
+  </data>
+  <data name="FeatureFormAttachmentSizeValidationErrorFallback" xml:space="preserve">
+    <value>This file is too large.</value>
+    <comment>Validation error shown when the selected attachment exceeds the maximum allowed size but no size value is available.</comment>
+  </data>
+  <data name="FeatureFormAttachmentValidationErrorTitle" xml:space="preserve">
+    <value>Attachment upload failed</value>
+    <comment>Title text for the attachment validation alert dialog.</comment>
+  </data>
   <data name="FeatureFormExceedsMaximumDateTime" xml:space="preserve">
     <value>Date must be on or before {0}</value>
     <comment>Input validation of entered date must be before or on the maximum allowed date {0}</comment>

--- a/src/Toolkit/Toolkit/LocalizedStrings/Resources.resx
+++ b/src/Toolkit/Toolkit/LocalizedStrings/Resources.resx
@@ -145,6 +145,14 @@
     <value>This file is too large.</value>
     <comment>Validation error shown when the selected attachment exceeds the maximum allowed size but no size value is available.</comment>
   </data>
+  <data name="FeatureFormAttachmentDurationValidationError" xml:space="preserve">
+    <value>This media is too long. Maximum allowed duration is {0} seconds.</value>
+    <comment>Validation error shown when selected audio or video exceeds the maximum duration; {0} is the allowed duration or durations in seconds.</comment>
+  </data>
+  <data name="FeatureFormAttachmentDurationValidationErrorFallback" xml:space="preserve">
+    <value>This media is too long.</value>
+    <comment>Validation error shown when selected audio or video exceeds the maximum duration but no limit value is available.</comment>
+  </data>
   <data name="FeatureFormAttachmentValidationErrorTitle" xml:space="preserve">
     <value>Attachment upload failed</value>
     <comment>Title text for the attachment validation alert dialog.</comment>

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/AttachmentsFormElementView.Maui.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/AttachmentsFormElementView.Maui.cs
@@ -259,7 +259,10 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
                     }
                     catch (System.Exception ex)
                     {
-                        Trace.WriteLine("Failed to add attachment: " + ex.Message, "ArcGIS Maps SDK Toolkit");
+                        if (!TryHandleAttachmentValidationException(ex))
+                        {
+                            Trace.WriteLine("Failed to add attachment: " + ex.Message, "ArcGIS Maps SDK Toolkit");
+                        }
                     }
                 }
                 if (result == addAttachment)
@@ -287,7 +290,21 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
             }
             catch (System.Exception ex)
             {
-                System.Diagnostics.Trace.WriteLine("Failed to add attachment: " + ex.Message);
+                if (!TryHandleAttachmentValidationException(ex))
+                {
+                    System.Diagnostics.Trace.WriteLine("Failed to add attachment: " + ex.Message);
+                }
+            }
+        }
+
+        private async partial Task ShowAttachmentValidationAlertAsync(string message)
+        {
+            if (GetParent<Page>() is Page page)
+            {
+                await page.DisplayAlertAsync(
+                    Properties.Resources.GetString("FeatureFormAttachmentValidationErrorTitle")!,
+                    message,
+                    Properties.Resources.GetString("FeatureFormRenameAttachmentDialogOK")!);
             }
         }
 

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/AttachmentsFormElementView.Maui.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/AttachmentsFormElementView.Maui.cs
@@ -292,7 +292,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Maui.Primitives
             {
                 if (!TryHandleAttachmentValidationException(ex))
                 {
-                    System.Diagnostics.Trace.WriteLine("Failed to add attachment: " + ex.Message);
+                    System.Diagnostics.Trace.WriteLine("Failed to add attachment: " + ex.Message, "ArcGIS Maps SDK Toolkit");
                 }
             }
         }

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/AttachmentsFormElementView.Windows.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/AttachmentsFormElementView.Windows.cs
@@ -152,7 +152,10 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
             }
             catch (System.Exception ex)
             {
-                System.Diagnostics.Trace.WriteLine("Failed to add attachment: " + ex.Message);
+                if (!TryHandleAttachmentValidationException(ex))
+                {
+                    System.Diagnostics.Trace.WriteLine("Failed to add attachment: " + ex.Message);
+                }
             }
         }
 

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/AttachmentsFormElementView.Windows.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/AttachmentsFormElementView.Windows.cs
@@ -167,6 +167,24 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
             }
         }
 
+        private async partial Task ShowAttachmentValidationAlertAsync(string message)
+        {
+            string title = Properties.Resources.GetString("FeatureFormAttachmentValidationErrorTitle")!;
+#if WPF
+            System.Windows.MessageBox.Show(message, title);
+            await Task.CompletedTask;
+#elif WINDOWS_XAML
+            var dialog = new ContentDialog
+            {
+                Title = title,
+                Content = message,
+                CloseButtonText = Properties.Resources.GetString("FeatureFormRenameAttachmentDialogOK")!
+            };
+            dialog.XamlRoot = this.XamlRoot;
+            await dialog.ShowAsync();
+#endif
+        }
+
         private partial void UpdateMinMaxAttachmentTextCore(string minAttachmentText, bool minVisible, string maxAttachmentText, bool maxVisible, string errorText, bool errorVisible)
         {
             if (_minAttachmentBadge is not null)

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/AttachmentsFormElementView.Windows.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/AttachmentsFormElementView.Windows.cs
@@ -154,7 +154,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
             {
                 if (!TryHandleAttachmentValidationException(ex))
                 {
-                    System.Diagnostics.Trace.WriteLine("Failed to add attachment: " + ex.Message);
+                    System.Diagnostics.Trace.WriteLine("Failed to add attachment: " + ex.Message, "ArcGIS Maps SDK Toolkit");
                 }
             }
         }

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/AttachmentsFormElementView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/AttachmentsFormElementView.cs
@@ -313,6 +313,13 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                     return true;
                 }
 
+                if (current is FeatureFormExceedsMaximumAttachmentDurationException)
+                {
+                    string message = GetMaximumAttachmentDurationErrorMessage();
+                    _ = ShowAttachmentValidationAlertAsync(message);
+                    return true;
+                }
+
                 current = current.InnerException;
             }
 
@@ -332,6 +339,40 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
             double maxSizeInMbValue = documentInput.MaxFileSize / bytesPerMegabyte;
             string maxSizeInMb = maxSizeInMbValue.ToString("0.##", CultureInfo.CurrentCulture);
             return string.Format(Properties.Resources.GetString("FeatureFormAttachmentSizeValidationError")!, maxSizeInMb);
+        }
+
+        private string GetMaximumAttachmentDurationErrorMessage()
+        {
+            string allowedDurations = GetAllowedMediaDurationsForCurrentInputs();
+            if (string.IsNullOrWhiteSpace(allowedDurations))
+            {
+                return Properties.Resources.GetString("FeatureFormAttachmentDurationValidationErrorFallback")!;
+            }
+
+            return string.Format(Properties.Resources.GetString("FeatureFormAttachmentDurationValidationError")!, allowedDurations);
+        }
+
+        private string GetAllowedMediaDurationsForCurrentInputs()
+        {
+            var element = Element;
+            if (element is null)
+            {
+                return string.Empty;
+            }
+
+            foreach (var input in element.Inputs)
+            {
+                if (input is AudioFormInput audioInput)
+                {
+                    return audioInput.MaxDuration.ToString("0.##", CultureInfo.CurrentCulture);
+                }
+                else if (input is VideoFormInput videoInput)
+                {
+                    return videoInput.MaxDuration.ToString("0.##", CultureInfo.CurrentCulture);
+                }
+            }
+
+            return string.Empty;
         }
 
         private DocumentFormInput? GetDocumentInputForCurrentInputs()

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/AttachmentsFormElementView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/AttachmentsFormElementView.cs
@@ -327,7 +327,8 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                 return Properties.Resources.GetString("FeatureFormAttachmentSizeValidationErrorFallback")!;
             }
 
-            const double bytesPerMegabyte = 1024d * 1024d;
+            // Use decimal MB (1,000,000 bytes) to match FeatureForm attachment size configuration units.
+            const double bytesPerMegabyte = 1000d * 1000d;
             double maxSizeInMbValue = documentInput.MaxFileSize / bytesPerMegabyte;
             string maxSizeInMb = maxSizeInMbValue.ToString("0.##", CultureInfo.CurrentCulture);
             return string.Format(Properties.Resources.GetString("FeatureFormAttachmentSizeValidationError")!, maxSizeInMb);

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/AttachmentsFormElementView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/AttachmentsFormElementView.cs
@@ -20,6 +20,7 @@ using Esri.ArcGISRuntime.Mapping.FeatureForms;
 using Esri.ArcGISRuntime.Toolkit.Internal;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Globalization;
 #if WPF || WINDOWS_XAML
 using Esri.ArcGISRuntime.Toolkit.UI.Controls;
 #elif MAUI
@@ -291,6 +292,107 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
 
             return string.Empty;
         }
+
+        private bool TryHandleAttachmentValidationException(Exception ex)
+        {
+            Exception? current = ex;
+            while (current is not null)
+            {
+                if (current is FeatureFormIncorrectAttachmentTypeException)
+                {
+                    string allowedTypes = GetAllowedAttachmentTypesForCurrentInputs();
+                    string message = string.Format(Properties.Resources.GetString("FeatureFormAttachmentTypeValidationError")!, allowedTypes);
+                    _ = ShowAttachmentValidationAlertAsync(message);
+                    return true;
+                }
+
+                if (current is FeatureFormExceedsMaximumAttachmentSizeException)
+                {
+                    string message = GetMaximumAttachmentSizeErrorMessage();
+                    _ = ShowAttachmentValidationAlertAsync(message);
+                    return true;
+                }
+
+                current = current.InnerException;
+            }
+
+            return false;
+        }
+
+        private string GetMaximumAttachmentSizeErrorMessage()
+        {
+            var documentInput = GetDocumentInputForCurrentInputs();
+            if (documentInput is null)
+            {
+                return Properties.Resources.GetString("FeatureFormAttachmentSizeValidationErrorFallback")!;
+            }
+
+            const double bytesPerMegabyte = 1024d * 1024d;
+            double maxSizeInMbValue = documentInput.MaxFileSize / bytesPerMegabyte;
+            string maxSizeInMb = maxSizeInMbValue.ToString("0.##", CultureInfo.CurrentCulture);
+            return string.Format(Properties.Resources.GetString("FeatureFormAttachmentSizeValidationError")!, maxSizeInMb);
+        }
+
+        private DocumentFormInput? GetDocumentInputForCurrentInputs()
+        {
+            var element = Element;
+            if (element is null)
+            {
+                return null;
+            }
+
+            foreach (var input in element.Inputs)
+            {
+                if (input is DocumentFormInput documentInput)
+                {
+                    return documentInput;
+                }
+            }
+
+            return null;
+        }
+
+        private string GetAllowedAttachmentTypesForCurrentInputs()
+        {
+            var element = Element;
+            if (element is null)
+            {
+                return string.Empty;
+            }
+
+            List<string> allowedTypes = new List<string>();
+            foreach (var input in element.Inputs)
+            {
+                if (input is AudioFormInput)
+                {
+                    AddAllowedType(allowedTypes, "audio");
+                }
+                else if (input is DocumentFormInput)
+                {
+                    AddAllowedType(allowedTypes, "document");
+                }
+                else if (input is ImageFormInput)
+                {
+                    AddAllowedType(allowedTypes, "image");
+                }
+                else if (input is VideoFormInput)
+                {
+                    AddAllowedType(allowedTypes, "video");
+                }
+            }
+
+            return string.Join(", ", allowedTypes);
+        }
+
+        private static void AddAllowedType(List<string> allowedTypes, string allowedType)
+        {
+            if (!allowedTypes.Contains(allowedType, StringComparer.OrdinalIgnoreCase))
+            {
+                allowedTypes.Add(allowedType);
+            }
+        }
+
+        private partial Task ShowAttachmentValidationAlertAsync(string message);
 
         private partial void UpdateMinMaxAttachmentTextCore(string minAttachmentText, bool minVisible, string maxAttachmentText, bool maxVisible, string errorText, bool errorVisible);
     }

--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FormAttachmentView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/FormAttachmentView.cs
@@ -234,7 +234,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                     }
                     catch (System.Exception ex)
                     {
-                        System.Diagnostics.Trace.WriteLine($"Failed to save file to disk: " + ex.Message);
+                        System.Diagnostics.Trace.WriteLine($"Failed to save file to disk: " + ex.Message, "ArcGIS Maps SDK Toolkit");
                     }
                 }
 #elif WINDOWS_XAML


### PR DESCRIPTION
Changes are related to the [recent attachment enhancements](https://devtopia.esri.com/runtime/dotnet-api/issues/14577). Creating small feature wise PRs for easy review.

With these changes, an alert/ dialog is displayed 
1. When `MaxDuration` (on Audio/ Video) is configured and the uploaded audio/ video file has the duration>`MaxDuration`
2. When `MaxFileSize` (on document) is configured and the uploaded document size > `MaxFileSize `

Note: Will require [this PR](https://devtopia.esri.com/runtime/dotnet-api/pull/14661) to be merged for the max duration exception to work.
Web map used for testing: https://runtimecoretest.maps.arcgis.com/home/item.html?id=5a6c6351dc4e44a189a6d56955fb4626
