### PR TITLE
Bump UITest and Analyzer dependencies

### DIFF
--- a/src/Analyzers/Toolkit.Maui.Analyzers.CodeFixes/Esri.ArcGISRuntime.Toolkit.Maui.Analyzers.CodeFixes.csproj
+++ b/src/Analyzers/Toolkit.Maui.Analyzers.CodeFixes/Esri.ArcGISRuntime.Toolkit.Maui.Analyzers.CodeFixes.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.6.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Analyzers/Toolkit.Maui.Analyzers.UnitTests/Esri.ArcGISRuntime.Toolkit.Maui.Analyzers.UnitTests.csproj
+++ b/src/Analyzers/Toolkit.Maui.Analyzers.UnitTests/Esri.ArcGISRuntime.Toolkit.Maui.Analyzers.UnitTests.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="MSTest" Version="4.0.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="5.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="5.6.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest" Version="1.1.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.MSTest" Version="1.1.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.MSTest" Version="1.1.2" />

--- a/src/Analyzers/Toolkit.Maui.Analyzers/Esri.ArcGISRuntime.Toolkit.Maui.Analyzers.csproj
+++ b/src/Analyzers/Toolkit.Maui.Analyzers/Esri.ArcGISRuntime.Toolkit.Maui.Analyzers.csproj
@@ -15,8 +15,8 @@
   <ItemGroup>
     <Using Include="System" />
     <Using Include="System.Linq" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="5.6.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tests/UITests/Toolkit.UITests.Generators/Toolkit.UITests.Generators.csproj
+++ b/src/Tests/UITests/Toolkit.UITests.Generators/Toolkit.UITests.Generators.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Tests/UITests/Toolkit.UITests.Maui.App/Toolkit.UITests.Maui.App.csproj
+++ b/src/Tests/UITests/Toolkit.UITests.Maui.App/Toolkit.UITests.Maui.App.csproj
@@ -87,9 +87,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Esri.Calcite.Maui" Version="1.0.0-rc.1" />
+    <PackageReference Include="Esri.Calcite.Maui" Version="1.1.0" />
     <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.10" />
   </ItemGroup>
 
   <!-- Test Pages -->


### PR DESCRIPTION
Grouped commit for the following dependabot updates, some of which overlapped. Requesting reviews just in case the analyzers are touchy (though the analyzer unit tests ran fine).

- https://github.com/Esri/arcgis-maps-sdk-dotnet-toolkit/pull/828
- https://github.com/Esri/arcgis-maps-sdk-dotnet-toolkit/pull/829
- https://github.com/Esri/arcgis-maps-sdk-dotnet-toolkit/pull/830
- https://github.com/Esri/arcgis-maps-sdk-dotnet-toolkit/pull/831
- https://github.com/Esri/arcgis-maps-sdk-dotnet-toolkit/pull/832