### PR TITLE
UITests: Fix windows ci runs by placing koffi in the appium folder

### DIFF
--- a/src/Tests/UITests/cibuild/utils.psm1
+++ b/src/Tests/UITests/cibuild/utils.psm1
@@ -70,8 +70,8 @@ function Invoke-WindowsUITests {
     exit $LASTEXITCODE
   }
 
-  # Install koffi
-  & $npm_exe install koffi --prefix $node_workspace
+  # Install koffi where the Windows driver can resolve it.
+  & $npm_exe install koffi --prefix $env:APPIUM_HOME
   if ($LASTEXITCODE -ne 0) {
     Write-Error "Error installing koffi node module. Koffi is necessary to avoid reliance on node-ffi, which in turn requires a Visual Studio install."
     exit $LASTEXITCODE

--- a/src/Tests/UITests/cibuild/utils.psm1
+++ b/src/Tests/UITests/cibuild/utils.psm1
@@ -70,7 +70,7 @@ function Invoke-WindowsUITests {
     exit $LASTEXITCODE
   }
 
-  # Install koffi where the Windows driver can resolve it.
+  # Install koffi
   & $npm_exe install koffi --prefix $env:APPIUM_HOME
   if ($LASTEXITCODE -ne 0) {
     Write-Error "Error installing koffi node module. Koffi is necessary to avoid reliance on node-ffi, which in turn requires a Visual Studio install."


### PR DESCRIPTION
I had placed Koffi in the node modules rather than the appium modules. I'm unclear why this stopped working only now, but the appium folder should be a better place for it regardless