### PR TITLE
Fix for FeatureForm datetime element update

### DIFF
--- a/src/Toolkit/Toolkit/UI/Controls/FeatureForm/DateTimePickerFormInputView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/FeatureForm/DateTimePickerFormInputView.cs
@@ -70,7 +70,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Primitives
                 if (doffset.HasValue)
                     date = new DateTime(doffset.Value.Ticks, DateTimeKind.Local);
 #else
-                date = _datePicker.SelectedDate?.ToUniversalTime();
+                date = _datePicker.SelectedDate?.Date.ToUniversalTime();
 #endif
                 TimeSpan? timePicked = _timePicker?.Time;
                 if (date is DateTime newDate && input.IncludeTime && timePicked is TimeSpan time


### PR DESCRIPTION
Fix update datatime issue.
This fixes issue where after updating a datetime element, the new time was being added old time before being set on the element.