### PR TITLE
UITests: Make FindElement more specific on mac

### DIFF
--- a/src/Tests/UITests/Toolkit.UITests.Shared/Appium/AppiumTestBase.Utils.cs
+++ b/src/Tests/UITests/Toolkit.UITests.Shared/Appium/AppiumTestBase.Utils.cs
@@ -47,6 +47,8 @@ public abstract partial class AppiumTestBase
     {
 #if WINDOWS_TEST
         var action = () => Driver.FindElement(MobileBy.AccessibilityId(id));
+#elif MAC_TEST
+        var action = () => Driver.FindElement(MobileBy.XPath($"//*[@identifier='{id}']"));
 #else
         var action = () => Driver.FindElement(MobileBy.Id(id));
 #endif
@@ -65,6 +67,8 @@ public abstract partial class AppiumTestBase
     {
 #if WINDOWS_TEST
         var action = () => parent.FindElement(MobileBy.AccessibilityId(id));
+#elif MAC_TEST
+        var action = () => parent.FindElement(MobileBy.XPath($".//*[@identifier='{id}']"));
 #else
         var action = () => parent.FindElement(MobileBy.Id(id));
 #endif


### PR DESCRIPTION
The default Appium locator strategies for Id all seem to search both the `identifier` and `value` properties. `value` is also linked to text, for example the the text value of an Entry field, which can mean the wrong element gets identified.

Theoretically XPath is slower than the locator, I didn't notice a difference, and appium mac is very slow anyway.