### PR TITLE
UITests: Increase compass hide timeout

### DIFF
--- a/src/Tests/UITests/Toolkit.UITests.Shared/Tests/Compass/CompassTests.cs
+++ b/src/Tests/UITests/Toolkit.UITests.Shared/Tests/Compass/CompassTests.cs
@@ -38,7 +38,7 @@ public class CompassTests : AppiumTestBase
         SetRotation(0);
         Click(autoHideButton);
 
-        var maxTries = 5;
+        var maxTries = 10;
         var hidden = false;
         for (var tryCount = 0; tryCount < maxTries; tryCount++)
         {


### PR DESCRIPTION
Doubled allowance from ~2.5 seconds to ~5 because of flakiness on mac/ios