### PR TITLE
utilnet: add support for barriers and filtering named traces

### DIFF
--- a/docs/un-trace.md
+++ b/docs/un-trace.md
@@ -7,6 +7,8 @@ Use named trace configurations defined in a web map to perform connected trace o
 ## Features
 
 - Load networks and named trace configurations from a web map
+- Load selected named trace configurations by name with `LoadNamedTracesAsync`
+- Add barriers interactively or programmatically with `AddBarrier`; barriers can also be configured as filter barriers
 - Support for templating
 - (WinUI, WPF) Identify starting point candidates, then use the inspection view to narrow the selection:
 
@@ -28,6 +30,7 @@ The following properties enable customization (WinUI, WPF only):
 
 - `ResultItemTemplate` - override the display of results
 - `StartingPointItemTemplate` - override the display of starting points
+- `BarrierItemTemplate` - override the display of barriers
 - `TraceTypeItemTemplate` - override the display of the trace configuration choices
 - `UtilityNetworkItemTemplate` - override the display of the Utility Network choices
 
@@ -35,9 +38,10 @@ All platforms:
 
 - `Template` - allows overriding the appearance of the entire control
 
-The following properties enable customizing symbology:
+The following properties enable customizing symbology on all platforms:
 
 - `StartingPointSymbol`
+- `BarrierSymbol`
 - `ResultFillSymbol`
 - `ResultLineSymbol`
 - `ResultPointSymbol`

--- a/src/Toolkit/Toolkit.Maui/UtilityNetworkTraceTool/UtilityNetworkTraceTool.Appearance.cs
+++ b/src/Toolkit/Toolkit.Maui/UtilityNetworkTraceTool/UtilityNetworkTraceTool.Appearance.cs
@@ -1,4 +1,4 @@
-﻿// /*******************************************************************************
+// /*******************************************************************************
 //  * Copyright 2012-2018 Esri
 //  *
 //  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +15,8 @@
 //  ******************************************************************************/
 
 using Esri.ArcGISRuntime.Toolkit.Maui.Primitives;
+using Esri.ArcGISRuntime.Mapping;
+using Esri.ArcGISRuntime.UtilityNetworks;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Esri.ArcGISRuntime.Toolkit.Maui;
@@ -39,6 +41,9 @@ public partial class UtilityNetworkTraceTool
     private Button? PART_ButtonAddStartingPoint;
     private Button? PART_ButtonCancelAddStartingPoint;
     private CollectionView? PART_ListViewStartingPoints;
+    private Button? PART_ButtonAddBarrier;
+    private Button? PART_ButtonCancelAddBarrier;
+    private CollectionView? PART_ListViewBarriers;
 
     // Run section
     private Layout? PART_RunContainer;
@@ -60,7 +65,13 @@ public partial class UtilityNetworkTraceTool
     private Button? PART_ButtonCancelActivity;
 #pragma warning restore SA1310, SX1309, SA1306
 
+    private DataTemplate? _defaultStartingPointItemTemplate;
+    private DataTemplate? _defaultBarrierItemTemplate;
     private static readonly ControlTemplate DefaultControlTemplate;
+
+    private DataTemplate DefaultStartingPointItemTemplate => _defaultStartingPointItemTemplate ??= CreateUtilityElementItemTemplate(false);
+
+    private DataTemplate DefaultBarrierItemTemplate => _defaultBarrierItemTemplate ??= CreateUtilityElementItemTemplate(true);
 
     [DynamicDependency(nameof(Esri.ArcGISRuntime.UtilityNetworks.UtilityTraceFunctionOutput.Function), "Esri.ArcGISRuntime.UtilityNetworks.UtilityTraceFunctionOutput", "Esri.ArcGISRuntime")]
     [DynamicDependency(nameof(Esri.ArcGISRuntime.UtilityNetworks.UtilityTraceFunctionOutput.Result), "Esri.ArcGISRuntime.UtilityNetworks.UtilityTraceFunctionOutput", "Esri.ArcGISRuntime")]
@@ -77,6 +88,7 @@ public partial class UtilityNetworkTraceTool
         var utilityNetworks = Properties.Resources.GetString("UtilityNetworkTraceToolUtilityNetworks");
         var traceTypes = Properties.Resources.GetString("UtilityNetworkTraceToolTraceTypes");
         var addStartingPoint = Properties.Resources.GetString("UtilityNetworkTraceToolAddStartingPoint");
+        var addBarrier = Properties.Resources.GetString("UtilityNetworkTraceToolAddBarrier");
         var cancel = Properties.Resources.GetString("UtilityNetworkTraceToolCancel");
         var notEnoughStartingPoints = Properties.Resources.GetString("UtilityNetworkTraceToolNotEnoughStartingPoints");
         var moreThanRequiredStartingPoints = Properties.Resources.GetString("UtilityNetworkTraceToolMoreThanRequiredStartingPoints");
@@ -122,32 +134,15 @@ xmlns:esriTK=""clr-namespace:Esri.ArcGISRuntime.Toolkit.Maui;assembly=Esri.ArcGI
         <Grid.RowDefinitions>
             <RowDefinition Height=""Auto"" />
             <RowDefinition Height=""*"" />
+            <RowDefinition Height=""Auto"" />
+            <RowDefinition Height=""*"" />
         </Grid.RowDefinitions>
         <Button x:Name=""{nameof(PART_ButtonAddStartingPoint)}"" Text=""{addStartingPoint}"" IsVisible=""false"" Grid.Row=""0"" />
         <Button x:Name=""{nameof(PART_ButtonCancelAddStartingPoint)}"" Text=""{cancel}"" IsVisible=""false"" Grid.Row=""0""/>
-        <CollectionView x:Name=""{nameof(PART_ListViewStartingPoints)}"" Background=""{backgroundColor}"" SelectionMode=""Single"" IsVisible=""false"" Grid.Row=""1"">
-            <CollectionView.ItemTemplate>
-                <DataTemplate>
-                    <Grid Padding=""4"">
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height=""Auto"" />
-                            <RowDefinition Height=""Auto"" />
-                            <RowDefinition Height=""Auto"" />
-                        </Grid.RowDefinitions>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width=""40"" />
-                            <ColumnDefinition Width=""*"" />
-                            <ColumnDefinition Width=""40"" />
-                        </Grid.ColumnDefinitions>
-                        <esriTK:SymbolDisplay Symbol=""{{Binding Symbol}}"" Grid.RowSpan=""2"" />
-                        <Label Grid.Column=""1"" Text=""{{Binding StartingPoint.NetworkSource.Name}}"" FontAttributes=""Bold"" TextColor=""{foregroundColor}""  />
-                        <Label Grid.Column=""1"" Grid.Row=""1"" Text=""{{Binding StartingPoint.AssetGroup.Name}}"" TextColor=""{foregroundColor}""  />
-                        <Button Grid.Column=""2"" Grid.RowSpan=""2"" Text=""X"" Command=""{{Binding DeleteCommand}}"" Padding=""2"" />
-                    </Grid>
-                </DataTemplate>
-            </CollectionView.ItemTemplate>
-        </CollectionView>
-
+        <CollectionView x:Name=""{nameof(PART_ListViewStartingPoints)}"" Background=""{backgroundColor}"" SelectionMode=""Single"" IsVisible=""false"" Grid.Row=""1"" />
+        <Button x:Name=""{nameof(PART_ButtonAddBarrier)}"" Text=""{addBarrier}"" IsVisible=""false"" Grid.Row=""2"" />
+        <Button x:Name=""{nameof(PART_ButtonCancelAddBarrier)}"" Text=""{cancel}"" IsVisible=""false"" Grid.Row=""2"" />
+        <CollectionView x:Name=""{nameof(PART_ListViewBarriers)}"" Background=""{backgroundColor}"" SelectionMode=""Single"" IsVisible=""false"" Grid.Row=""3"" />
     </Grid>
     <Grid x:Name=""{nameof(PART_RunContainer)}"" Grid.Row=""2"">
         <Grid.RowDefinitions>
@@ -276,5 +271,161 @@ xmlns:esriTK=""clr-namespace:Esri.ArcGISRuntime.Toolkit.Maui;assembly=Esri.ArcGI
 </Grid>
 </ControlTemplate>";
         DefaultControlTemplate = new ControlTemplate().LoadFromXaml(template);
+    }
+
+    private DataTemplate CreateUtilityElementItemTemplate(bool isBarrier)
+    {
+        var terminal = Properties.Resources.GetString("UtilityNetworkTraceToolTerminal") ?? string.Empty;
+        var fractionAlongEdge = Properties.Resources.GetString("UtilityNetworkTraceToolFractionAlongEdge") ?? string.Empty;
+        var zoom = Properties.Resources.GetString("UtilityNetworkTraceToolZoomStartingPoint") ?? string.Empty;
+        var useAsFilterBarrier = Properties.Resources.GetString("UtilityNetworkTraceToolUseAsFilterBarrier") ?? string.Empty;
+
+        return new DataTemplate(() =>
+        {
+            var itemGrid = new Grid { Padding = 4, RowSpacing = 4, ColumnSpacing = 4 };
+            for (var row = 0; row < 5; row++)
+            {
+                itemGrid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+            }
+
+            itemGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = 40 });
+            itemGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Star });
+            itemGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = 40 });
+            itemGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = 40 });
+
+            var symbolDisplay = new SymbolDisplay
+            {
+                WidthRequest = 32,
+                HeightRequest = 32,
+                HorizontalOptions = LayoutOptions.Center,
+                VerticalOptions = LayoutOptions.Center,
+            };
+            symbolDisplay.SetBinding(SymbolDisplay.SymbolProperty, static (UtilityElementModel element) => element.Symbol);
+            Grid.SetRowSpan(symbolDisplay, 2);
+
+            var networkSourceLabel = new Label { FontAttributes = FontAttributes.Bold };
+            networkSourceLabel.SetBinding(Label.TextProperty, static (UtilityElementModel element) => element.Element.NetworkSource.Name);
+            networkSourceLabel.SetAppThemeColor(Label.TextColorProperty, Color.FromArgb("#151515"), Colors.White);
+            Grid.SetColumn(networkSourceLabel, 1);
+
+            var assetGroupLabel = new Label();
+            assetGroupLabel.SetBinding(Label.TextProperty, static (UtilityElementModel element) => element.Element.AssetGroup.Name);
+            assetGroupLabel.SetAppThemeColor(Label.TextColorProperty, Color.FromArgb("#151515"), Colors.White);
+            Grid.SetRow(assetGroupLabel, 1);
+            Grid.SetColumn(assetGroupLabel, 1);
+
+            var zoomButton = new Button
+            {
+                Text = ToolkitIcons.ZoomToObject,
+                FontFamily = ToolkitIcons.FontFamilyName,
+                FontSize = 18,
+                Padding = 2,
+                WidthRequest = 40,
+                HeightRequest = 40,
+            };
+            ToolTipProperties.SetText(zoomButton, zoom);
+            zoomButton.Clicked += OnZoomToUtilityElementClicked;
+            Grid.SetColumn(zoomButton, 2);
+            Grid.SetRowSpan(zoomButton, 2);
+
+            var deleteButton = new Button { Text = "X", Padding = 2, WidthRequest = 40, HeightRequest = 40 };
+            deleteButton.SetBinding(Button.CommandProperty, static (UtilityElementModel element) => element.DeleteCommand);
+            Grid.SetColumn(deleteButton, 3);
+            Grid.SetRowSpan(deleteButton, 2);
+
+            var terminalGrid = new Grid { ColumnSpacing = 8 };
+            terminalGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+            terminalGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Star });
+            terminalGrid.SetBinding(VisualElement.IsVisibleProperty, static (UtilityElementModel element) => element.TerminalPickerVisible);
+
+            var terminalLabel = new Label { Text = terminal, VerticalOptions = LayoutOptions.Center };
+            terminalLabel.SetAppThemeColor(Label.TextColorProperty, Color.FromArgb("#151515"), Colors.White);
+
+            var terminalPicker = new Picker { Title = terminal };
+            terminalPicker.SetBinding(Picker.ItemsSourceProperty, static (UtilityElementModel element) => element.Element.AssetType?.TerminalConfiguration?.Terminals);
+            terminalPicker.SetBinding(Picker.SelectedItemProperty, static (UtilityElementModel element) => element.Element.Terminal);
+            terminalPicker.ItemDisplayBinding = BindingBase.Create(static (UtilityTerminal item) => item.Name);
+            terminalPicker.SelectedIndexChanged += OnTerminalSelected;
+            terminalPicker.SetAppThemeColor(Picker.BackgroundColorProperty, Color.FromArgb("#eaeaea"), Color.FromArgb("#151515"));
+            Grid.SetColumn(terminalPicker, 1);
+
+            terminalGrid.Children.Add(terminalLabel);
+            terminalGrid.Children.Add(terminalPicker);
+            Grid.SetRow(terminalGrid, 2);
+            Grid.SetColumnSpan(terminalGrid, 4);
+
+            var fractionGrid = new Grid { RowSpacing = 0 };
+            fractionGrid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+            fractionGrid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+            fractionGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Star });
+            fractionGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+            fractionGrid.SetBinding(VisualElement.IsVisibleProperty, static (UtilityElementModel element) => element.FractionSliderVisible);
+
+            var fractionLabel = new Label { Text = fractionAlongEdge };
+            fractionLabel.SetAppThemeColor(Label.TextColorProperty, Color.FromArgb("#151515"), Colors.White);
+
+            var fractionValueLabel = new Label { HorizontalTextAlignment = TextAlignment.End };
+            fractionValueLabel.SetAppThemeColor(Label.TextColorProperty, Color.FromArgb("#151515"), Colors.White);
+            Grid.SetColumn(fractionValueLabel, 1);
+
+            var fractionSlider = new Slider { Minimum = 0, Maximum = 1 };
+            fractionSlider.SetBinding(Slider.ValueProperty, static (UtilityElementModel element) => element.FractionAlongEdge);
+            fractionSlider.ValueChanged += OnFractionAlongEdgeChanged;
+            Grid.SetRow(fractionSlider, 1);
+            Grid.SetColumnSpan(fractionSlider, 2);
+            fractionValueLabel.SetBinding(Label.TextProperty, static (Slider slider) => slider.Value, stringFormat: "{0:0.00}", source: fractionSlider);
+
+            fractionGrid.Children.Add(fractionLabel);
+            fractionGrid.Children.Add(fractionValueLabel);
+            fractionGrid.Children.Add(fractionSlider);
+            Grid.SetRow(fractionGrid, 3);
+            Grid.SetColumnSpan(fractionGrid, 4);
+
+            itemGrid.Children.Add(symbolDisplay);
+            itemGrid.Children.Add(networkSourceLabel);
+            itemGrid.Children.Add(assetGroupLabel);
+            itemGrid.Children.Add(zoomButton);
+            itemGrid.Children.Add(deleteButton);
+            itemGrid.Children.Add(terminalGrid);
+            itemGrid.Children.Add(fractionGrid);
+
+            if (isBarrier)
+            {
+                var filterBarrierCheckBox = new CheckBox();
+                filterBarrierCheckBox.SetBinding(CheckBox.IsCheckedProperty, static (BarrierModel barrier) => barrier.UseAsFilterBarrier, BindingMode.TwoWay);
+                var filterBarrierLabel = new Label { Text = useAsFilterBarrier, VerticalOptions = LayoutOptions.Center };
+                filterBarrierLabel.SetAppThemeColor(Label.TextColorProperty, Color.FromArgb("#151515"), Colors.White);
+                var filterBarrierLayout = new HorizontalStackLayout { Spacing = 4, Children = { filterBarrierCheckBox, filterBarrierLabel } };
+                Grid.SetRow(filterBarrierLayout, 4);
+                Grid.SetColumnSpan(filterBarrierLayout, 4);
+                itemGrid.Children.Add(filterBarrierLayout);
+            }
+
+            return itemGrid;
+        });
+    }
+
+    private void OnZoomToUtilityElementClicked(object? sender, EventArgs e)
+    {
+        if (sender is Button { BindingContext: UtilityElementModel element } && element.ZoomToExtent is { } zoomExtent)
+        {
+            GeoView?.SetViewpoint(new Viewpoint(zoomExtent));
+        }
+    }
+
+    private static void OnTerminalSelected(object? sender, EventArgs e)
+    {
+        if (sender is Picker { BindingContext: UtilityElementModel element, SelectedItem: UtilityTerminal terminal })
+        {
+            element.Element.Terminal = terminal;
+        }
+    }
+
+    private static void OnFractionAlongEdgeChanged(object? sender, ValueChangedEventArgs e)
+    {
+        if (sender is Slider { BindingContext: UtilityElementModel element })
+        {
+            element.FractionAlongEdge = e.NewValue;
+        }
     }
 }

--- a/src/Toolkit/Toolkit.Maui/UtilityNetworkTraceTool/UtilityNetworkTraceTool.Appearance.cs
+++ b/src/Toolkit/Toolkit.Maui/UtilityNetworkTraceTool/UtilityNetworkTraceTool.Appearance.cs
@@ -39,9 +39,11 @@ public partial class UtilityNetworkTraceTool
     // Configure section
     private Layout? PART_ConfigureContainer;
     private Button? PART_ButtonAddStartingPoint;
+    private Button? PART_ButtonRemoveAllStartingPoints;
     private Button? PART_ButtonCancelAddStartingPoint;
     private CollectionView? PART_ListViewStartingPoints;
     private Button? PART_ButtonAddBarrier;
+    private Button? PART_ButtonRemoveAllBarriers;
     private Button? PART_ButtonCancelAddBarrier;
     private CollectionView? PART_ListViewBarriers;
 
@@ -88,7 +90,9 @@ public partial class UtilityNetworkTraceTool
         var utilityNetworks = Properties.Resources.GetString("UtilityNetworkTraceToolUtilityNetworks");
         var traceTypes = Properties.Resources.GetString("UtilityNetworkTraceToolTraceTypes");
         var addStartingPoint = Properties.Resources.GetString("UtilityNetworkTraceToolAddStartingPoint");
+        var removeAllStartingPoints = Properties.Resources.GetString("UtilityNetworkTraceToolRemoveAllStartingPoints");
         var addBarrier = Properties.Resources.GetString("UtilityNetworkTraceToolAddBarrier");
+        var removeAllBarriers = Properties.Resources.GetString("UtilityNetworkTraceToolRemoveAllBarriers");
         var cancel = Properties.Resources.GetString("UtilityNetworkTraceToolCancel");
         var notEnoughStartingPoints = Properties.Resources.GetString("UtilityNetworkTraceToolNotEnoughStartingPoints");
         var moreThanRequiredStartingPoints = Properties.Resources.GetString("UtilityNetworkTraceToolMoreThanRequiredStartingPoints");
@@ -137,11 +141,25 @@ xmlns:esriTK=""clr-namespace:Esri.ArcGISRuntime.Toolkit.Maui;assembly=Esri.ArcGI
             <RowDefinition Height=""Auto"" />
             <RowDefinition Height=""*"" />
         </Grid.RowDefinitions>
-        <Button x:Name=""{nameof(PART_ButtonAddStartingPoint)}"" Text=""{addStartingPoint}"" IsVisible=""false"" Grid.Row=""0"" />
-        <Button x:Name=""{nameof(PART_ButtonCancelAddStartingPoint)}"" Text=""{cancel}"" IsVisible=""false"" Grid.Row=""0""/>
+        <Grid Grid.Row=""0"" ColumnSpacing=""4"">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width=""*"" />
+                <ColumnDefinition Width=""*"" />
+            </Grid.ColumnDefinitions>
+            <Button x:Name=""{nameof(PART_ButtonRemoveAllStartingPoints)}"" Text=""{removeAllStartingPoints}"" IsVisible=""false"" />
+            <Button x:Name=""{nameof(PART_ButtonAddStartingPoint)}"" Text=""{addStartingPoint}"" IsVisible=""false"" Grid.Column=""1"" />
+            <Button x:Name=""{nameof(PART_ButtonCancelAddStartingPoint)}"" Text=""{cancel}"" IsVisible=""false"" Grid.ColumnSpan=""2"" />
+        </Grid>
         <CollectionView x:Name=""{nameof(PART_ListViewStartingPoints)}"" Background=""{backgroundColor}"" SelectionMode=""Single"" IsVisible=""false"" Grid.Row=""1"" />
-        <Button x:Name=""{nameof(PART_ButtonAddBarrier)}"" Text=""{addBarrier}"" IsVisible=""false"" Grid.Row=""2"" />
-        <Button x:Name=""{nameof(PART_ButtonCancelAddBarrier)}"" Text=""{cancel}"" IsVisible=""false"" Grid.Row=""2"" />
+        <Grid Grid.Row=""2"" ColumnSpacing=""4"">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width=""*"" />
+                <ColumnDefinition Width=""*"" />
+            </Grid.ColumnDefinitions>
+            <Button x:Name=""{nameof(PART_ButtonRemoveAllBarriers)}"" Text=""{removeAllBarriers}"" IsVisible=""false"" />
+            <Button x:Name=""{nameof(PART_ButtonAddBarrier)}"" Text=""{addBarrier}"" IsVisible=""false"" Grid.Column=""1"" />
+            <Button x:Name=""{nameof(PART_ButtonCancelAddBarrier)}"" Text=""{cancel}"" IsVisible=""false"" Grid.ColumnSpan=""2"" />
+        </Grid>
         <CollectionView x:Name=""{nameof(PART_ListViewBarriers)}"" Background=""{backgroundColor}"" SelectionMode=""Single"" IsVisible=""false"" Grid.Row=""3"" />
     </Grid>
     <Grid x:Name=""{nameof(PART_RunContainer)}"" Grid.Row=""2"">

--- a/src/Toolkit/Toolkit.Maui/UtilityNetworkTraceTool/UtilityNetworkTraceTool.cs
+++ b/src/Toolkit/Toolkit.Maui/UtilityNetworkTraceTool/UtilityNetworkTraceTool.cs
@@ -1,4 +1,4 @@
-﻿// /*******************************************************************************
+// /*******************************************************************************
 //  * Copyright 2012-2018 Esri
 //  *
 //  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,7 @@
 using System.Collections.Specialized;
 using System.ComponentModel;
 using Esri.ArcGISRuntime.Data;
+using Esri.ArcGISRuntime.Geometry;
 using Esri.ArcGISRuntime.Symbology;
 using Esri.ArcGISRuntime.Toolkit.Maui.Primitives;
 using Esri.ArcGISRuntime.UI;
@@ -47,12 +48,35 @@ public partial class UtilityNetworkTraceTool : TemplatedView
         ResultLineSymbol = _controller.ResultLineSymbol;
         ResultPointSymbol = _controller.ResultPointSymbol;
         StartingPointSymbol = _controller.StartingPointSymbol;
+        BarrierSymbol = _controller.BarrierSymbol;
         ControlTemplate = DefaultControlTemplate;
         _controller.AutoZoomToTraceResults = AutoZoomToTraceResults;
         _controller.PropertyChanged += Controller_PropertyChanged;
         _controller.Results.CollectionChanged += Results_CollectionChanged;
         _controller.StartingPoints.CollectionChanged += StartingPoints_CollectionChanged;
+        _controller.Barriers.CollectionChanged += Barriers_CollectionChanged;
         _controller.UtilityNetworks.CollectionChanged += UtilityNetworks_CollectionChanged;
+    }
+
+    /// <summary>
+    /// Adds a starting point.
+    /// </summary>
+    /// <param name="feature">The feature to use as the basis for the starting point.</param>
+    /// <param name="location">Optional location to use, which will be used to specify the location along the line for line features.</param>
+    public void AddStartingPoint(ArcGISFeature feature, MapPoint? location)
+    {
+        _controller.AddStartingPoint(feature, location);
+    }
+
+    /// <summary>
+    /// Adds a barrier.
+    /// </summary>
+    /// <param name="feature">The feature to use as the basis for the barrier.</param>
+    /// <param name="location">Optional location to use, which will be used to specify the location along the line for line features.</param>
+    /// <param name="useAsFilterBarrier">A value indicating whether to use the barrier as a filter barrier.</param>
+    public void AddBarrier(ArcGISFeature feature, MapPoint? location, bool? useAsFilterBarrier = false)
+    {
+        _controller.AddBarrier(feature, location, useAsFilterBarrier);
     }
 
     /// <summary>
@@ -85,10 +109,31 @@ public partial class UtilityNetworkTraceTool : TemplatedView
             PART_ButtonAddStartingPoint.Clicked -= OnAddStartingPointClicked;
         }
 
+        if (PART_ButtonRemoveAllStartingPoints != null)
+        {
+            PART_ButtonRemoveAllStartingPoints.Clicked -= OnRemoveAllStartingPointsClicked;
+        }
+
         if (PART_ListViewStartingPoints != null)
         {
             PART_ListViewStartingPoints.SelectionChanged -= OnStartingPointSelected;
             PART_ListViewStartingPoints.ItemsSource = null;
+        }
+
+        if (PART_ButtonAddBarrier != null)
+        {
+            PART_ButtonAddBarrier.Clicked -= OnAddBarrierClicked;
+        }
+
+        if (PART_ButtonRemoveAllBarriers != null)
+        {
+            PART_ButtonRemoveAllBarriers.Clicked -= OnRemoveAllBarriersClicked;
+        }
+
+        if (PART_ListViewBarriers != null)
+        {
+            PART_ListViewBarriers.SelectionChanged -= OnBarrierSelected;
+            PART_ListViewBarriers.ItemsSource = null;
         }
 
         if (PART_ButtonRunTrace != null)
@@ -104,6 +149,11 @@ public partial class UtilityNetworkTraceTool : TemplatedView
         if (PART_ButtonCancelAddStartingPoint != null)
         {
             PART_ButtonCancelAddStartingPoint.Clicked -= OnAddStartingPointCancelClicked;
+        }
+
+        if (PART_ButtonCancelAddBarrier != null)
+        {
+            PART_ButtonCancelAddBarrier.Clicked -= OnAddBarrierCancelClicked;
         }
 
         if (PART_ButtonCancelActivity != null)
@@ -138,11 +188,38 @@ public partial class UtilityNetworkTraceTool : TemplatedView
             PART_ButtonAddStartingPoint.Clicked += OnAddStartingPointClicked;
         }
 
+        if (GetTemplateChild(nameof(PART_ButtonRemoveAllStartingPoints)) is Button removeAllStartingPointsButton)
+        {
+            PART_ButtonRemoveAllStartingPoints = removeAllStartingPointsButton;
+            PART_ButtonRemoveAllStartingPoints.Clicked += OnRemoveAllStartingPointsClicked;
+        }
+
         if (GetTemplateChild(nameof(PART_ListViewStartingPoints)) is CollectionView startingPointListView)
         {
             PART_ListViewStartingPoints = startingPointListView;
             PART_ListViewStartingPoints.ItemsSource = _controller.StartingPoints;
+            PART_ListViewStartingPoints.ItemTemplate ??= DefaultStartingPointItemTemplate;
             PART_ListViewStartingPoints.SelectionChanged += OnStartingPointSelected;
+        }
+
+        if (GetTemplateChild(nameof(PART_ButtonAddBarrier)) is Button barrierButton)
+        {
+            PART_ButtonAddBarrier = barrierButton;
+            PART_ButtonAddBarrier.Clicked += OnAddBarrierClicked;
+        }
+
+        if (GetTemplateChild(nameof(PART_ButtonRemoveAllBarriers)) is Button removeAllBarriersButton)
+        {
+            PART_ButtonRemoveAllBarriers = removeAllBarriersButton;
+            PART_ButtonRemoveAllBarriers.Clicked += OnRemoveAllBarriersClicked;
+        }
+
+        if (GetTemplateChild(nameof(PART_ListViewBarriers)) is CollectionView barrierListView)
+        {
+            PART_ListViewBarriers = barrierListView;
+            PART_ListViewBarriers.ItemsSource = _controller.Barriers;
+            PART_ListViewBarriers.ItemTemplate ??= DefaultBarrierItemTemplate;
+            PART_ListViewBarriers.SelectionChanged += OnBarrierSelected;
         }
 
         if (GetTemplateChild(nameof(PART_ButtonRunTrace)) is Button runTraceButton)
@@ -161,6 +238,12 @@ public partial class UtilityNetworkTraceTool : TemplatedView
         {
             PART_ButtonCancelAddStartingPoint = cancelAdd;
             PART_ButtonCancelAddStartingPoint.Clicked += OnAddStartingPointCancelClicked;
+        }
+
+        if (GetTemplateChild(nameof(PART_ButtonCancelAddBarrier)) is Button cancelAddBarrier)
+        {
+            PART_ButtonCancelAddBarrier = cancelAddBarrier;
+            PART_ButtonCancelAddBarrier.Clicked += OnAddBarrierCancelClicked;
         }
 
         if (GetTemplateChild(nameof(PART_DuplicateTraceWarning)) is View duplicateWarning)
@@ -198,6 +281,7 @@ public partial class UtilityNetworkTraceTool : TemplatedView
         {
             PART_ListViewTraceTypes = picker;
             PART_ListViewTraceTypes.ItemsSource = _controller.TraceTypes;
+            PART_ListViewTraceTypes.SelectedItem = _controller.SelectedTraceType;
             PART_ListViewTraceTypes.SelectedIndexChanged += OnTraceTypeSelected;
         }
 
@@ -243,6 +327,8 @@ public partial class UtilityNetworkTraceTool : TemplatedView
 
     private void OnStartingPointSelected(object? sender, SelectionChangedEventArgs e) => _controller.SelectedStartingPoint = e.CurrentSelection.FirstOrDefault() as StartingPointModel;
 
+    private void OnBarrierSelected(object? sender, SelectionChangedEventArgs e) => _controller.SelectedBarrier = e.CurrentSelection.FirstOrDefault() as BarrierModel;
+
     private void OnTraceTypeSelected(object? sender, EventArgs e)
     {
         if (PART_ListViewTraceTypes?.SelectedItem is UtilityNamedTraceConfiguration config)
@@ -252,6 +338,8 @@ public partial class UtilityNetworkTraceTool : TemplatedView
     }
 
     private void OnAddStartingPointCancelClicked(object? sender, EventArgs e) => _controller.IsAddingStartingPoints = false;
+
+    private void OnAddBarrierCancelClicked(object? sender, EventArgs e) => _controller.IsAddingBarriers = false;
 
     private void OnSectionNavigated(object? sender, PropertyChangedEventArgs e)
     {
@@ -284,10 +372,15 @@ public partial class UtilityNetworkTraceTool : TemplatedView
         PART_ButtonRunTrace?.SetValue(IsVisibleProperty, false);
         PART_GridResultsDisplay?.SetValue(View.IsVisibleProperty, false);
         PART_ButtonCancelAddStartingPoint?.SetValue(IsVisibleProperty, false);
+        PART_ButtonCancelAddBarrier?.SetValue(IsVisibleProperty, false);
         PART_LabelTraceTypes?.SetValue(IsVisibleProperty, false);
         PART_ListViewTraceTypes?.SetValue(IsVisibleProperty, false);
         PART_ButtonAddStartingPoint?.SetValue(IsVisibleProperty, false);
+        PART_ButtonRemoveAllStartingPoints?.SetValue(IsVisibleProperty, false);
+        PART_ButtonAddBarrier?.SetValue(IsVisibleProperty, false);
+        PART_ButtonRemoveAllBarriers?.SetValue(IsVisibleProperty, false);
         PART_ListViewStartingPoints?.SetValue(IsVisibleProperty, false);
+        PART_ListViewBarriers?.SetValue(IsVisibleProperty, false);
         PART_ExtraStartingPointsWarning?.SetValue(IsVisibleProperty, false);
         PART_NeedMoreStartingPointsWarning?.SetValue(IsVisibleProperty, false);
         if (PART_NavigationSegment == null)
@@ -308,9 +401,7 @@ public partial class UtilityNetworkTraceTool : TemplatedView
 
             // Configure
             case 1:
-                PART_ListViewStartingPoints?.SetValue(IsVisibleProperty, true);
-                PART_ButtonCancelAddStartingPoint?.SetValue(IsVisibleProperty, _controller.IsAddingStartingPoints);
-                PART_ButtonAddStartingPoint?.SetValue(IsVisibleProperty, !_controller.IsAddingStartingPoints);
+                ApplyConfigureAddModeState();
                 PART_ExtraStartingPointsWarning?.SetValue(IsVisibleProperty, _controller.TooManyStartingPointsWarning);
                 PART_NeedMoreStartingPointsWarning?.SetValue(IsVisibleProperty, _controller.InsufficientStartingPointsWarning);
                 PART_ConfigureContainer?.SetValue(IsVisibleProperty, true);
@@ -351,6 +442,45 @@ public partial class UtilityNetworkTraceTool : TemplatedView
 
     private void OnAddStartingPointClicked(object? sender, EventArgs e) => _controller.IsAddingStartingPoints = !_controller.IsAddingStartingPoints;
 
+    private void OnRemoveAllStartingPointsClicked(object? sender, EventArgs e) => _controller.StartingPoints.Clear();
+
+    private void OnAddBarrierClicked(object? sender, EventArgs e) => _controller.IsAddingBarriers = !_controller.IsAddingBarriers;
+
+    private void OnRemoveAllBarriersClicked(object? sender, EventArgs e) => _controller.Barriers.Clear();
+
+    private void ApplyConfigureAddModeState()
+    {
+        var isAddingTraceLocation = _controller.IsAddingStartingPoints || _controller.IsAddingBarriers;
+        PART_ButtonAddStartingPoint?.SetValue(IsVisibleProperty, !isAddingTraceLocation);
+        PART_ButtonAddBarrier?.SetValue(IsVisibleProperty, !isAddingTraceLocation);
+        PART_ButtonCancelAddStartingPoint?.SetValue(IsVisibleProperty, _controller.IsAddingStartingPoints);
+        PART_ButtonCancelAddBarrier?.SetValue(IsVisibleProperty, _controller.IsAddingBarriers);
+        PART_ListViewStartingPoints?.SetValue(IsVisibleProperty, !isAddingTraceLocation);
+        PART_ListViewBarriers?.SetValue(IsVisibleProperty, !isAddingTraceLocation);
+        UpdateRemoveAllButtonState();
+    }
+
+    private void UpdateRemoveAllButtonState()
+    {
+        var isAddingTraceLocation = _controller.IsAddingStartingPoints || _controller.IsAddingBarriers;
+        var hasStartingPoints = _controller.StartingPoints.Count > 0;
+        var hasBarriers = _controller.Barriers.Count > 0;
+        PART_ButtonRemoveAllStartingPoints?.SetValue(IsVisibleProperty, !isAddingTraceLocation && hasStartingPoints);
+        PART_ButtonRemoveAllBarriers?.SetValue(IsVisibleProperty, !isAddingTraceLocation && hasBarriers);
+
+        if (PART_ButtonAddStartingPoint != null)
+        {
+            Grid.SetColumn(PART_ButtonAddStartingPoint, hasStartingPoints ? 1 : 0);
+            Grid.SetColumnSpan(PART_ButtonAddStartingPoint, hasStartingPoints ? 1 : 2);
+        }
+
+        if (PART_ButtonAddBarrier != null)
+        {
+            Grid.SetColumn(PART_ButtonAddBarrier, hasBarriers ? 1 : 0);
+            Grid.SetColumnSpan(PART_ButtonAddBarrier, hasBarriers ? 1 : 2);
+        }
+    }
+
     private void PART_NetworksCollectionView_SelectionChanged(object? sender, EventArgs e)
     {
         _controller.SelectedUtilityNetwork = PART_ListViewNetworks?.SelectedItem as UtilityNetwork;
@@ -362,7 +492,17 @@ public partial class UtilityNetworkTraceTool : TemplatedView
         PART_LabelNetworks?.SetValue(IsVisibleProperty, _controller.UtilityNetworks.Count > 1);
     }
 
-    private void StartingPoints_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e) => GeoView?.DismissCallout();
+    private void StartingPoints_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        GeoView?.DismissCallout();
+        UpdateRemoveAllButtonState();
+    }
+
+    private void Barriers_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        GeoView?.DismissCallout();
+        UpdateRemoveAllButtonState();
+    }
 
     private void Results_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
@@ -409,7 +549,7 @@ public partial class UtilityNetworkTraceTool : TemplatedView
                     _resultOverlays.Add(item.ResultOverlay);
                     GeoView.GraphicsOverlays.Insert(0, item.ResultOverlay);
                 }
-                                
+
                 if (item.Error != null)
                 {
                     UtilityNetworkTraceCompleted?.Invoke(this, new UtilityNetworkTraceCompletedEventArgs(item.Parameters, item.Error));
@@ -432,23 +572,19 @@ public partial class UtilityNetworkTraceTool : TemplatedView
         switch (e.PropertyName)
         {
             case nameof(_controller.IsAddingStartingPoints):
-                if (_controller.IsAddingStartingPoints)
+            case nameof(_controller.IsAddingBarriers):
+                if (_controller.IsAddingStartingPoints || _controller.IsAddingBarriers)
                 {
                     PART_NavigationSegment?.SetValue(SegmentedControl.SelectedSegmentIndexProperty, 1);
-                    PART_ButtonAddStartingPoint?.SetValue(IsVisibleProperty, false);
-                    PART_ListViewStartingPoints?.SetValue(IsVisibleProperty, false);
-                    PART_ButtonCancelAddStartingPoint?.SetValue(IsVisibleProperty, true);
-                }
-                else
-                {
-                    PART_ButtonAddStartingPoint?.SetValue(IsVisibleProperty, true);
-                    PART_ListViewStartingPoints?.SetValue(IsVisibleProperty, true);
-                    PART_ButtonCancelAddStartingPoint?.SetValue(IsVisibleProperty, false);
                 }
 
+                ApplyConfigureAddModeState();
                 break;
             case nameof(_controller.EnableTrace):
                 PART_ButtonRunTrace?.SetValue(IsEnabledProperty, _controller.EnableTrace);
+                break;
+            case nameof(_controller.SelectedTraceType):
+                PART_ListViewTraceTypes?.SetValue(Picker.SelectedItemProperty, _controller.SelectedTraceType);
                 break;
             case nameof(_controller.RequestedViewpoint):
                 if (GeoView != null && _controller.RequestedViewpoint != null)
@@ -492,7 +628,7 @@ public partial class UtilityNetworkTraceTool : TemplatedView
 
             sendingView._controller.IsRunningTrace = true;
 
-            var graphicsOverlays = new[] { sendingView._controller.StartingPointGraphicsOverlay };
+            var graphicsOverlays = new[] { sendingView._controller.StartingPointGraphicsOverlay, sendingView._controller.BarrierGraphicsOverlay };
 
             if (oldValue is GeoView oldGeoView)
             {
@@ -549,7 +685,7 @@ public partial class UtilityNetworkTraceTool : TemplatedView
 
     private async void OnGeoViewTapped(object? sender, GeoViewInputEventArgs e)
     {
-        if (e.Handled || !_controller.IsAddingStartingPoints || _controller.SelectedUtilityNetwork == null)
+        if (e.Handled || (!_controller.IsAddingStartingPoints && !_controller.IsAddingBarriers) || _controller.SelectedUtilityNetwork == null)
         {
             return;
         }
@@ -573,7 +709,14 @@ public partial class UtilityNetworkTraceTool : TemplatedView
                 {
                     if (GetFeature(identifyResult) is ArcGISFeature feature)
                     {
-                        _controller.AddStartingPoint(feature, e.Location);
+                        if (_controller.IsAddingBarriers)
+                        {
+                            _controller.AddBarrier(feature, e.Location);
+                        }
+                        else
+                        {
+                            _controller.AddStartingPoint(feature, e.Location);
+                        }
                     }
                 }
             }
@@ -650,6 +793,18 @@ public partial class UtilityNetworkTraceTool : TemplatedView
     }
 
     /// <summary>
+    /// Gets or sets a <see cref="Symbol"/> that represents a barrier.
+    /// </summary>
+    /// <value>
+    /// A <see cref="Symbol"/> that represents a barrier.
+    /// </value>
+    public Symbol? BarrierSymbol
+    {
+        get => GetValue(BarrierSymbolProperty) as Symbol;
+        set => SetValue(BarrierSymbolProperty, value);
+    }
+
+    /// <summary>
     /// Gets or sets a <see cref="Symbol"/> that represents an aggregated multipoint trace result.
     /// </summary>
     /// <value>
@@ -719,6 +874,12 @@ public partial class UtilityNetworkTraceTool : TemplatedView
         BindableProperty.Create(nameof(StartingPointSymbol), typeof(Symbol), typeof(UtilityNetworkTraceTool), propertyChanged: OnStartingPointSymbolPropertyChanged);
 
     /// <summary>
+    /// Identifies the <see cref="BarrierSymbol"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty BarrierSymbolProperty =
+        BindableProperty.Create(nameof(BarrierSymbol), typeof(Symbol), typeof(UtilityNetworkTraceTool), propertyChanged: OnBarrierSymbolPropertyChanged);
+
+    /// <summary>
     /// Identifies the <see cref="ResultFillSymbol"/> bindable property.
     /// </summary>
     public static readonly BindableProperty ResultFillSymbolProperty =
@@ -737,6 +898,16 @@ public partial class UtilityNetworkTraceTool : TemplatedView
         if (sender is UtilityNetworkTraceTool untt && untt._controller is UtilityNetworkTraceToolController controller)
         {
             controller.StartingPointSymbol = newValue as Symbol;
+            controller.HandleStartingPointSymbolChanged();
+        }
+    }
+
+    private static void OnBarrierSymbolPropertyChanged(BindableObject sender, object? oldValue, object? newValue)
+    {
+        if (sender is UtilityNetworkTraceTool untt && untt._controller is UtilityNetworkTraceToolController controller)
+        {
+            controller.BarrierSymbol = newValue as Symbol;
+            controller.HandleBarrierSymbolChanged();
         }
     }
 

--- a/src/Toolkit/Toolkit.Maui/UtilityNetworkTraceTool/UtilityNetworkTraceTool.cs
+++ b/src/Toolkit/Toolkit.Maui/UtilityNetworkTraceTool/UtilityNetworkTraceTool.cs
@@ -80,13 +80,20 @@ public partial class UtilityNetworkTraceTool : TemplatedView
     }
 
     /// <summary>
-    /// Reloads the named trace configurations available for the selected utility network, filtered by name.
+    /// Reloads the named trace configurations available for the selected utility network
+    /// and updates the list of trace configurations displayed by the tool.
     /// </summary>
-    /// <param name="availableTraces">The names of the trace configurations to load.</param>
-    /// <returns>A task that represents the asynchronous load operation.</returns>
-    public Task LoadNamedTracesAsync(IEnumerable<string> availableTraces)
+    /// <param name="visibleTraceNames">
+    /// The names of trace configurations to display. Only configurations with matching
+    /// names are included. Name matching is case-insensitive. If <c>null</c> or empty,
+    /// all available trace configurations are displayed.
+    /// </param>
+    /// <returns>
+    /// A task that represents the asynchronous load operation.
+    /// </returns>
+    public Task LoadAsync(IEnumerable<string>? visibleTraceNames)
     {
-        return _controller.LoadNamedTracesAsync(availableTraces);
+        return _controller.LoadAsync(visibleTraceNames);
     }
 
     /// <inheritdoc/>

--- a/src/Toolkit/Toolkit.Maui/UtilityNetworkTraceTool/UtilityNetworkTraceTool.cs
+++ b/src/Toolkit/Toolkit.Maui/UtilityNetworkTraceTool/UtilityNetworkTraceTool.cs
@@ -692,6 +692,8 @@ public partial class UtilityNetworkTraceTool : TemplatedView
 
     private async void OnGeoViewTapped(object? sender, GeoViewInputEventArgs e)
     {
+        _controller.DismissCallout();
+
         if (e.Handled || (!_controller.IsAddingStartingPoints && !_controller.IsAddingBarriers) || _controller.SelectedUtilityNetwork == null)
         {
             return;

--- a/src/Toolkit/Toolkit.Maui/UtilityNetworkTraceTool/UtilityNetworkTraceTool.cs
+++ b/src/Toolkit/Toolkit.Maui/UtilityNetworkTraceTool/UtilityNetworkTraceTool.cs
@@ -55,6 +55,16 @@ public partial class UtilityNetworkTraceTool : TemplatedView
         _controller.UtilityNetworks.CollectionChanged += UtilityNetworks_CollectionChanged;
     }
 
+    /// <summary>
+    /// Reloads the named trace configurations available for the selected utility network, filtered by name.
+    /// </summary>
+    /// <param name="availableTraces">The names of the trace configurations to load.</param>
+    /// <returns>A task that represents the asynchronous load operation.</returns>
+    public Task LoadNamedTracesAsync(IEnumerable<string> availableTraces)
+    {
+        return _controller.LoadNamedTracesAsync(availableTraces);
+    }
+
     /// <inheritdoc/>
     protected override void OnApplyTemplate()
     {

--- a/src/Toolkit/Toolkit.UI.Controls/UtilityNetworkTraceTool/UtilityNetworkTraceTool.Appearance.cs
+++ b/src/Toolkit/Toolkit.UI.Controls/UtilityNetworkTraceTool/UtilityNetworkTraceTool.Appearance.cs
@@ -44,6 +44,13 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
     [TemplatePart(Name = "PART_ResetStartingPointsButton", Type = typeof(ButtonBase))]
     [TemplatePart(Name = "PART_AddStartingPointsButton", Type = typeof(ButtonBase))]
     [TemplatePart(Name = "PART_CancelAddStartingPointsButton", Type = typeof(ButtonBase))]
+    [TemplatePart(Name = "PART_BarriersSectionContainer", Type = typeof(UIElement))]
+    [TemplatePart(Name = "PART_BarriersList", Type = typeof(ListView))]
+    [TemplatePart(Name = "PART_IsAddingBarriersIndicator", Type = typeof(UIElement))]
+    [TemplatePart(Name = "PART_AddRemoveBarrierButtonsContainer", Type = typeof(UIElement))]
+    [TemplatePart(Name = "PART_ResetBarriersButton", Type = typeof(ButtonBase))]
+    [TemplatePart(Name = "PART_AddBarriersButton", Type = typeof(ButtonBase))]
+    [TemplatePart(Name = "PART_CancelAddBarriersButton", Type = typeof(ButtonBase))]
     [TemplatePart(Name = "PART_AdvancedOptionsSectionContainer", Type = typeof(UIElement))]
     [TemplatePart(Name = "PART_ResultNameTextBox", Type = typeof(TextBox))]
     [TemplatePart(Name = "PART_ResultColorPalette", Type = typeof(UIElement))]
@@ -81,6 +88,13 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         private ButtonBase? _part_resetStartingPointsButton;
         private ButtonBase? _part_addStartingPointsButton;
         private ButtonBase? _part_cancelAddStartingPointsButton;
+        private UIElement? _part_barriersSectionContainer;
+        private ListView? _part_barriersList;
+        private UIElement? _part_isAddingBarriersIndicator;
+        private UIElement? _part_addRemoveBarriersButtonContainer;
+        private ButtonBase? _part_resetBarriersButton;
+        private ButtonBase? _part_addBarriersButton;
+        private ButtonBase? _part_cancelAddBarriersButton;
         private UIElement? _part_advancedOptionsSectionContainer;
         private TextBox? _part_resultNamedTextBox;
         private ToolkitColorPalette? _part_resultColorPalette;
@@ -187,6 +201,57 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
                 _part_cancelAddStartingPointsButton = cancelAddStartingPointsButton;
                 _part_cancelAddStartingPointsButton.Visibility = _controller.IsAddingStartingPoints ? Visibility.Visible : Visibility.Collapsed;
                 _part_cancelAddStartingPointsButton.Click += Part_cancelAddStartingPointsButton_Click;
+            }
+
+            if (GetTemplateChild("PART_BarriersSectionContainer") is UIElement barriersSectionContainer)
+            {
+                _part_barriersSectionContainer = barriersSectionContainer;
+                _part_barriersSectionContainer.Visibility = _controller.SelectedTraceType == null ? Visibility.Collapsed : Visibility.Visible;
+            }
+
+            if (GetTemplateChild("PART_BarriersList") is ListView barriersList)
+            {
+                _part_barriersList = barriersList;
+                _part_barriersList.ItemsSource = _controller.Barriers;
+                _part_barriersList.SelectedItem = _controller.SelectedBarrier;
+                _part_barriersList.Visibility = _controller.IsAddingBarriers ? Visibility.Collapsed : Visibility.Visible;
+                _part_barriersList.SelectionChanged += Part_barriersList_SelectionChanged;
+                if (_part_barriersList is StartingPointListView specialized)
+                {
+                    specialized.ZoomToCommand = new DelegateCommand((parameter) => HandleZoomToBarrierCommand(parameter));
+                }
+            }
+
+            if (GetTemplateChild("PART_IsAddingBarriersIndicator") is UIElement addingBarriersIndicator)
+            {
+                _part_isAddingBarriersIndicator = addingBarriersIndicator;
+                _part_isAddingBarriersIndicator.Visibility = _controller.IsAddingBarriers ? Visibility.Visible : Visibility.Collapsed;
+            }
+
+            if (GetTemplateChild("PART_AddRemoveBarrierButtonsContainer") is UIElement addRemoveBarrierButtonsContainer)
+            {
+                _part_addRemoveBarriersButtonContainer = addRemoveBarrierButtonsContainer;
+                _part_addRemoveBarriersButtonContainer.Visibility = _controller.IsAddingBarriers ? Visibility.Collapsed : Visibility.Visible;
+            }
+
+            if (GetTemplateChild("PART_ResetBarriersButton") is ButtonBase resetBarriersButton)
+            {
+                _part_resetBarriersButton = resetBarriersButton;
+                _part_resetBarriersButton.Visibility = _controller.Barriers.Any() ? Visibility.Visible : Visibility.Collapsed;
+                _part_resetBarriersButton.Click += Part_resetBarriersButton_Click;
+            }
+
+            if (GetTemplateChild("PART_AddBarriersButton") is ButtonBase addBarriersButton)
+            {
+                _part_addBarriersButton = addBarriersButton;
+                _part_addBarriersButton.Click += Part_addBarriersButton_Click;
+            }
+
+            if (GetTemplateChild("PART_CancelAddBarriersButton") is ButtonBase cancelAddBarriersButton)
+            {
+                _part_cancelAddBarriersButton = cancelAddBarriersButton;
+                _part_cancelAddBarriersButton.Visibility = _controller.IsAddingBarriers ? Visibility.Visible : Visibility.Collapsed;
+                _part_cancelAddBarriersButton.Click += Part_cancelAddBarriersButton_Click;
             }
 
             if (GetTemplateChild("PART_AdvancedOptionsSectionContainer") is UIElement advancedOptionsSectionContainer)
@@ -327,6 +392,11 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             _controller.StartingPoints.Clear();
         }
 
+        private void Part_resetBarriersButton_Click(object? sender, RoutedEventArgs e)
+        {
+            _controller.Barriers.Clear();
+        }
+
         private void Part_deleteAllResultsButton_Click(object? sender, RoutedEventArgs e)
         {
             foreach (var result in _controller.Results)
@@ -371,9 +441,24 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             _controller.IsAddingStartingPoints = true;
         }
 
+        private void Part_cancelAddBarriersButton_Click(object? sender, RoutedEventArgs e)
+        {
+            _controller.IsAddingBarriers = false;
+        }
+
+        private void Part_addBarriersButton_Click(object? sender, RoutedEventArgs e)
+        {
+            _controller.IsAddingBarriers = true;
+        }
+
         private void Part_startingPointsList_SelectionChanged(object? sender, SelectionChangedEventArgs e)
         {
             _controller.SelectedStartingPoint = (sender as Selector)?.SelectedItem as StartingPointModel;
+        }
+
+        private void Part_barriersList_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+        {
+            _controller.SelectedBarrier = (sender as Selector)?.SelectedItem as BarrierModel;
         }
 
         private void Part_traceConfigurationsSelector_SelectionChanged(object? sender, SelectionChangedEventArgs e)
@@ -439,6 +524,26 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         /// </summary>
         public static readonly DependencyProperty StartingPointItemTemplateProperty =
             DependencyProperty.Register(nameof(StartingPointItemTemplate), typeof(DataTemplate),
+                typeof(UtilityNetworkTraceTool), new PropertyMetadata(null));
+
+        /// <summary>
+        /// Gets or sets the <see cref="DataTemplate"/> used to display a barrier, which is
+        /// a <see cref="UtilityElement"/> item.
+        /// </summary>
+        /// <value>
+        /// A <see cref="DataTemplate"/> for a <see cref="UtilityElement"/> item.
+        /// </value>
+        public DataTemplate? BarrierItemTemplate
+        {
+            get => GetValue(BarrierItemTemplateProperty) as DataTemplate;
+            set => SetValue(BarrierItemTemplateProperty, value);
+        }
+
+        /// <summary>
+        /// Identifies the <see cref="BarrierItemTemplate"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty BarrierItemTemplateProperty =
+            DependencyProperty.Register(nameof(BarrierItemTemplate), typeof(DataTemplate),
                 typeof(UtilityNetworkTraceTool), new PropertyMetadata(null));
 
         /// <summary>

--- a/src/Toolkit/Toolkit.UI.Controls/UtilityNetworkTraceTool/UtilityNetworkTraceTool.Appearance.cs
+++ b/src/Toolkit/Toolkit.UI.Controls/UtilityNetworkTraceTool/UtilityNetworkTraceTool.Appearance.cs
@@ -62,6 +62,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
     [TemplatePart(Name = "PART_RunTraceButton", Type = typeof(ButtonBase))]
     [TemplatePart(Name = "PART_CancelTraceButton", Type = typeof(ButtonBase))]
     [TemplatePart(Name = "PART_IdentifyInProgressIndicator", Type = typeof(UIElement))]
+    [TemplatePart(Name = "PART_IdentifyInProgressText", Type = typeof(TextBlock))]
     [TemplatePart(Name = "PART_CancelIdentifyButton", Type = typeof(ButtonBase))]
     [TemplatePart(Name = "PART_ResultsTabItem", Type = typeof(UIElement))]
     [TemplatePart(Name = "PART_ResultsItemControl", Type = typeof(ItemsControl))]
@@ -106,6 +107,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         private ButtonBase? _part_runTraceButton;
         private ButtonBase? _part_cancelTraceButton;
         private UIElement? _part_identifyInProgressIndicator;
+        private TextBlock? _part_identifyInProgressText;
         private ButtonBase? _part_cancelIdentifyButton;
         private UIElement? _part_resultsTabItem;
         private ItemsControl? _part_resultsItemControl;
@@ -321,6 +323,12 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             {
                 _part_identifyInProgressIndicator = identifyInProgressIndicator;
                 _part_identifyInProgressIndicator.Visibility = Visibility.Collapsed;
+            }
+
+            if (GetTemplateChild("PART_IdentifyInProgressText") is TextBlock identifyInProgressText)
+            {
+                _part_identifyInProgressText = identifyInProgressText;
+                UpdateIdentifyInProgressText();
             }
 
             if (GetTemplateChild("PART_CancelIdentifyButton") is ButtonBase cancelIdentifyButton)

--- a/src/Toolkit/Toolkit.UI.Controls/UtilityNetworkTraceTool/UtilityNetworkTraceTool.Windows.cs
+++ b/src/Toolkit/Toolkit.UI.Controls/UtilityNetworkTraceTool/UtilityNetworkTraceTool.Windows.cs
@@ -321,6 +321,8 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
 
         private async void OnGeoViewTapped(object? sender, GeoViewInputEventArgs e)
         {
+            _controller.DismissCallout();
+
             if (e.Handled || (!_controller.IsAddingStartingPoints && !_controller.IsAddingBarriers) || _controller.SelectedUtilityNetwork == null)
             {
                 return;
@@ -328,6 +330,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
 
             try
             {
+                UpdateIdentifyInProgressText();
                 _part_identifyInProgressIndicator?.SetValue(VisibilityProperty, Visibility.Visible);
 
                 if (sender is GeoView geoView)
@@ -366,6 +369,17 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             finally
             {
                 _part_identifyInProgressIndicator?.SetValue(VisibilityProperty, Visibility.Collapsed);
+            }
+        }
+
+        private void UpdateIdentifyInProgressText()
+        {
+            if (_part_identifyInProgressText != null)
+            {
+                var resourceKey = _controller.IsAddingBarriers
+                    ? "UtilityNetworkTraceToolIdentifyingBarriers"
+                    : "UtilityNetworkTraceToolIdentifyingStartingPoints";
+                _part_identifyInProgressText.Text = Properties.Resources.GetString(resourceKey);
             }
         }
 

--- a/src/Toolkit/Toolkit.UI.Controls/UtilityNetworkTraceTool/UtilityNetworkTraceTool.Windows.cs
+++ b/src/Toolkit/Toolkit.UI.Controls/UtilityNetworkTraceTool/UtilityNetworkTraceTool.Windows.cs
@@ -56,6 +56,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             _controller.Results.CollectionChanged += Results_CollectionChanged;
             _controller.TraceTypes.CollectionChanged += TraceTypes_CollectionChanged;
             _controller.StartingPoints.CollectionChanged += StartingPoints_CollectionChanged;
+            _controller.Barriers.CollectionChanged += Barriers_CollectionChanged;
             _controller.UtilityNetworks.CollectionChanged += UtilityNetworks_CollectionChanged;
             ResultFillSymbol = _controller.ResultFillSymbol;
             ResultLineSymbol = _controller.ResultLineSymbol;
@@ -72,10 +73,16 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             _part_resetStartingPointsButton?.SetValue(VisibilityProperty, _controller.StartingPoints.Any() ? Visibility.Visible : Visibility.Collapsed);
         }
 
+        private void Barriers_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            _part_resetBarriersButton?.SetValue(VisibilityProperty, _controller.Barriers.Any() ? Visibility.Visible : Visibility.Collapsed);
+        }
+
         private void TraceTypes_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
             _part_noNamedTraceConfigurationsWarningContainer?.SetValue(VisibilityProperty, _controller.TraceTypes.Any() ? Visibility.Collapsed : Visibility.Visible);
             _part_startingPointsSectionContainer?.SetValue(VisibilityProperty, _controller.TraceTypes.Any() ? Visibility.Visible : Visibility.Collapsed);
+            _part_barriersSectionContainer?.SetValue(VisibilityProperty, _controller.TraceTypes.Any() ? Visibility.Visible : Visibility.Collapsed);
             _part_traceConfigurationsContainer?.SetValue(VisibilityProperty, _controller.TraceTypes.Any() ? Visibility.Visible : Visibility.Collapsed);
         }
 
@@ -89,6 +96,17 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             _controller.AddStartingPoint(feature, location);
         }
 
+        /// <summary>
+        /// Adds a barrier.
+        /// </summary>
+        /// <param name="feature">The feature to use as the basis for the barrier.</param>
+        /// <param name="location">Optional location to use, which will be used to specify the location along the line for line features.</param>
+        /// <param name="useAsFilterBarrier">A value indicating whether to use the barrier as a filter barrier.</param>
+        public void AddBarrier(ArcGISFeature feature, MapPoint? location, bool? useAsFilterBarrier = false)
+        {
+            _controller.AddBarrier(feature, location, useAsFilterBarrier);
+        }
+
         #region Command implementations
 
         private void HandleZoomToStartingPointCommand(object? parameter)
@@ -98,6 +116,18 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
                 GeoView?.SetViewpoint(new Viewpoint(zoomEnvelope));
             }
             else if (_part_startingPointsList?.SelectedItem is StartingPointModel selectedSP && selectedSP.ZoomToExtent is Envelope selectedZoomEnvelope)
+            {
+                GeoView?.SetViewpoint(new Viewpoint(selectedZoomEnvelope));
+            }
+        }
+
+        private void HandleZoomToBarrierCommand(object? parameter)
+        {
+            if (parameter is BarrierModel selectedBarrier && selectedBarrier.ZoomToExtent is Envelope zoomEnvelope)
+            {
+                GeoView?.SetViewpoint(new Viewpoint(zoomEnvelope));
+            }
+            else if (_part_barriersList?.SelectedItem is BarrierModel selectedBarrierItem && selectedBarrierItem.ZoomToExtent is Envelope selectedZoomEnvelope)
             {
                 GeoView?.SetViewpoint(new Viewpoint(selectedZoomEnvelope));
             }
@@ -217,6 +247,9 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
                 case nameof(_controller.SelectedStartingPoint):
                     _part_startingPointsList?.SetValue(ListView.SelectedItemProperty, _controller.SelectedStartingPoint);
                     break;
+                case nameof(_controller.SelectedBarrier):
+                    _part_barriersList?.SetValue(ListView.SelectedItemProperty, _controller.SelectedBarrier);
+                    break;
                 case nameof(_controller.TraceName):
                     _part_resultNamedTextBox?.SetValue(TextBox.TextProperty, _controller.TraceName ?? "");
                     break;
@@ -240,6 +273,10 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
                 case nameof(_controller.IsAddingStartingPoints):
                     _part_addRemoveStartingPointsButtonContainer?.SetValue(VisibilityProperty, _controller.IsAddingStartingPoints ? Visibility.Collapsed : Visibility.Visible);
                     _part_cancelAddStartingPointsButton?.SetValue(VisibilityProperty, _controller.IsAddingStartingPoints ? Visibility.Visible : Visibility.Collapsed);
+                    break;
+                case nameof(_controller.IsAddingBarriers):
+                    _part_addRemoveBarriersButtonContainer?.SetValue(VisibilityProperty, _controller.IsAddingBarriers ? Visibility.Collapsed : Visibility.Visible);
+                    _part_cancelAddBarriersButton?.SetValue(VisibilityProperty, _controller.IsAddingBarriers ? Visibility.Visible : Visibility.Collapsed);
                     break;
                 case nameof(_controller.StartingPointSymbol):
                     StartingPointSymbol = _controller.StartingPointSymbol;
@@ -267,7 +304,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
 
         private async void OnGeoViewTapped(object? sender, GeoViewInputEventArgs e)
         {
-            if (e.Handled || !_controller.IsAddingStartingPoints || _controller.SelectedUtilityNetwork == null)
+            if (e.Handled || (!_controller.IsAddingStartingPoints && !_controller.IsAddingBarriers) || _controller.SelectedUtilityNetwork == null)
             {
                 return;
             }
@@ -290,7 +327,14 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
                     {
                         if (GetFeature(identifyResult) is ArcGISFeature feature)
                         {
-                            _controller.AddStartingPoint(feature, e.Location);
+                            if (_controller.IsAddingBarriers)
+                            {
+                                _controller.AddBarrier(feature, e.Location);
+                            }
+                            else
+                            {
+                                _controller.AddStartingPoint(feature, e.Location);
+                            }
                         }
                     }
                 }
@@ -389,6 +433,15 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             }
         }
 
+        private static void OnBarrierSymbolChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is UtilityNetworkTraceTool traceTool)
+            {
+                traceTool._controller.BarrierSymbol = e.NewValue as Symbol;
+                traceTool._controller.HandleBarrierSymbolChanged();
+            }
+        }
+
         private static void OnResultPointSymbolChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             if (d is UtilityNetworkTraceTool traceTool)
@@ -415,7 +468,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
 
             _controller.IsRunningTrace = true;
 
-            var graphicsOverlays = new[] { _controller.StartingPointGraphicsOverlay };
+            var graphicsOverlays = new[] { _controller.StartingPointGraphicsOverlay, _controller.BarrierGraphicsOverlay };
 
             if (oldGeoView != null)
             {
@@ -513,9 +566,9 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         #region Convenience Properties
 
         /// <summary>
-        /// Gets or sets the <see cref="GeoView"/> where starting points and trace results are displayed.
+        /// Gets or sets the <see cref="GeoView"/> where starting points, barriers, and trace results are displayed.
         /// </summary>
-        /// <value>A <see cref="GeoView"/> where starting points and trace results are displayed.</value>
+        /// <value>A <see cref="GeoView"/> where starting points, barriers, and trace results are displayed.</value>
         public GeoView? GeoView
         {
             get => GetValue(GeoViewProperty) as GeoView;
@@ -544,6 +597,18 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         {
             get => GetValue(StartingPointSymbolProperty) as Symbol;
             set => SetValue(StartingPointSymbolProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets a <see cref="Symbol"/> that represents a barrier.
+        /// </summary>
+        /// <value>
+        /// A <see cref="Symbol"/> that represents a barrier.
+        /// </value>
+        public Symbol? BarrierSymbol
+        {
+            get => GetValue(BarrierSymbolProperty) as Symbol;
+            set => SetValue(BarrierSymbolProperty, value);
         }
 
         /// <summary>
@@ -603,6 +668,12 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         /// </summary>
         public static readonly DependencyProperty StartingPointSymbolProperty =
             DependencyProperty.Register(nameof(StartingPointSymbol), typeof(Symbol), typeof(UtilityNetworkTraceTool), new PropertyMetadata(null, OnStartingPointSymbolChanged));
+
+        /// <summary>
+        /// Identifies the <see cref="BarrierSymbol"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty BarrierSymbolProperty =
+            DependencyProperty.Register(nameof(BarrierSymbol), typeof(Symbol), typeof(UtilityNetworkTraceTool), new PropertyMetadata(null, OnBarrierSymbolChanged));
 
         /// <summary>
         /// Identifies the <see cref="ResultPointSymbol"/> dependency property.

--- a/src/Toolkit/Toolkit.UI.Controls/UtilityNetworkTraceTool/UtilityNetworkTraceTool.Windows.cs
+++ b/src/Toolkit/Toolkit.UI.Controls/UtilityNetworkTraceTool/UtilityNetworkTraceTool.Windows.cs
@@ -107,6 +107,16 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             _controller.AddBarrier(feature, location, useAsFilterBarrier);
         }
 
+        /// <summary>
+        /// Reloads the named trace configurations available for the selected utility network, filtered by name.
+        /// </summary>
+        /// <param name="availableTraces">The names of the trace configurations to load.</param>
+        /// <returns>A task that represents the asynchronous load operation.</returns>
+        public Task LoadNamedTracesAsync(IEnumerable<string> availableTraces)
+        {
+            return _controller.LoadNamedTracesAsync(availableTraces);
+        }
+
         #region Command implementations
 
         private void HandleZoomToStartingPointCommand(object? parameter)

--- a/src/Toolkit/Toolkit.UI.Controls/UtilityNetworkTraceTool/UtilityNetworkTraceTool.Windows.cs
+++ b/src/Toolkit/Toolkit.UI.Controls/UtilityNetworkTraceTool/UtilityNetworkTraceTool.Windows.cs
@@ -439,6 +439,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         {
             if (d is UtilityNetworkTraceTool traceTool)
             {
+                traceTool._controller.StartingPointSymbol = e.NewValue as Symbol;
                 traceTool._controller.HandleStartingPointSymbolChanged();
             }
         }

--- a/src/Toolkit/Toolkit.UI.Controls/UtilityNetworkTraceTool/UtilityNetworkTraceTool.Windows.cs
+++ b/src/Toolkit/Toolkit.UI.Controls/UtilityNetworkTraceTool/UtilityNetworkTraceTool.Windows.cs
@@ -108,13 +108,20 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         }
 
         /// <summary>
-        /// Reloads the named trace configurations available for the selected utility network, filtered by name.
+        /// Reloads the named trace configurations available for the selected utility network
+        /// and updates the list of trace configurations displayed by the tool.
         /// </summary>
-        /// <param name="availableTraces">The names of the trace configurations to load.</param>
-        /// <returns>A task that represents the asynchronous load operation.</returns>
-        public Task LoadNamedTracesAsync(IEnumerable<string> availableTraces)
+        /// <param name="visibleTraceNames">
+        /// The names of trace configurations to display. Only configurations with matching
+        /// names are included. Name matching is case-insensitive. If <c>null</c> or empty,
+        /// all available trace configurations are displayed.
+        /// </param>
+        /// <returns>
+        /// A task that represents the asynchronous load operation.
+        /// </returns>
+        public Task LoadAsync(IEnumerable<string>? visibleTraceNames)
         {
-            return _controller.LoadNamedTracesAsync(availableTraces);
+            return _controller.LoadAsync(visibleTraceNames);
         }
 
         #region Command implementations

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/UtilityNetworkTraceTool/UtilityNetworkTraceTool.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/UtilityNetworkTraceTool/UtilityNetworkTraceTool.Theme.xaml
@@ -523,6 +523,127 @@
                 </DataTemplate>
             </Setter.Value>
         </Setter>
+        <Setter Property="BarrierItemTemplate">
+            <Setter.Value>
+                <DataTemplate>
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <controls:SymbolDisplay
+                            Grid.RowSpan="2"
+                            Width="32"
+                            Height="32"
+                            Margin="0,0,4,0"
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center"
+                            Focusable="False"
+                            Symbol="{Binding Symbol, Mode=OneWay}" />
+                        <TextBlock
+                            Grid.Column="1"
+                            Margin="2"
+                            Text="{Binding Barrier.NetworkSource.Name}"
+                            TextWrapping="Wrap" />
+                        <TextBlock
+                            Grid.Row="1"
+                            Grid.Column="1"
+                            Margin="2"
+                            FontWeight="SemiBold"
+                            Text="{Binding Barrier.AssetGroup.Name}"
+                            TextWrapping="Wrap" />
+                        <ComboBox
+                            Grid.Row="2"
+                            Grid.Column="0"
+                            Grid.ColumnSpan="5"
+                            ItemContainerStyle="{StaticResource UNTraceComboBoxItem}"
+                            ItemsSource="{Binding Barrier.AssetType.TerminalConfiguration.Terminals}"
+                            KeyboardNavigation.TabIndex="8"
+                            SelectedItem="{Binding Barrier.Terminal, Mode=TwoWay}"
+                            Style="{StaticResource UNTraceTaggedComboBox}"
+                            Tag="Terminal"
+                            Visibility="{Binding TerminalPickerVisible, Converter={StaticResource VisibilityConverter}}">
+                            <ComboBox.ItemTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding Name}" TextWrapping="Wrap" />
+                                </DataTemplate>
+                            </ComboBox.ItemTemplate>
+                        </ComboBox>
+                        <Slider
+                            x:Name="FractionAlongSlider"
+                            Grid.Row="2"
+                            Grid.Column="0"
+                            Grid.ColumnSpan="3"
+                            Margin="2"
+                            VerticalAlignment="Center"
+                            KeyboardNavigation.TabIndex="9"
+                            Style="{StaticResource UNTraceSlider}"
+                            Visibility="{Binding FractionSliderVisible, Converter={StaticResource VisibilityConverter}}"
+                            Value="{Binding FractionAlongEdge, Mode=TwoWay}" />
+                        <TextBox
+                            Grid.Row="2"
+                            Grid.Column="3"
+                            Grid.ColumnSpan="2"
+                            Margin="4,0,0,0"
+                            KeyboardNavigation.TabIndex="10"
+                            Style="{StaticResource UNTraceTextBoxCompact}"
+                            Text="{Binding ElementName=FractionAlongSlider, Path=Value, Mode=TwoWay, StringFormat=0.00}"
+                            Visibility="{Binding FractionSliderVisible, Converter={StaticResource VisibilityConverter}}" />
+                        <CheckBox
+                            Grid.Row="3"
+                            Grid.ColumnSpan="5"
+                            Margin="2"
+                            Content="{internal:LocalizedString Key=UtilityNetworkTraceToolUseAsFilterBarrier}"
+                            IsChecked="{Binding UseAsFilterBarrier, Mode=TwoWay}"
+                            Style="{StaticResource UNTraceCheckBox}" />
+                        <Button
+                            Grid.RowSpan="2"
+                            Grid.Column="2"
+                            Margin="8,4,0,4"
+                            VerticalAlignment="Center"
+                            VerticalContentAlignment="Center"
+                            Command="{Binding RelativeSource={RelativeSource AncestorType=internal:StartingPointListView}, Path=ZoomToCommand}"
+                            CommandParameter="{Binding}"
+                            KeyboardNavigation.TabIndex="1"
+                            Style="{StaticResource UNTraceIconButton}">
+                            <Path Data="{StaticResource UNTraceIconZoomTo}" Style="{StaticResource UNTracePathCommandIconStyle}" />
+                        </Button>
+                        <Button
+                            Grid.RowSpan="2"
+                            Grid.Column="3"
+                            Margin="8,4,0,4"
+                            VerticalAlignment="Center"
+                            Command="{Binding RelativeSource={RelativeSource AncestorType=internal:StartingPointListView}, Path=OpenInspectorCommand}"
+                            CommandParameter="{Binding}"
+                            KeyboardNavigation.TabIndex="2"
+                            Style="{StaticResource UNTraceIconButton}">
+                            <Path Data="{StaticResource UNTraceIconInspect}" Style="{StaticResource UNTracePathCommandIconStyle}" />
+                        </Button>
+                        <Button
+                            Grid.RowSpan="2"
+                            Grid.Column="4"
+                            Margin="8,4,0,4"
+                            VerticalAlignment="Center"
+                            VerticalContentAlignment="Center"
+                            Command="{Binding RelativeSource={RelativeSource AncestorType=internal:StartingPointListView}, Path=DeleteSelectedCommand}"
+                            CommandParameter="{Binding}"
+                            KeyboardNavigation.TabIndex="3"
+                            Style="{StaticResource UNTraceIconButton}">
+                            <Path Data="{StaticResource UNTraceIconDelete}" Style="{StaticResource UNTracePathCommandIconStyle}" />
+                        </Button>
+                    </Grid>
+                </DataTemplate>
+            </Setter.Value>
+        </Setter>
 
         <Setter Property="Template">
             <Setter.Value>
@@ -669,6 +790,117 @@
                                                         </UniformGrid>
 
                                                         <Button x:Name="PART_CancelAddStartingPointsButton"
+                                                            Margin="4"
+                                                            Content="{internal:LocalizedString Key=UtilityNetworkTraceToolCancel}"
+                                                            Style="{StaticResource UNTracePrimaryButton}" />
+                                                    </StackPanel>
+                                                </GroupBox>
+                                                <GroupBox x:Name="PART_BarriersSectionContainer"
+                                                    Header="{internal:LocalizedString Key=UtilityNetworkTraceToolBarriers}"
+                                                    Style="{StaticResource UNTraceGroupBox}">
+                                                    <StackPanel Orientation="Vertical">
+                                                        <internal:StartingPointListView x:Name="PART_BarriersList"
+                                                            ItemTemplate="{TemplateBinding BarrierItemTemplate}">
+                                                            <internal:StartingPointListView.InspectorViewTemplate>
+                                                                <DataTemplate>
+                                                                    <Border Background="Transparent">
+                                                                        <StackPanel>
+                                                                            <Grid>
+                                                                                <Grid.ColumnDefinitions>
+                                                                                    <ColumnDefinition Width="*" />
+                                                                                    <ColumnDefinition Width="Auto" />
+                                                                                </Grid.ColumnDefinitions>
+                                                                                <Grid.RowDefinitions>
+                                                                                    <RowDefinition Height="Auto" />
+                                                                                    <RowDefinition Height="Auto" />
+                                                                                </Grid.RowDefinitions>
+                                                                                <TextBlock
+                                                                                    Grid.Row="0"
+                                                                                    Grid.Column="0"
+                                                                                    Margin="4"
+                                                                                    FontSize="14"
+                                                                                    FontWeight="SemiBold"
+                                                                                    Text="{Binding Barrier.NetworkSource.Name}" />
+                                                                                <TextBlock
+                                                                                    Grid.Row="1"
+                                                                                    Grid.Column="0"
+                                                                                    Margin="4"
+                                                                                    FontWeight="SemiBold"
+                                                                                    Text="{Binding Barrier.AssetGroup.Name}" />
+                                                                                <controls:SymbolDisplay
+                                                                                    Grid.RowSpan="2"
+                                                                                    Grid.Column="1"
+                                                                                    Width="32"
+                                                                                    Height="32"
+                                                                                    Margin="4"
+                                                                                    VerticalAlignment="Center"
+                                                                                    Focusable="False"
+                                                                                    Symbol="{Binding Symbol, Mode=OneTime}" />
+                                                                            </Grid>
+                                                                            <CheckBox
+                                                                                Margin="4"
+                                                                                Content="{internal:LocalizedString Key=UtilityNetworkTraceToolUseAsFilterBarrier}"
+                                                                                IsChecked="{Binding UseAsFilterBarrier, Mode=TwoWay}" />
+                                                                            <GroupBox
+                                                                                BorderBrush="{StaticResource UNTraceBorder1}"
+                                                                                BorderThickness="0,1,0,0"
+                                                                                Header="{internal:LocalizedString Key=UtilityNetworkTraceToolTerminal}"
+                                                                                Style="{StaticResource UNTraceGroupBox}"
+                                                                                Visibility="{Binding TerminalPickerVisible, Converter={StaticResource VisibilityConverter}}">
+                                                                                <ComboBox
+                                                                                    DisplayMemberPath="Name"
+                                                                                    ItemsSource="{Binding Barrier.AssetType.TerminalConfiguration.Terminals}"
+                                                                                    SelectedItem="{Binding Barrier.Terminal, Mode=TwoWay}"
+                                                                                    Style="{StaticResource UNTraceComboBox}" />
+                                                                            </GroupBox>
+                                                                            <GroupBox
+                                                                                BorderBrush="{StaticResource UNTraceBorder1}"
+                                                                                BorderThickness="0,1,0,0"
+                                                                                Header="{internal:LocalizedString Key=UtilityNetworkTraceToolFractionAlongEdge}"
+                                                                                Style="{StaticResource UNTraceGroupBox}"
+                                                                                Visibility="{Binding FractionSliderVisible, Converter={StaticResource VisibilityConverter}}">
+                                                                                <Slider Style="{StaticResource UNTraceSlider}" Value="{Binding FractionAlongEdge, Mode=TwoWay}" />
+                                                                            </GroupBox>
+                                                                            <GroupBox
+                                                                                BorderBrush="{StaticResource UNTraceBorder1}"
+                                                                                BorderThickness="0,1,0,0"
+                                                                                Header="{internal:LocalizedString Key=UtilityNetworkTraceToolAssetDetails}"
+                                                                                Style="{StaticResource UNTraceGroupBox}">
+                                                                                <controls:PopupViewer Popup="{Binding Popup}" />
+                                                                            </GroupBox>
+                                                                        </StackPanel>
+                                                                    </Border>
+                                                                </DataTemplate>
+                                                            </internal:StartingPointListView.InspectorViewTemplate>
+                                                        </internal:StartingPointListView>
+                                                        <TextBlock x:Name="PART_IsAddingBarriersIndicator"
+                                                            Margin="2"
+                                                            FontWeight="SemiBold"
+                                                            Text="{internal:LocalizedString Key=UtilityNetworkTraceToolTapToIdentifyBarriers}"
+                                                            TextAlignment="Center" />
+                                                        <UniformGrid x:Name="PART_AddRemoveBarrierButtonsContainer"
+                                                            Margin="0,4,0,0"
+                                                            Rows="1">
+                                                            <Button x:Name="PART_ResetBarriersButton"
+                                                                Margin="0,0,4,0"
+                                                                Style="{StaticResource UNTraceSecondaryButton}">
+                                                                <StackPanel Orientation="Horizontal">
+                                                                    <Path Data="{StaticResource UNTraceIconReset}" Style="{StaticResource UNTraceButtonEmbeddedIcon}" />
+                                                                    <TextBlock Margin="0,0,4,0" Text="{internal:LocalizedString Key=UtilityNetworkTraceToolRemoveAllBarriers}" />
+                                                                </StackPanel>
+                                                            </Button>
+                                                            <Button x:Name="PART_AddBarriersButton"
+                                                                Grid.Column="1"
+                                                                Margin="0"
+                                                                Style="{StaticResource UNTracePrimaryButton}">
+                                                                <StackPanel Orientation="Horizontal">
+                                                                    <Path Data="{StaticResource UNTraceIconPlus}" Style="{StaticResource UNTraceButtonEmbeddedIcon}" />
+                                                                    <TextBlock Text="{internal:LocalizedString Key=UtilityNetworkTraceToolAddBarrier}" />
+                                                                </StackPanel>
+                                                            </Button>
+                                                        </UniformGrid>
+
+                                                        <Button x:Name="PART_CancelAddBarriersButton"
                                                             Margin="4"
                                                             Content="{internal:LocalizedString Key=UtilityNetworkTraceToolCancel}"
                                                             Style="{StaticResource UNTracePrimaryButton}" />

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/UtilityNetworkTraceTool/UtilityNetworkTraceTool.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/UtilityNetworkTraceTool/UtilityNetworkTraceTool.Theme.xaml
@@ -471,6 +471,7 @@
                             Grid.ColumnSpan="3"
                             Margin="2"
                             VerticalAlignment="Center"
+                            AutomationProperties.Name="{internal:LocalizedString Key=UtilityNetworkTraceToolFractionAlongEdge}"
                             KeyboardNavigation.TabIndex="9"
                             Style="{StaticResource UNTraceSlider}"
                             Visibility="{Binding FractionSliderVisible, Converter={StaticResource VisibilityConverter}}"
@@ -480,6 +481,7 @@
                             Grid.Column="3"
                             Grid.ColumnSpan="2"
                             Margin="4,0,0,0"
+                            AutomationProperties.Name="{internal:LocalizedString Key=UtilityNetworkTraceToolFractionAlongEdge}"
                             KeyboardNavigation.TabIndex="10"
                             Style="{StaticResource UNTraceTextBoxCompact}"
                             Text="{Binding ElementName=FractionAlongSlider, Path=Value, Mode=TwoWay, StringFormat=0.00}"
@@ -585,6 +587,7 @@
                             Grid.ColumnSpan="3"
                             Margin="2"
                             VerticalAlignment="Center"
+                            AutomationProperties.Name="{internal:LocalizedString Key=UtilityNetworkTraceToolFractionAlongEdge}"
                             KeyboardNavigation.TabIndex="9"
                             Style="{StaticResource UNTraceSlider}"
                             Visibility="{Binding FractionSliderVisible, Converter={StaticResource VisibilityConverter}}"
@@ -594,6 +597,7 @@
                             Grid.Column="3"
                             Grid.ColumnSpan="2"
                             Margin="4,0,0,0"
+                            AutomationProperties.Name="{internal:LocalizedString Key=UtilityNetworkTraceToolFractionAlongEdge}"
                             KeyboardNavigation.TabIndex="10"
                             Style="{StaticResource UNTraceTextBoxCompact}"
                             Text="{Binding ElementName=FractionAlongSlider, Path=Value, Mode=TwoWay, StringFormat=0.00}"
@@ -748,7 +752,10 @@
                                                                                 Header="{internal:LocalizedString Key=UtilityNetworkTraceToolFractionAlongEdge}"
                                                                                 Style="{StaticResource UNTraceGroupBox}"
                                                                                 Visibility="{Binding FractionSliderVisible, Converter={StaticResource VisibilityConverter}}">
-                                                                                <Slider Style="{StaticResource UNTraceSlider}" Value="{Binding FractionAlongEdge, Mode=TwoWay}" />
+                                                                                <Slider
+                                                                                    AutomationProperties.Name="{internal:LocalizedString Key=UtilityNetworkTraceToolFractionAlongEdge}"
+                                                                                    Style="{StaticResource UNTraceSlider}"
+                                                                                    Value="{Binding FractionAlongEdge, Mode=TwoWay}" />
                                                                             </GroupBox>
                                                                             <GroupBox
                                                                                 BorderBrush="{StaticResource UNTraceBorder1}"
@@ -859,7 +866,10 @@
                                                                                 Header="{internal:LocalizedString Key=UtilityNetworkTraceToolFractionAlongEdge}"
                                                                                 Style="{StaticResource UNTraceGroupBox}"
                                                                                 Visibility="{Binding FractionSliderVisible, Converter={StaticResource VisibilityConverter}}">
-                                                                                <Slider Style="{StaticResource UNTraceSlider}" Value="{Binding FractionAlongEdge, Mode=TwoWay}" />
+                                                                                <Slider
+                                                                                    AutomationProperties.Name="{internal:LocalizedString Key=UtilityNetworkTraceToolFractionAlongEdge}"
+                                                                                    Style="{StaticResource UNTraceSlider}"
+                                                                                    Value="{Binding FractionAlongEdge, Mode=TwoWay}" />
                                                                             </GroupBox>
                                                                             <GroupBox
                                                                                 BorderBrush="{StaticResource UNTraceBorder1}"
@@ -1024,7 +1034,7 @@
                                                 MaxWidth="120"
                                                 VerticalAlignment="Center"
                                                 Orientation="Vertical">
-                                                <TextBlock
+                                                <TextBlock x:Name="PART_IdentifyInProgressText"
                                                     HorizontalAlignment="Center"
                                                     Text="{internal:LocalizedString Key=UtilityNetworkTraceToolIdentifyingStartingPoints}"
                                                     TextAlignment="Center"

--- a/src/Toolkit/Toolkit.WinUI/Themes/Generic.xaml
+++ b/src/Toolkit/Toolkit.WinUI/Themes/Generic.xaml
@@ -15,7 +15,7 @@
         <ResourceDictionary Source="ms-appx:///Esri.ArcGISRuntime.Toolkit.WinUI/UI/Controls/TimeSlider/TimeSlider.Theme.xaml" />
         <ResourceDictionary Source="ms-appx:///Esri.ArcGISRuntime.Toolkit.WinUI/UI/Controls/PopupViewer/PopupViewer.Theme.xaml" />
         <local:FloorFilterResources />
-        <ResourceDictionary Source="ms-appx:///Esri.ArcGISRuntime.Toolkit.WinUI/UI/Controls/UtilityNetworkTraceTool/UtilityNetworkTraceTool.Theme.xaml" />
+        <local:UtilityNetworkTraceToolResources />
         <ResourceDictionary Source="ms-appx:///Esri.ArcGISRuntime.Toolkit.WinUI/UI/Controls/UtilityNetworkTraceTool/StartingPointListView.Theme.xaml" />
         <ResourceDictionary Source="ms-appx:///Esri.ArcGISRuntime.Toolkit.WinUI/UI/Controls/UtilityNetworkTraceTool/ToolkitColorPalette.Theme.xaml" />
         <local:FeatureFormViewResources />

--- a/src/Toolkit/Toolkit.WinUI/UI/Controls/UtilityNetworkTraceTool/StartingPointListView.Theme.xaml
+++ b/src/Toolkit/Toolkit.WinUI/UI/Controls/UtilityNetworkTraceTool/StartingPointListView.Theme.xaml
@@ -29,7 +29,7 @@
 						<TextBlock Margin="8,0,8,0" Text="{TemplateBinding InspectorViewSelectionLabelText}" />
 						<Button
                             Command="{TemplateBinding SelectNextItemCommand}"
-                            Content="{internal:LocalizedString Key=UtilityNetworkTraceToolSelectNext}"
+							Content="{internal:LocalizedString Key=UtilityNetworkTraceToolNext}"
                             Style="{StaticResource UNTraceIconButton}" />
 					</StackPanel>
 					<Button
@@ -53,7 +53,7 @@
                         Margin="8,4,0,4"
                         VerticalAlignment="Center"
                         Command="{TemplateBinding CloseInspectorCommand}"
-                        Content="{internal:LocalizedString Key=UtilityNetworkTraceToolNext}"
+						Content="{internal:LocalizedString Key=UtilityNetworkTraceToolClose}"
                         Style="{StaticResource UNTraceIconButton}" />
 				</Grid>
 				<ContentControl

--- a/src/Toolkit/Toolkit.WinUI/UI/Controls/UtilityNetworkTraceTool/UtilityNetworkTraceTool.Theme.xaml
+++ b/src/Toolkit/Toolkit.WinUI/UI/Controls/UtilityNetworkTraceTool/UtilityNetworkTraceTool.Theme.xaml
@@ -459,6 +459,7 @@
                             Grid.ColumnSpan="2"
                             Margin="2"
                             VerticalAlignment="Center"
+                            AutomationProperties.Name="{internal:LocalizedString Key=UtilityNetworkTraceToolFractionAlongEdge}"
                             Maximum="1"
                             Minimum="0"
                             StepFrequency="0.05"
@@ -469,6 +470,7 @@
                             Grid.Row="2"
                             Grid.Column="2"
                             VerticalAlignment="Center"
+                            AutomationProperties.Name="{internal:LocalizedString Key=UtilityNetworkTraceToolFractionAlongEdge}"
                             Style="{StaticResource UNTraceFractionTextBoxStyle}"
                             Text="{Binding ElementName=FractionAlongSlider, Path=Value, Mode=TwoWay}"
                             Visibility="{Binding FractionSliderVisible, Converter={StaticResource VisibilityConverter}}" />
@@ -537,6 +539,7 @@
                             Grid.ColumnSpan="2"
                             Margin="2"
                             VerticalAlignment="Center"
+                            AutomationProperties.Name="{internal:LocalizedString Key=UtilityNetworkTraceToolFractionAlongEdge}"
                             Maximum="1"
                             Minimum="0"
                             StepFrequency="0.05"
@@ -546,6 +549,7 @@
                         <TextBox
                             Grid.Row="2"
                             Grid.Column="2"
+                            AutomationProperties.Name="{internal:LocalizedString Key=UtilityNetworkTraceToolFractionAlongEdge}"
                             Style="{StaticResource UNTraceFractionTextBoxStyle}"
                             Text="{x:Bind FractionAlongEdge, Mode=TwoWay}"
                             Visibility="{x:Bind FractionSliderVisible, Mode=OneWay, Converter={StaticResource VisibilityConverter}}" />
@@ -721,7 +725,10 @@
                                                                                 Header="{internal:LocalizedString Key=UtilityNetworkTraceToolFractionAlongEdge}"
                                                                                 Style="{StaticResource UNTraceGroupBox}"
                                                                                 Visibility="{Binding FractionSliderVisible, Converter={StaticResource VisibilityConverter}}">
-                                                                                <Slider Style="{StaticResource UNTraceSlider}" Value="{Binding FractionAlongEdge, Mode=TwoWay}" />
+                                                                                <Slider
+                                                                                    AutomationProperties.Name="{internal:LocalizedString Key=UtilityNetworkTraceToolFractionAlongEdge}"
+                                                                                    Style="{StaticResource UNTraceSlider}"
+                                                                                    Value="{Binding FractionAlongEdge, Mode=TwoWay}" />
                                                                             </internal:GroupBox>
                                                                             <internal:GroupBox
                                                                                 BorderBrush="{StaticResource UNTraceBorder1}"
@@ -858,6 +865,7 @@
                                                                                 Style="{StaticResource UNTraceGroupBox}"
                                                                                 Visibility="{x:Bind FractionSliderVisible, Mode=OneWay, Converter={StaticResource VisibilityConverter}}">
                                                                                 <Slider
+                                                                                    AutomationProperties.Name="{internal:LocalizedString Key=UtilityNetworkTraceToolFractionAlongEdge}"
                                                                                     Style="{StaticResource UNTraceSlider}"
                                                                                     Value="{x:Bind FractionAlongEdge, Mode=TwoWay}" />
                                                                             </internal:GroupBox>
@@ -1007,6 +1015,7 @@
                                                 Orientation="Vertical"
                                                 Spacing="4">
                                                 <TextBlock
+                                                    x:Name="PART_IdentifyInProgressText"
                                                     HorizontalAlignment="Center"
                                                     Style="{StaticResource UNTraceBasicText}"
                                                     Text="{internal:LocalizedString Key=UtilityNetworkTraceToolRuningTrace}"

--- a/src/Toolkit/Toolkit.WinUI/UI/Controls/UtilityNetworkTraceTool/UtilityNetworkTraceTool.Theme.xaml
+++ b/src/Toolkit/Toolkit.WinUI/UI/Controls/UtilityNetworkTraceTool/UtilityNetworkTraceTool.Theme.xaml
@@ -1,9 +1,12 @@
 ﻿<ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    x:Class="Esri.ArcGISRuntime.Toolkit.UtilityNetworkTraceToolResources"
     xmlns:controls="using:Esri.ArcGISRuntime.Toolkit.UI.Controls"
     xmlns:internal="using:Esri.ArcGISRuntime.Toolkit.Internal"
-    xmlns:localPrimitives="using:Esri.ArcGISRuntime.Toolkit.Primitives">
+    xmlns:localPrimitives="using:Esri.ArcGISRuntime.Toolkit.Primitives"
+    xmlns:ui="using:Esri.ArcGISRuntime.Toolkit.UI"
+    xmlns:utilityNetworks="using:Esri.ArcGISRuntime.UtilityNetworks">
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="UNVisualResources.xaml" />
         <!--<ResourceDictionary Source="StartingPointListView.Theme.xaml" />-->
@@ -13,6 +16,18 @@
     <internal:ListSizeVisibilityConverter x:Key="ListSizeVisibilityConverter" />
     <internal:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />
     <internal:EmptyStringToVisibilityConverter x:Key="PlaceholderVisibilityConverter" />
+
+    <Style
+        x:Key="UNTraceFractionTextBoxStyle"
+        BasedOn="{StaticResource UNTraceTextBoxStyle}"
+        TargetType="TextBox">
+        <Setter Property="Width" Value="48" />
+        <Setter Property="MinHeight" Value="0" />
+        <Setter Property="MaxLength" Value="4" />
+        <Setter Property="Padding" Value="4" />
+        <Setter Property="TextAlignment" Value="Right" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+    </Style>
 
     <Style x:Key="UNTraceIcon32Info" TargetType="Path">
         <Setter Property="Fill" Value="{StaticResource UNTraceTintNormal}" />
@@ -453,15 +468,108 @@
                         <TextBox
                             Grid.Row="2"
                             Grid.Column="2"
-                            MinHeight="0"
-                            Padding="4"
                             VerticalAlignment="Center"
-                            VerticalContentAlignment="Center"
+                            Style="{StaticResource UNTraceFractionTextBoxStyle}"
                             Text="{Binding ElementName=FractionAlongSlider, Path=Value, Mode=TwoWay}"
                             Visibility="{Binding FractionSliderVisible, Converter={StaticResource VisibilityConverter}}" />
                         <Button Command="{Binding DeleteCommand}" Margin="0,0,4,0" VerticalAlignment="Center" HorizontalAlignment="Right" Grid.Column="2" Style="{StaticResource UNTraceIconButton}">
 							<FontIcon Glyph="&#xE74D;" FontFamily="Segoe MDL2 Assets" Foreground="{ThemeResource UNTraceTintNormal}" />
 						</Button>
+                    </Grid>
+                </DataTemplate>
+            </Setter.Value>
+        </Setter>
+        <Setter Property="BarrierItemTemplate">
+            <Setter.Value>
+                <DataTemplate x:DataType="ui:BarrierModel">
+                    <Grid Margin="0,4,0,4" HorizontalAlignment="Stretch">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <controls:SymbolDisplay
+                            Grid.RowSpan="2"
+                            Width="32"
+                            Height="32"
+                            Margin="0,0,4,0"
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center"
+                            Symbol="{x:Bind Symbol, Mode=OneWay}" />
+                        <TextBlock
+                            Grid.Column="1"
+                            Margin="2"
+                            Text="{x:Bind Barrier.NetworkSource.Name, Mode=OneWay}" />
+                        <TextBlock
+                            Grid.Row="1"
+                            Grid.Column="1"
+                            Margin="2"
+                            FontWeight="SemiBold"
+                            Text="{x:Bind Barrier.AssetGroup.Name, Mode=OneWay}" />
+                        <ComboBox
+                            Grid.Row="2"
+                            Grid.Column="0"
+                            Grid.ColumnSpan="3"
+                            HorizontalAlignment="Stretch"
+                            ItemContainerStyle="{StaticResource UNTraceComboBoxItem}"
+                            ItemsSource="{x:Bind Barrier.AssetType.TerminalConfiguration.Terminals, Mode=OneWay}"
+                            SelectedItem="{x:Bind Barrier.Terminal, Mode=TwoWay}"
+                            Style="{StaticResource UNTraceComboBox}"
+                            Visibility="{x:Bind TerminalPickerVisible, Mode=OneWay, Converter={StaticResource VisibilityConverter}}">
+                            <ComboBox.ItemTemplate>
+                                <DataTemplate x:DataType="utilityNetworks:UtilityTerminal">
+                                    <TextBlock
+                                        Style="{StaticResource UNTraceBasicText}"
+                                        Text="{x:Bind Name, Mode=OneWay}" />
+                                </DataTemplate>
+                            </ComboBox.ItemTemplate>
+                        </ComboBox>
+                        <Slider
+                            x:Name="FractionAlongSlider"
+                            Grid.Row="2"
+                            Grid.Column="0"
+                            Grid.ColumnSpan="2"
+                            Margin="2"
+                            VerticalAlignment="Center"
+                            Maximum="1"
+                            Minimum="0"
+                            StepFrequency="0.05"
+                            Style="{StaticResource UNTraceSlider}"
+                            Visibility="{x:Bind FractionSliderVisible, Mode=OneWay, Converter={StaticResource VisibilityConverter}}"
+                            Value="{x:Bind FractionAlongEdge, Mode=TwoWay}" />
+                        <TextBox
+                            Grid.Row="2"
+                            Grid.Column="2"
+                            Style="{StaticResource UNTraceFractionTextBoxStyle}"
+                            Text="{x:Bind FractionAlongEdge, Mode=TwoWay}"
+                            Visibility="{x:Bind FractionSliderVisible, Mode=OneWay, Converter={StaticResource VisibilityConverter}}" />
+                        <CheckBox
+                            Grid.Row="3"
+                            Grid.ColumnSpan="3"
+                            Margin="2"
+                            Content="{internal:LocalizedString Key=UtilityNetworkTraceToolUseAsFilterBarrier}"
+                            IsChecked="{x:Bind UseAsFilterBarrier, Mode=TwoWay}"
+                            Style="{StaticResource UNTraceCheckBox}" />
+                        <Button
+                            Grid.Column="2"
+                            Margin="0,0,4,0"
+                            HorizontalAlignment="Right"
+                            VerticalAlignment="Center"
+                            AutomationProperties.Name="{internal:LocalizedString Key=UtilityNetworkTraceToolRemoveStartingPoint}"
+                            Command="{x:Bind DeleteCommand, Mode=OneWay}"
+                            Style="{StaticResource UNTraceIconButton}"
+                            ToolTipService.ToolTip="{internal:LocalizedString Key=UtilityNetworkTraceToolRemoveStartingPoint}">
+                            <FontIcon
+                                FontFamily="Segoe MDL2 Assets"
+                                Foreground="{ThemeResource UNTraceTintNormal}"
+                                Glyph="&#xE74D;" />
+                        </Button>
                     </Grid>
                 </DataTemplate>
             </Setter.Value>
@@ -652,6 +760,143 @@
                                                             HorizontalAlignment="Stretch"
                                                             Content="{internal:LocalizedString Key=UtilityNetworkTraceToolCancel}"
                                                             Style="{StaticResource UNTracePrimaryButton}" />
+                                                    </StackPanel>
+                                                </internal:GroupBox>
+                                                <internal:GroupBox
+                                                    x:Name="PART_BarriersSectionContainer"
+                                                    HorizontalAlignment="Stretch"
+                                                    Header="{internal:LocalizedString Key=UtilityNetworkTraceToolBarriers}"
+                                                    Style="{StaticResource UNTraceGroupBox}">
+                                                    <StackPanel Orientation="Vertical">
+                                                        <Grid Visibility="{Binding ElementName=PART_BarriersList, Path=IsInspecting, Mode=OneWay, Converter={StaticResource VisibilityConverter}, ConverterParameter='Reverse'}">
+                                                            <Grid
+                                                                Margin="0,0,0,8"
+                                                                ColumnSpacing="8"
+                                                                Visibility="{Binding ElementName=PART_BarriersList, Path=SelectedItem, Mode=OneWay, Converter={StaticResource NullToVisibilityConverter}, ConverterParameter='notnull'}">
+                                                                <Grid.ColumnDefinitions>
+                                                                    <ColumnDefinition Width="*" />
+                                                                    <ColumnDefinition Width="*" />
+                                                                    <ColumnDefinition Width="*" />
+                                                                </Grid.ColumnDefinitions>
+                                                                <Button
+                                                                    HorizontalAlignment="Stretch"
+                                                                    Command="{Binding ElementName=PART_BarriersList, Path=ZoomToCommand, Mode=OneWay}"
+                                                                    Content="{internal:LocalizedString Key=UtilityNetworkTraceToolZoomStartingPoint}"
+                                                                    Style="{StaticResource UNTraceSecondaryButton}" />
+                                                                <Button
+                                                                    Grid.Column="1"
+                                                                    HorizontalAlignment="Stretch"
+                                                                    Command="{Binding ElementName=PART_BarriersList, Path=OpenInspectorCommand, Mode=OneWay}"
+                                                                    CommandParameter="{Binding ElementName=PART_BarriersList, Path=SelectedItem, Mode=OneWay}"
+                                                                    Content="{internal:LocalizedString Key=UtilityNetworkTraceToolInspectStartingPoint}"
+                                                                    Style="{StaticResource UNTraceSecondaryButton}" />
+                                                                <Button
+                                                                    Grid.Column="2"
+                                                                    HorizontalAlignment="Stretch"
+                                                                    Command="{Binding ElementName=PART_BarriersList, Path=DeleteSelectedCommand, Mode=OneWay}"
+                                                                    Content="{internal:LocalizedString Key=UtilityNetworkTraceToolRemoveStartingPoint}"
+                                                                    Style="{StaticResource UNTraceSecondaryButton}" />
+                                                            </Grid>
+                                                        </Grid>
+                                                        <internal:StartingPointListView x:Name="PART_BarriersList" ItemTemplate="{TemplateBinding BarrierItemTemplate}">
+                                                            <internal:StartingPointListView.InspectorViewTemplate>
+                                                                <DataTemplate x:DataType="ui:BarrierModel">
+                                                                    <Border HorizontalAlignment="Stretch" Background="Transparent">
+                                                                        <StackPanel HorizontalAlignment="Stretch">
+                                                                            <Grid>
+                                                                                <Grid.ColumnDefinitions>
+                                                                                    <ColumnDefinition Width="*" />
+                                                                                    <ColumnDefinition Width="Auto" />
+                                                                                </Grid.ColumnDefinitions>
+                                                                                <Grid.RowDefinitions>
+                                                                                    <RowDefinition Height="Auto" />
+                                                                                    <RowDefinition Height="Auto" />
+                                                                                </Grid.RowDefinitions>
+                                                                                <TextBlock
+                                                                                    Grid.Row="0"
+                                                                                    Grid.Column="0"
+                                                                                    Margin="4"
+                                                                                    FontSize="14"
+                                                                                    Style="{StaticResource UNTraceBoldText}"
+                                                                                    Text="{x:Bind Barrier.NetworkSource.Name, Mode=OneWay}" />
+                                                                                <TextBlock
+                                                                                    Grid.Row="1"
+                                                                                    Grid.Column="0"
+                                                                                    Margin="4"
+                                                                                    Style="{StaticResource UNTraceBoldText}"
+                                                                                    Text="{x:Bind Barrier.AssetGroup.Name, Mode=OneWay}" />
+                                                                                <controls:SymbolDisplay
+                                                                                    Grid.RowSpan="2"
+                                                                                    Grid.Column="1"
+                                                                                    Width="32"
+                                                                                    Height="32"
+                                                                                    Margin="4"
+                                                                                    VerticalAlignment="Center"
+                                                                                    Symbol="{x:Bind Symbol, Mode=OneWay}" />
+                                                                            </Grid>
+                                                                            <CheckBox
+                                                                                Margin="4"
+                                                                                Content="{internal:LocalizedString Key=UtilityNetworkTraceToolUseAsFilterBarrier}"
+                                                                                IsChecked="{x:Bind UseAsFilterBarrier, Mode=TwoWay}"
+                                                                                Style="{StaticResource UNTraceCheckBox}" />
+                                                                            <internal:GroupBox
+                                                                                BorderBrush="{StaticResource UNTraceBorder1}"
+                                                                                BorderThickness="0,1,0,0"
+                                                                                Header="{internal:LocalizedString Key=UtilityNetworkTraceToolTerminal}"
+                                                                                Style="{StaticResource UNTraceGroupBox}"
+                                                                                Visibility="{x:Bind TerminalPickerVisible, Mode=OneWay, Converter={StaticResource VisibilityConverter}}">
+                                                                                <ComboBox
+                                                                                    DisplayMemberPath="Name"
+                                                                                    ItemsSource="{x:Bind Barrier.AssetType.TerminalConfiguration.Terminals, Mode=OneWay}"
+                                                                                    SelectedItem="{x:Bind Barrier.Terminal, Mode=TwoWay}"
+                                                                                    Style="{StaticResource UNTraceComboBox}" />
+                                                                            </internal:GroupBox>
+                                                                            <internal:GroupBox
+                                                                                BorderBrush="{StaticResource UNTraceBorder1}"
+                                                                                BorderThickness="0,1,0,0"
+                                                                                Header="{internal:LocalizedString Key=UtilityNetworkTraceToolFractionAlongEdge}"
+                                                                                Style="{StaticResource UNTraceGroupBox}"
+                                                                                Visibility="{x:Bind FractionSliderVisible, Mode=OneWay, Converter={StaticResource VisibilityConverter}}">
+                                                                                <Slider
+                                                                                    Style="{StaticResource UNTraceSlider}"
+                                                                                    Value="{x:Bind FractionAlongEdge, Mode=TwoWay}" />
+                                                                            </internal:GroupBox>
+                                                                            <internal:GroupBox
+                                                                                BorderBrush="{StaticResource UNTraceBorder1}"
+                                                                                BorderThickness="0,1,0,0"
+                                                                                Header="{internal:LocalizedString Key=UtilityNetworkTraceToolAssetDetails}"
+                                                                                Style="{StaticResource UNTraceGroupBox}">
+                                                                                <controls:PopupViewer Popup="{x:Bind Popup, Mode=OneWay}" />
+                                                                            </internal:GroupBox>
+                                                                        </StackPanel>
+                                                                    </Border>
+                                                                </DataTemplate>
+                                                            </internal:StartingPointListView.InspectorViewTemplate>
+                                                        </internal:StartingPointListView>
+                                                        <TextBlock
+                                                            x:Name="PART_IsAddingBarriersIndicator"
+                                                            Margin="2"
+                                                            Style="{StaticResource UNTraceBoldText}"
+                                                            Text="{internal:LocalizedString Key=UtilityNetworkTraceToolTapToIdentifyBarriers}"
+                                                            TextAlignment="Center" />
+                                                        <Grid Margin="0,4,0,0">
+                                                            <StackPanel x:Name="PART_AddRemoveBarrierButtonsContainer" Spacing="4">
+                                                                <Button
+                                                                    x:Name="PART_ResetBarriersButton"
+                                                                    Content="{internal:LocalizedString Key=UtilityNetworkTraceToolRemoveAllBarriers}"
+                                                                    Style="{StaticResource UNTraceSecondaryButton}" />
+                                                                <Button
+                                                                    x:Name="PART_AddBarriersButton"
+                                                                    HorizontalAlignment="Stretch"
+                                                                    Content="{internal:LocalizedString Key=UtilityNetworkTraceToolAddBarrier}"
+                                                                    Style="{StaticResource UNTracePrimaryButton}" />
+                                                            </StackPanel>
+                                                            <Button
+                                                                x:Name="PART_CancelAddBarriersButton"
+                                                                HorizontalAlignment="Stretch"
+                                                                Content="{internal:LocalizedString Key=UtilityNetworkTraceToolCancel}"
+                                                                Style="{StaticResource UNTracePrimaryButton}" />
+                                                        </Grid>
                                                     </StackPanel>
                                                 </internal:GroupBox>
                                                 <internal:Expander x:Name="PART_AdvancedOptionsContainer" Header="{internal:LocalizedString Key=UtilityNetworkTraceToolAdvancedOptions}">

--- a/src/Toolkit/Toolkit.WinUI/UI/Controls/UtilityNetworkTraceTool/UtilityNetworkTraceTool.Theme.xaml.cs
+++ b/src/Toolkit/Toolkit.WinUI/UI/Controls/UtilityNetworkTraceTool/UtilityNetworkTraceTool.Theme.xaml.cs
@@ -1,0 +1,9 @@
+namespace Esri.ArcGISRuntime.Toolkit;
+
+internal sealed partial class UtilityNetworkTraceToolResources : ResourceDictionary
+{
+    public UtilityNetworkTraceToolResources()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Toolkit/Toolkit/LocalizedStrings/Resources.resx
+++ b/src/Toolkit/Toolkit/LocalizedStrings/Resources.resx
@@ -621,6 +621,10 @@
     <value>Search results</value>
     <comment>UIA AutomationProperties.Name for the list view control displaying search results, used by screen readers to identify the control</comment>
   </data>
+  <data name="UtilityNetworkTraceToolAddBarrier" xml:space="preserve">
+    <value>Add barrier</value>
+    <comment>The text on button for adding barriers.</comment>
+  </data>
   <data name="UtilityNetworkTraceToolAddStartingPoint" xml:space="preserve">
     <value>Add starting point</value>
     <comment>The text on button for adding starting points.</comment>
@@ -632,6 +636,10 @@
   <data name="UtilityNetworkTraceToolAssetDetails" xml:space="preserve">
     <value>Asset details</value>
     <comment>The text for listing the asset information of the starting point.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolBarriers" xml:space="preserve">
+    <value>Barriers</value>
+    <comment>The text for listing barriers.</comment>
   </data>
   <data name="UtilityNetworkTraceToolCancel" xml:space="preserve">
     <value>Cancel</value>
@@ -664,6 +672,10 @@
   <data name="UtilityNetworkTraceToolFunctionResults" xml:space="preserve">
     <value>Function results</value>
     <comment>The text for expanding function result collection.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolIdentifyingBarriers" xml:space="preserve">
+    <value>Identifying barriers...</value>
+    <comment>The status message when tapping on features to add as barriers.</comment>
   </data>
   <data name="UtilityNetworkTraceToolIdentifyingStartingPoints" xml:space="preserve">
     <value>Identifying starting points...</value>
@@ -721,6 +733,10 @@
     <value>Previous</value>
     <comment>The text on button for navigating to the previous starting point's information.</comment>
   </data>
+  <data name="UtilityNetworkTraceToolRemoveAllBarriers" xml:space="preserve">
+    <value>Remove all</value>
+    <comment>The text on button for removing all barriers.</comment>
+  </data>
   <data name="UtilityNetworkTraceToolRemoveAllStartingPoints" xml:space="preserve">
     <value>Remove all</value>
     <comment>The text on button for removing all starting points.</comment>
@@ -761,6 +777,10 @@
     <value>Starting points</value>
     <comment>The text for listing starting points.</comment>
   </data>
+  <data name="UtilityNetworkTraceToolTapToIdentifyBarriers" xml:space="preserve">
+    <value>Tap on the map to identify barriers.</value>
+    <comment>The instruction text for identifying barriers on the map.</comment>
+  </data>
   <data name="UtilityNetworkTraceToolTapToIdentifyStartingPoints" xml:space="preserve">
     <value>Tap on the map to identify starting points.</value>
     <comment>The instruction text for identifying starting points on the map.</comment>
@@ -792,6 +812,10 @@
   <data name="UtilityNetworkTraceToolUtilityNetworks" xml:space="preserve">
     <value>Utility networks</value>
     <comment>The text for listing utility networks.</comment>
+  </data>
+  <data name="UtilityNetworkTraceToolUseAsFilterBarrier" xml:space="preserve">
+    <value>Use as filter barrier</value>
+    <comment>The text for choosing whether to use the barrier as a filter barrier.</comment>
   </data>
   <data name="UtilityNetworkTraceToolVisualizationOptions" xml:space="preserve">
     <value>Visualization options</value>

--- a/src/Toolkit/Toolkit/UI/Controls/UtilityNetworkTraceTool/BarrierModel.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/UtilityNetworkTraceTool/BarrierModel.cs
@@ -1,0 +1,69 @@
+using System;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using Esri.ArcGISRuntime.Data;
+using Esri.ArcGISRuntime.Geometry;
+using Esri.ArcGISRuntime.UI;
+using Esri.ArcGISRuntime.UtilityNetworks;
+
+#if MAUI
+namespace Esri.ArcGISRuntime.Toolkit.Maui
+#else
+namespace Esri.ArcGISRuntime.Toolkit.UI
+#endif
+{
+    /// <summary>
+    /// Models a barrier used for a utility network trace.
+    /// </summary>
+    internal class BarrierModel : UtilityElementModel, IEquatable<BarrierModel>, INotifyPropertyChanged
+    {
+        private readonly UtilityNetworkTraceToolController _controller;
+        private bool _useAsFilterBarrier;
+
+        internal BarrierModel(UtilityNetworkTraceToolController controller, UtilityElement element, Graphic selectionGraphic, Feature feature, Envelope? zoomToExtent, bool? useAsFilterBarrier)
+            : base(element, selectionGraphic, feature, zoomToExtent, model => controller.Barriers.Remove((BarrierModel)model))
+        {
+            _controller = controller;
+            _useAsFilterBarrier = useAsFilterBarrier == true;
+        }
+
+        /// <summary>
+        /// Gets the underlying utility element.
+        /// </summary>
+        public UtilityElement Barrier => Element;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the barrier is evaluated during the second trace pass.
+        /// </summary>
+        public bool UseAsFilterBarrier
+        {
+            get => _useAsFilterBarrier;
+            set
+            {
+                if (_useAsFilterBarrier != value)
+                {
+                    _useAsFilterBarrier = value;
+                    OnPropertyChanged();
+                    _controller.HandleBarrierChanged();
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        public bool Equals(BarrierModel? other)
+        {
+            return other != null
+                && other.FractionAlongEdge == FractionAlongEdge
+                && other.Barrier.Terminal == Barrier.Terminal
+                && other.Barrier.GlobalId == Barrier.GlobalId;
+        }
+
+        /// <inheritdoc />
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}

--- a/src/Toolkit/Toolkit/UI/Controls/UtilityNetworkTraceTool/BarrierModel.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/UtilityNetworkTraceTool/BarrierModel.cs
@@ -1,4 +1,3 @@
-using System;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using Esri.ArcGISRuntime.Data;
@@ -15,7 +14,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
     /// <summary>
     /// Models a barrier used for a utility network trace.
     /// </summary>
-    internal class BarrierModel : UtilityElementModel, IEquatable<BarrierModel>, INotifyPropertyChanged
+    internal class BarrierModel : UtilityElementModel, INotifyPropertyChanged
     {
         private readonly UtilityNetworkTraceToolController _controller;
         private bool _useAsFilterBarrier;
@@ -47,15 +46,6 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
                     _controller.HandleBarrierChanged();
                 }
             }
-        }
-
-        /// <inheritdoc />
-        public bool Equals(BarrierModel? other)
-        {
-            return other != null
-                && other.FractionAlongEdge == FractionAlongEdge
-                && other.Barrier.Terminal == Barrier.Terminal
-                && other.Barrier.GlobalId == Barrier.GlobalId;
         }
 
         /// <inheritdoc />

--- a/src/Toolkit/Toolkit/UI/Controls/UtilityNetworkTraceTool/StartingPointModel.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/UtilityNetworkTraceTool/StartingPointModel.cs
@@ -14,7 +14,6 @@
 //  *   limitations under the License.
 //  ******************************************************************************/
 
-using System;
 using Esri.ArcGISRuntime.Data;
 using Esri.ArcGISRuntime.Geometry;
 using Esri.ArcGISRuntime.UI;
@@ -29,7 +28,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
     /// <summary>
     /// Models a starting point used for a utility network trace.
     /// </summary>
-    internal class StartingPointModel : UtilityElementModel, IEquatable<StartingPointModel>
+    internal class StartingPointModel : UtilityElementModel
     {
         internal StartingPointModel(UtilityNetworkTraceToolController controller, UtilityElement element, Graphic selectionGraphic, Feature feature, Envelope? zoomToExtent)
             : base(element, selectionGraphic, feature, zoomToExtent, model => controller.StartingPoints.Remove((StartingPointModel)model))
@@ -41,23 +40,5 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
         /// </summary>
         public UtilityElement StartingPoint => Element;
 
-        /// <inheritdoc />
-        /// <remarks>
-        /// This is used internally to enable appropriate warnings for duplicate trace operations.
-        /// </remarks>
-        public bool Equals(StartingPointModel? other)
-        {
-            if (other == null)
-            {
-                return false;
-            }
-
-            if (other.FractionAlongEdge == FractionAlongEdge && other.TerminalPickerVisible == TerminalPickerVisible && other.StartingPoint.ObjectId == StartingPoint.ObjectId)
-            {
-                return true;
-            }
-
-            return false;
-        }
     }
 }

--- a/src/Toolkit/Toolkit/UI/Controls/UtilityNetworkTraceTool/StartingPointModel.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/UtilityNetworkTraceTool/StartingPointModel.cs
@@ -15,16 +15,10 @@
 //  ******************************************************************************/
 
 using System;
-using System.Windows.Input;
 using Esri.ArcGISRuntime.Data;
 using Esri.ArcGISRuntime.Geometry;
-using Esri.ArcGISRuntime.Mapping;
-using Esri.ArcGISRuntime.Mapping.Popups;
-using Esri.ArcGISRuntime.Toolkit.Internal;
 using Esri.ArcGISRuntime.UI;
 using Esri.ArcGISRuntime.UtilityNetworks;
-using Popup = Esri.ArcGISRuntime.Mapping.Popups.Popup;
-using Symbol = Esri.ArcGISRuntime.Symbology.Symbol;
 
 #if MAUI
 namespace Esri.ArcGISRuntime.Toolkit.Maui
@@ -35,114 +29,17 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
     /// <summary>
     /// Models a starting point used for a utility network trace.
     /// </summary>
-    internal class StartingPointModel : IEquatable<StartingPointModel>
+    internal class StartingPointModel : UtilityElementModel, IEquatable<StartingPointModel>
     {
-        private UtilityNetworkTraceToolController? _controller;
-
         internal StartingPointModel(UtilityNetworkTraceToolController controller, UtilityElement element, Graphic selectionGraphic, Feature feature, Envelope? zoomToExtent)
+            : base(element, selectionGraphic, feature, zoomToExtent, model => controller.StartingPoints.Remove((StartingPointModel)model))
         {
-            _controller = controller;
-            StartingPoint = element;
-            SelectionGraphic = selectionGraphic;
-            ZoomToExtent = zoomToExtent;
-            DeleteCommand = new DelegateCommand(() =>
-            {
-                _controller.StartingPoints.Remove(this);
-                _controller = null;
-            });
-
-            // Create popup if possible.
-            if (feature is ArcGISFeature arcFeature)
-            {
-                Popup = new Popup(feature, arcFeature.FeatureTable?.PopupDefinition);
-            }
-
-            // Get symbol if possible
-            if (feature.FeatureTable?.Layer is FeatureLayer featureLayer && featureLayer.Renderer?.GetSymbol(feature) is Symbol symbol)
-            {
-                Symbol = symbol;
-            }
         }
-
-        public ICommand DeleteCommand { get; set; }
-
-        /// <summary>
-        /// Gets the graphic representing the starting point, which may have different geometry from the <see cref="UtilityElement"/>.
-        /// </summary>
-        /// <remarks>
-        /// In the case of line elements, the starting point will be a point on the line. Setting <see cref="FractionAlongEdge"/> will change the graphic's geometry.
-        /// </remarks>
-        public Graphic SelectionGraphic { get; }
-
-        /// <summary>
-        /// Gets the extent used for zooming to the starting point.
-        /// </summary>
-        public Envelope? ZoomToExtent { get; }
-
-        /// <summary>
-        /// Gets the symbol used to visually identify the starting point in a list.
-        /// </summary>
-        public Symbol? Symbol { get; }
 
         /// <summary>
         /// Gets the underlying utility element.
         /// </summary>
-        public UtilityElement StartingPoint { get; }
-
-        /// <summary>
-        /// Gets the popup for the starting point.
-        /// </summary>
-        /// <remarks>
-        /// The popup can be used to inspect and differentiate starting points.
-        /// </remarks>
-        public Popup? Popup { get; }
-
-        /// <summary>
-        /// Gets or sets the starting point's location along a line element. Setting this value will update the geometry of <see cref="SelectionGraphic"/>.
-        /// </summary>
-        public double FractionAlongEdge
-        {
-            get => StartingPoint.FractionAlongEdge;
-            set
-            {
-                if (StartingPoint.FractionAlongEdge != value)
-                {
-                    StartingPoint.FractionAlongEdge = value;
-                }
-
-                if (SelectionGraphic != null && SelectionGraphic.Attributes.TryGetValue("Geometry", out var jsonObj) && jsonObj is string jsonString && Geometry.Geometry.FromJson(jsonString) is Polyline originalLine)
-                {
-                    SelectionGraphic.Geometry = GeometryEngine.CreatePointAlong(originalLine, GeometryEngine.Length(originalLine) * FractionAlongEdge);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Gets a value indicating whether users should be allowed to specify a terminal for the starting point.
-        /// </summary>
-        public bool TerminalPickerVisible
-        {
-            get
-            {
-                if (StartingPoint?.AssetType?.TerminalConfiguration is UtilityTerminalConfiguration terminalConfig)
-                {
-                    return terminalConfig.Terminals.Count > 1;
-                }
-
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Gets a value indicating whether users should be allowed to specify a position along a line feature for the starting point.
-        /// </summary>
-        public bool FractionSliderVisible
-        {
-            get
-            {
-                return StartingPoint?.NetworkSource?.SourceType == UtilityNetworkSourceType.Edge;
-            }
-        }
+        public UtilityElement StartingPoint => Element;
 
         /// <inheritdoc />
         /// <remarks>

--- a/src/Toolkit/Toolkit/UI/Controls/UtilityNetworkTraceTool/UtilityElementModel.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/UtilityNetworkTraceTool/UtilityElementModel.cs
@@ -34,7 +34,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
     /// <summary>
     /// Models a utility element used as an input to a utility network trace.
     /// </summary>
-    internal abstract class UtilityElementModel
+    internal abstract class UtilityElementModel : IEquatable<UtilityElementModel>
     {
         private Action<UtilityElementModel>? _deleteAction;
 
@@ -142,5 +142,21 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
                 return Element?.NetworkSource?.SourceType == UtilityNetworkSourceType.Edge;
             }
         }
+
+        /// <inheritdoc />
+        public bool Equals(UtilityElementModel? other)
+        {
+            return other != null
+                && other.GetType() == GetType()
+                && other.FractionAlongEdge == FractionAlongEdge
+                && other.Element.Terminal == Element.Terminal
+                && other.Element.GlobalId == Element.GlobalId;
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object? obj) => Equals(obj as UtilityElementModel);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => HashCode.Combine(GetType(), FractionAlongEdge, Element.Terminal, Element.GlobalId);
     }
 }

--- a/src/Toolkit/Toolkit/UI/Controls/UtilityNetworkTraceTool/UtilityElementModel.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/UtilityNetworkTraceTool/UtilityElementModel.cs
@@ -1,0 +1,146 @@
+// /*******************************************************************************
+//  * Copyright 2012-2018 Esri
+//  *
+//  *  Licensed under the Apache License, Version 2.0 (the "License");
+//  *  you may not use this file except in compliance with the License.
+//  *  You may obtain a copy of the License at
+//  *
+//  *  http://www.apache.org/licenses/LICENSE-2.0
+//  *
+//  *   Unless required by applicable law or agreed to in writing, software
+//  *   distributed under the License is distributed on an "AS IS" BASIS,
+//  *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  *   See the License for the specific language governing permissions and
+//  *   limitations under the License.
+//  ******************************************************************************/
+
+using System;
+using System.Windows.Input;
+using Esri.ArcGISRuntime.Data;
+using Esri.ArcGISRuntime.Geometry;
+using Esri.ArcGISRuntime.Mapping;
+using Esri.ArcGISRuntime.Toolkit.Internal;
+using Esri.ArcGISRuntime.UI;
+using Esri.ArcGISRuntime.UtilityNetworks;
+using Popup = Esri.ArcGISRuntime.Mapping.Popups.Popup;
+using Symbol = Esri.ArcGISRuntime.Symbology.Symbol;
+
+#if MAUI
+namespace Esri.ArcGISRuntime.Toolkit.Maui
+#else
+namespace Esri.ArcGISRuntime.Toolkit.UI
+#endif
+{
+    /// <summary>
+    /// Models a utility element used as an input to a utility network trace.
+    /// </summary>
+    internal abstract class UtilityElementModel
+    {
+        private Action<UtilityElementModel>? _deleteAction;
+
+        internal UtilityElementModel(UtilityElement element, Graphic selectionGraphic, Feature feature, Envelope? zoomToExtent, Action<UtilityElementModel> deleteAction)
+        {
+            Element = element;
+            SelectionGraphic = selectionGraphic;
+            ZoomToExtent = zoomToExtent;
+            _deleteAction = deleteAction;
+            DeleteCommand = new DelegateCommand(() =>
+            {
+                _deleteAction!.Invoke(this);
+                _deleteAction = null;
+            });
+
+            // Create popup if possible.
+            if (feature is ArcGISFeature arcFeature)
+            {
+                Popup = new Popup(feature, arcFeature.FeatureTable?.PopupDefinition);
+            }
+
+            // Get symbol if possible
+            if (feature.FeatureTable?.Layer is FeatureLayer featureLayer && featureLayer.Renderer?.GetSymbol(feature) is Symbol symbol)
+            {
+                Symbol = symbol;
+            }
+        }
+
+        public ICommand DeleteCommand { get; set; }
+
+        /// <summary>
+        /// Gets the graphic representing the utility element, which may have different geometry from the <see cref="UtilityElement"/>.
+        /// </summary>
+        /// <remarks>
+        /// In the case of line elements, the graphic will be a point on the line. Setting <see cref="FractionAlongEdge"/> will change the graphic's geometry.
+        /// </remarks>
+        public Graphic SelectionGraphic { get; }
+
+        /// <summary>
+        /// Gets the extent used for zooming to the utility element.
+        /// </summary>
+        public Envelope? ZoomToExtent { get; }
+
+        /// <summary>
+        /// Gets the symbol used to visually identify the utility element in a list.
+        /// </summary>
+        public Symbol? Symbol { get; }
+
+        /// <summary>
+        /// Gets the underlying utility element.
+        /// </summary>
+        public UtilityElement Element { get; }
+
+        /// <summary>
+        /// Gets the popup for the utility element.
+        /// </summary>
+        /// <remarks>
+        /// The popup can be used to inspect and differentiate utility elements.
+        /// </remarks>
+        public Popup? Popup { get; }
+
+        /// <summary>
+        /// Gets or sets the utility element's location along a line element. Setting this value will update the geometry of <see cref="SelectionGraphic"/>.
+        /// </summary>
+        public double FractionAlongEdge
+        {
+            get => Element.FractionAlongEdge;
+            set
+            {
+                if (Element.FractionAlongEdge != value)
+                {
+                    Element.FractionAlongEdge = value;
+                }
+
+                if (SelectionGraphic != null && SelectionGraphic.Attributes.TryGetValue("Geometry", out var jsonObj) && jsonObj is string jsonString && Geometry.Geometry.FromJson(jsonString) is Polyline originalLine)
+                {
+                    SelectionGraphic.Geometry = GeometryEngine.CreatePointAlong(originalLine, GeometryEngine.Length(originalLine) * FractionAlongEdge);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether users should be allowed to specify a terminal for the utility element.
+        /// </summary>
+        public bool TerminalPickerVisible
+        {
+            get
+            {
+                if (Element?.AssetType?.TerminalConfiguration is UtilityTerminalConfiguration terminalConfig)
+                {
+                    return terminalConfig.Terminals.Count > 1;
+                }
+
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether users should be allowed to specify a position along a line feature for the utility element.
+        /// </summary>
+        public bool FractionSliderVisible
+        {
+            get
+            {
+                return Element?.NetworkSource?.SourceType == UtilityNetworkSourceType.Edge;
+            }
+        }
+    }
+}

--- a/src/Toolkit/Toolkit/UI/Controls/UtilityNetworkTraceTool/UtilityNetworkTraceToolController.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/UtilityNetworkTraceTool/UtilityNetworkTraceToolController.cs
@@ -285,38 +285,106 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
             }
         }
 
+        /// <summary>
+        /// Reloads the named trace configurations available for the selected utility network, filtered by name.
+        /// </summary>
+        /// <param name="availableTraces">The names of the trace configurations to load.</param>
+        /// <returns>A task that represents the asynchronous load operation.</returns>
+        public async Task LoadNamedTracesAsync(IEnumerable<string> availableTraces)
+        {
+            ArgumentNullException.ThrowIfNull(availableTraces);
+
+            var requestedNames = availableTraces.ToArray();
+            if (requestedNames.Length == 0 || requestedNames.Any(string.IsNullOrWhiteSpace))
+            {
+                throw new ArgumentException("At least one valid trace configuration name is required.", nameof(availableTraces));
+            }
+
+            requestedNames = requestedNames.Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+
+            if (Map is not Map map || SelectedUtilityNetwork is not UtilityNetwork utilityNetwork)
+            {
+                throw new InvalidOperationException("A map and utility network must be selected before loading named traces.");
+            }
+
+            await LoadTraceTypesAsync(map, utilityNetwork, requestedNames);
+        }
+
         private async Task LoadTraceTypesAsync()
         {
             try
             {
-                IsLoadingNetwork = true;
-
-                if (Map != null
-                    && SelectedUtilityNetwork is UtilityNetwork utilityNetwork)
+                if (Map is Map map && SelectedUtilityNetwork is UtilityNetwork utilityNetwork)
                 {
-                    if (_getTraceTypesCts != null)
-                    {
-                        _getTraceTypesCts.Cancel();
-                    }
-
-                    _getTraceTypesCts = new CancellationTokenSource();
-                    var traceTypes = await Map.GetNamedTraceConfigurationsFromUtilityNetworkAsync(utilityNetwork, _getTraceTypesCts.Token);
-                    foreach (var traceType in traceTypes.OrderBy(tt => tt.Name))
-                    {
-                        TraceTypes.Add(traceType);
-                    }
+                    await LoadTraceTypesAsync(map, utilityNetwork, requestedNames: null);
                 }
-            }
-            catch (TaskCanceledException)
-            {
-                // Do nothing when canceled
+                else
+                {
+                    IsLoadingNetwork = false;
+                }
             }
             catch (Exception)
             {
             }
+        }
+
+        private async Task LoadTraceTypesAsync(Map map, UtilityNetwork utilityNetwork, IReadOnlyCollection<string>? requestedNames)
+        {
+            var requestCts = new CancellationTokenSource();
+            var previousRequestCts = _getTraceTypesCts;
+            _getTraceTypesCts = requestCts;
+            previousRequestCts?.Cancel();
+
+            SelectedTraceType = null;
+            TraceTypes.Clear();
+            EnableTrace = false;
+            InsufficientStartingPointsWarning = false;
+            TooManyStartingPointsWarning = false;
+            DuplicatedTraceWarning = false;
+            IsLoadingNetwork = true;
+
+            try
+            {
+                IEnumerable<UtilityNamedTraceConfiguration> traceTypes;
+                if (requestedNames == null || map.Item != null)
+                {
+                    traceTypes = await map.GetNamedTraceConfigurationsFromUtilityNetworkAsync(utilityNetwork, requestCts.Token);
+                    if (requestedNames != null)
+                    {
+                        traceTypes = traceTypes.Where(traceType => requestedNames.Any(name => string.Equals(name, traceType.Name, StringComparison.OrdinalIgnoreCase)));
+                    }
+                }
+                else
+                {
+                    var queryParameters = new UtilityNamedTraceConfigurationQueryParameters();
+                    foreach (var requestedName in requestedNames)
+                    {
+                        queryParameters.Names.Add(requestedName);
+                    }
+
+                    traceTypes = await utilityNetwork.QueryNamedTraceConfigurationsAsync(queryParameters, requestCts.Token);
+                }
+
+                requestCts.Token.ThrowIfCancellationRequested();
+                if (!ReferenceEquals(_getTraceTypesCts, requestCts))
+                {
+                    throw new OperationCanceledException(requestCts.Token);
+                }
+
+                foreach (var traceType in traceTypes.OrderBy(traceType => traceType.Name))
+                {
+                    TraceTypes.Add(traceType);
+                }
+            }
             finally
             {
-                IsLoadingNetwork = false;
+                if (ReferenceEquals(_getTraceTypesCts, requestCts))
+                {
+                    _getTraceTypesCts = null;
+                    IsLoadingNetwork = false;
+                }
+
+                requestCts.Dispose();
             }
         }
 
@@ -931,7 +999,9 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
             BarrierGraphicsOverlay.Graphics.Clear();
             IsAddingBarriers = false;
 
-            _getTraceTypesCts?.Cancel();
+            var getTraceTypesCts = _getTraceTypesCts;
+            _getTraceTypesCts = null;
+            getTraceTypesCts?.Cancel();
             _traceCts?.Cancel();
             _getFeaturesForElementsCts?.Cancel();
 

--- a/src/Toolkit/Toolkit/UI/Controls/UtilityNetworkTraceTool/UtilityNetworkTraceToolController.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/UtilityNetworkTraceTool/UtilityNetworkTraceToolController.cs
@@ -277,28 +277,26 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
         }
 
         /// <summary>
-        /// Reloads the named trace configurations available for the selected utility network, filtered by name.
+        /// Reloads the named trace configurations available for the selected utility network
+        /// and updates the list of trace configurations displayed by the tool.
         /// </summary>
-        /// <param name="availableTraces">The names of the trace configurations to load.</param>
-        /// <returns>A task that represents the asynchronous load operation.</returns>
-        public async Task LoadNamedTracesAsync(IEnumerable<string> availableTraces)
+        /// <param name="visibleTraceNames">
+        /// The names of trace configurations to display. Only configurations with matching
+        /// names are included. Name matching is case-insensitive. If <c>null</c> or empty,
+        /// all available trace configurations are displayed.
+        /// </param>
+        /// <returns>
+        /// A task that represents the asynchronous load operation.
+        /// </returns>
+        public Task LoadAsync(IEnumerable<string>? visibleTraceNames)
         {
-            ArgumentNullException.ThrowIfNull(availableTraces);
-
-            var requestedNames = availableTraces.ToArray();
-            if (requestedNames.Length == 0 || requestedNames.Any(string.IsNullOrWhiteSpace))
-            {
-                throw new ArgumentException("At least one valid trace configuration name is required.", nameof(availableTraces));
-            }
-
-            requestedNames = requestedNames.Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
-
+            var requestedNames = visibleTraceNames?.ToArray() ?? Array.Empty<string>();
             if (Map is not Map map || SelectedUtilityNetwork is not UtilityNetwork utilityNetwork)
             {
                 throw new InvalidOperationException("A map and utility network must be selected before loading named traces.");
             }
 
-            await LoadTraceTypesAsync(map, utilityNetwork, requestedNames);
+            return LoadTraceTypesAsync(map, utilityNetwork, requestedNames);
         }
 
         private async Task LoadTraceTypesAsync()
@@ -337,10 +335,10 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
             try
             {
                 IEnumerable<UtilityNamedTraceConfiguration> traceTypes;
-                if (requestedNames == null || map.Item != null)
+                if (map.Item != null)
                 {
                     traceTypes = await map.GetNamedTraceConfigurationsFromUtilityNetworkAsync(utilityNetwork, requestCts.Token);
-                    if (requestedNames != null)
+                    if (requestedNames?.Any(n => !string.IsNullOrWhiteSpace(n)) == true)
                     {
                         traceTypes = traceTypes.Where(traceType => requestedNames.Any(name => string.Equals(name, traceType.Name, StringComparison.OrdinalIgnoreCase)));
                     }
@@ -348,9 +346,12 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
                 else
                 {
                     var queryParameters = new UtilityNamedTraceConfigurationQueryParameters();
-                    foreach (var requestedName in requestedNames)
+                    if (requestedNames != null)
                     {
-                        queryParameters.Names.Add(requestedName);
+                        foreach (var requestedName in requestedNames)
+                        {
+                            queryParameters.Names.Add(requestedName);
+                        }
                     }
 
                     traceTypes = await utilityNetwork.QueryNamedTraceConfigurationsAsync(queryParameters, requestCts.Token);

--- a/src/Toolkit/Toolkit/UI/Controls/UtilityNetworkTraceTool/UtilityNetworkTraceToolController.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/UtilityNetworkTraceTool/UtilityNetworkTraceToolController.cs
@@ -624,17 +624,18 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
                     OnPropertyChanged();
 
                     // Update selection and show callout.
-                    DismissCallout();
+                    ClearRequestedCallout();
+                    StartingPointGraphicsOverlay.ClearSelection();
 
-                    if (SelectedStartingPoint?.StartingPoint is UtilityElement startingPoint
-                     && StartingPointGraphicsOverlay.Graphics.FirstOrDefault(g => g.Attributes["GlobalId"] is Guid guid
-                     && guid.Equals(startingPoint.GlobalId)) is Graphic graphic)
+                    if (SelectedStartingPoint is StartingPointModel selectedStartingPoint)
                     {
-                        StartingPointGraphicsOverlay.ClearSelection();
+                        SelectedBarrier = null;
+                        BarrierGraphicsOverlay.ClearSelection();
+                        var graphic = selectedStartingPoint.SelectionGraphic;
                         graphic.IsSelected = true;
                         if (graphic.Geometry is MapPoint location)
                         {
-                            _ = SetCallout(SelectedStartingPoint, location);
+                            _ = SetCallout(selectedStartingPoint, location);
                         }
                     }
                 }
@@ -674,6 +675,13 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
         }
 
         public void DismissCallout()
+        {
+            ClearRequestedCallout();
+            SelectedStartingPoint = null;
+            SelectedBarrier = null;
+        }
+
+        private void ClearRequestedCallout()
         {
             _calloutRequestVersion++;
             _requestedCallout = null;
@@ -764,17 +772,18 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
                     _selectedBarrier = value;
                     OnPropertyChanged();
 
-                    DismissCallout();
+                    ClearRequestedCallout();
+                    BarrierGraphicsOverlay.ClearSelection();
 
-                    if (SelectedBarrier?.Barrier is UtilityElement barrier
-                     && BarrierGraphicsOverlay.Graphics.FirstOrDefault(g => g.Attributes["GlobalId"] is Guid guid
-                     && guid.Equals(barrier.GlobalId)) is Graphic graphic)
+                    if (SelectedBarrier is BarrierModel selectedBarrier)
                     {
-                        BarrierGraphicsOverlay.ClearSelection();
+                        SelectedStartingPoint = null;
+                        StartingPointGraphicsOverlay.ClearSelection();
+                        var graphic = selectedBarrier.SelectionGraphic;
                         graphic.IsSelected = true;
                         if (graphic.Geometry is MapPoint location)
                         {
-                            _ = SetCallout(SelectedBarrier, location);
+                            _ = SetCallout(selectedBarrier, location);
                         }
                     }
                 }

--- a/src/Toolkit/Toolkit/UI/Controls/UtilityNetworkTraceTool/UtilityNetworkTraceToolController.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/UtilityNetworkTraceTool/UtilityNetworkTraceToolController.cs
@@ -134,14 +134,6 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
             }
         }
 
-        private void TraceTypes_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
-        {
-            if (TraceTypes.Count == 1)
-            {
-                SelectedTraceType = TraceTypes[0];
-            }
-        }
-
         private void Results_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
             ApplyWarnings();
@@ -236,7 +228,6 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
 
             // Automatically select sole items in lists.
             UtilityNetworks.CollectionChanged += UtilityNetworks_CollectionChanged;
-            TraceTypes.CollectionChanged += TraceTypes_CollectionChanged;
 
             // Automatically update warnings
             Results.CollectionChanged += Results_CollectionChanged;
@@ -374,6 +365,11 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
                 foreach (var traceType in traceTypes.OrderBy(traceType => traceType.Name))
                 {
                     TraceTypes.Add(traceType);
+                }
+
+                if (TraceTypes.Count > 0)
+                {
+                    SelectedTraceType = TraceTypes[0];
                 }
             }
             finally

--- a/src/Toolkit/Toolkit/UI/Controls/UtilityNetworkTraceTool/UtilityNetworkTraceToolController.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/UtilityNetworkTraceTool/UtilityNetworkTraceToolController.cs
@@ -623,7 +623,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
             }
 
             // Skip adding duplicate barriers.
-            if (BarrierGraphicsOverlay.Graphics.Any(g => g.Attributes["GlobalId"] is Guid guid && guid.Equals(element.GlobalId)))
+            if (Barriers.Any(barrier => barrier.Barrier.GlobalId == element.GlobalId))
             {
                 return;
             }

--- a/src/Toolkit/Toolkit/UI/Controls/UtilityNetworkTraceTool/UtilityNetworkTraceToolController.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/UtilityNetworkTraceTool/UtilityNetworkTraceToolController.cs
@@ -1051,7 +1051,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
 
         // Fallback symbols
         private readonly Symbol _defaultStartingLocationSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Cross, System.Drawing.Color.LimeGreen, 20d);
-        private readonly Symbol _defaultBarrierSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Cross, System.Drawing.Color.Red, 20d);
+        private readonly Symbol _defaultBarrierSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.X, System.Drawing.Color.Red, 20d);
         private readonly Symbol _defaultResultPointSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Circle, System.Drawing.Color.Blue, 20d);
         private readonly Symbol _defaultResultLineSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Dot, System.Drawing.Color.Blue, 5d);
         private readonly Symbol _defaultResultFillSymbol = new SimpleFillSymbol(SimpleFillSymbolStyle.ForwardDiagonal, System.Drawing.Color.Blue,

--- a/src/Toolkit/Toolkit/UI/Controls/UtilityNetworkTraceTool/UtilityNetworkTraceToolController.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/UtilityNetworkTraceTool/UtilityNetworkTraceToolController.cs
@@ -56,16 +56,20 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
         private bool _isReadyToConfigure;
         private bool _isRunningTrace;
         private bool _isAddingStartingPoints;
+        private bool _isAddingBarriers;
         private bool _enableTrace;
 
         // Symbology
         private System.Drawing.Color _resultColor = System.Drawing.Color.Blue;
         private Symbol? _startingPointSymbol;
+        private Symbol? _barrierSymbol;
         private Symbol? _resultPointSymbol;
         private Symbol? _resultLineSymbol;
         private Symbol? _resultFillSymbol;
 
         public GraphicsOverlay StartingPointGraphicsOverlay { get; } = new GraphicsOverlay();
+
+        public GraphicsOverlay BarrierGraphicsOverlay { get; } = new GraphicsOverlay();
 
         // Cancellation
         private CancellationTokenSource? _getTraceTypesCts;
@@ -78,6 +82,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
         private UtilityNetwork? _selectedUtilityNetwork;
         private UtilityNamedTraceConfiguration? _selectedTraceType;
         private StartingPointModel? _selectedStartingPoint;
+        private BarrierModel? _selectedBarrier;
 
         // Trace configuration
         private string? _activeTraceName;
@@ -112,6 +117,11 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
         /// Gets the collection of starting points. Consumers should use <see cref="AddStartingPoint(ArcGISFeature, MapPoint?)"/> to add to this collection.
         /// </summary>
         public ObservableCollection<StartingPointModel> StartingPoints { get; } = new ObservableCollection<StartingPointModel>();
+
+        /// <summary>
+        /// Gets the collection of barriers.
+        /// </summary>
+        public ObservableCollection<BarrierModel> Barriers { get; } = new ObservableCollection<BarrierModel>();
 
         private void UtilityNetworks_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
@@ -175,6 +185,43 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
             });
         }
 
+        private void Barriers_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            RunOnUIThread(() =>
+            {
+                if (e.Action == NotifyCollectionChangedAction.Reset)
+                {
+                    BarrierGraphicsOverlay.Graphics.Clear();
+                }
+
+                if (e.OldItems != null)
+                {
+                    foreach (var item in e.OldItems.OfType<BarrierModel>().Where(m => m.SelectionGraphic != null))
+                    {
+                        if (item.SelectionGraphic != null)
+                        {
+                            BarrierGraphicsOverlay.Graphics.Remove(item.SelectionGraphic);
+                        }
+                    }
+                }
+
+                if (e.NewItems != null)
+                {
+                    foreach (var item in e.NewItems.OfType<BarrierModel>())
+                    {
+                        if (item.SelectionGraphic != null && !BarrierGraphicsOverlay.Graphics.Contains(item.SelectionGraphic))
+                        {
+                            BarrierGraphicsOverlay.Graphics.Add(item.SelectionGraphic);
+                        }
+                    }
+
+                    IsAddingBarriers = false;
+                }
+
+                ApplyWarnings();
+            });
+        }
+
         #endregion Observable collections
 
         /// <summary>
@@ -196,6 +243,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
 
             // Automatically update warnings, keep graphics overlay in sync
             StartingPoints.CollectionChanged += StartingPoints_CollectionChanged;
+            Barriers.CollectionChanged += Barriers_CollectionChanged;
         }
 
         #region Utility Network and Trace Type Selection
@@ -497,7 +545,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
 
         /// <summary>
         /// Gets or sets the selected starting point.
-        /// Selecting a starting point selects the <see cref="StartingPointModel.SelectionGraphic"/> and updates <see cref="RequestedCallout"/> and <see cref="RequestedViewpoint"/>.
+        /// Selecting a starting point selects the <see cref="UtilityElementModel.SelectionGraphic"/> and updates <see cref="RequestedCallout"/> and <see cref="RequestedViewpoint"/>.
         /// </summary>
         public StartingPointModel? SelectedStartingPoint
         {
@@ -556,6 +604,127 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
         }
         #endregion Starting Points
 
+        #region Barriers
+        public void AddBarrier(ArcGISFeature feature, MapPoint? location = null, bool? useAsFilterBarrier = false)
+        {
+            Geometry.Geometry? geometry = feature.Geometry;
+            UtilityElement? element = null;
+            try
+            {
+                element = SelectedUtilityNetwork?.CreateElement(feature);
+            }
+            catch (Exception)
+            {
+            }
+
+            if (element == null)
+            {
+                return;
+            }
+
+            // Skip adding duplicate barriers.
+            if (BarrierGraphicsOverlay.Graphics.Any(g => g.Attributes["GlobalId"] is Guid guid && guid.Equals(element.GlobalId)))
+            {
+                return;
+            }
+
+            // Apply fraction along edge based on identify location.
+            if (element.NetworkSource.SourceType == UtilityNetworkSourceType.Edge && feature.Geometry is Polyline polyline)
+            {
+                if (polyline.HasZ && GeometryEngine.RemoveZ(polyline) is Polyline polyline2d)
+                {
+                    polyline = polyline2d;
+                }
+
+                if (location?.SpatialReference is SpatialReference sr && !sr.IsEqual(polyline?.SpatialReference)
+                    && polyline != null && GeometryEngine.Project(polyline, sr) is Polyline projectedPolyline)
+                {
+                    polyline = projectedPolyline;
+                }
+
+                geometry = polyline;
+
+                if (polyline != null && location != null && GeometryEngine.FractionAlong(polyline, location, double.NaN) is double fractionAlongEdge
+                    && !double.IsNaN(fractionAlongEdge))
+                {
+                    element.FractionAlongEdge = fractionAlongEdge;
+                }
+
+                if (location == null && polyline?.Parts?.FirstOrDefault()?.StartPoint is MapPoint startPoint)
+                {
+                    location = startPoint;
+                }
+            }
+
+            // Apply terminal settings.
+            else if (element.NetworkSource.SourceType == UtilityNetworkSourceType.Junction
+                && element.AssetType?.TerminalConfiguration?.Terminals.Count > 1)
+            {
+                element.Terminal = element.AssetType.TerminalConfiguration.Terminals[0];
+            }
+
+            var graphic = new Graphic { Geometry = geometry as MapPoint ?? location, Symbol = BarrierSymbol ?? _defaultBarrierSymbol };
+            graphic.Attributes["GlobalId"] = element.GlobalId;
+            graphic.Attributes["NetworkSource"] = element.NetworkSource.Name;
+            graphic.Attributes["AssetGroup"] = element.AssetGroup.Name;
+            graphic.Attributes["AssetType"] = element.AssetType?.Name;
+            graphic.Attributes["Geometry"] = geometry?.ToJson();
+
+            Barriers.Add(new BarrierModel(this, element, graphic, feature, geometry?.Extent, useAsFilterBarrier));
+        }
+
+        /// <summary>
+        /// Gets or sets the selected barrier.
+        /// Selecting a barrier selects the <see cref="UtilityElementModel.SelectionGraphic"/> and updates <see cref="RequestedCallout"/> and <see cref="RequestedViewpoint"/>.
+        /// </summary>
+        public BarrierModel? SelectedBarrier
+        {
+            get => _selectedBarrier;
+            set
+            {
+                if (_selectedBarrier != value)
+                {
+                    _selectedBarrier = value;
+                    OnPropertyChanged();
+
+                    RequestedCallout = null;
+
+                    if (SelectedBarrier?.Barrier is UtilityElement barrier
+                     && BarrierGraphicsOverlay.Graphics.FirstOrDefault(g => g.Attributes["GlobalId"] is Guid guid
+                     && guid.Equals(barrier.GlobalId)) is Graphic graphic)
+                    {
+                        BarrierGraphicsOverlay.ClearSelection();
+                        graphic.IsSelected = true;
+                        if (graphic.Geometry is MapPoint location)
+                        {
+                            _ = SetCallout(SelectedBarrier, location);
+                        }
+                    }
+                }
+            }
+        }
+
+        private async Task SetCallout(BarrierModel selectedBarrier, MapPoint location)
+        {
+            var calloutDefinition = new CalloutDefinition(selectedBarrier.Barrier.NetworkSource.Name, selectedBarrier.Barrier.AssetGroup.Name);
+            try
+            {
+                calloutDefinition.Icon = selectedBarrier.Symbol is null ? null : await selectedBarrier.Symbol.CreateSwatchAsync();
+            }
+            catch (Exception)
+            {
+                // Ignore
+            }
+
+            RequestedCallout = new Tuple<CalloutDefinition, MapPoint>(calloutDefinition, location);
+        }
+
+        internal void HandleBarrierChanged()
+        {
+            ApplyWarnings();
+        }
+        #endregion Barriers
+
         #region Tracing
 
         /// <summary>
@@ -569,8 +738,19 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
             }
 
             var traceParameters = new UtilityTraceParameters(SelectedTraceType, StartingPoints.Select(sp => sp.StartingPoint));
+            foreach (var barrier in Barriers)
+            {
+                if (barrier.UseAsFilterBarrier)
+                {
+                    traceParameters.FilterBarriers.Add(barrier.Barrier);
+                }
+                else
+                {
+                    traceParameters.Barriers.Add(barrier.Barrier);
+                }
+            }
 
-            UtilityTraceOperationResult resultInProgress = new UtilityTraceOperationResult(this, SelectedTraceType, traceParameters, StartingPoints.ToList()) { GraphicVisualizationColor = ResultColor };
+            UtilityTraceOperationResult resultInProgress = new UtilityTraceOperationResult(this, SelectedTraceType, traceParameters, StartingPoints.ToList(), Barriers.ToList()) { GraphicVisualizationColor = ResultColor };
 
             try
             {
@@ -747,6 +927,9 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
 
             StartingPoints.Clear();
             StartingPointGraphicsOverlay.Graphics.Clear();
+            Barriers.Clear();
+            BarrierGraphicsOverlay.Graphics.Clear();
+            IsAddingBarriers = false;
 
             _getTraceTypesCts?.Cancel();
             _traceCts?.Cancel();
@@ -801,6 +984,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
 
         // Fallback symbols
         private readonly Symbol _defaultStartingLocationSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Cross, System.Drawing.Color.LimeGreen, 20d);
+        private readonly Symbol _defaultBarrierSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Cross, System.Drawing.Color.Red, 20d);
         private readonly Symbol _defaultResultPointSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Circle, System.Drawing.Color.Blue, 20d);
         private readonly Symbol _defaultResultLineSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Dot, System.Drawing.Color.Blue, 5d);
         private readonly Symbol _defaultResultFillSymbol = new SimpleFillSymbol(SimpleFillSymbolStyle.ForwardDiagonal, System.Drawing.Color.Blue,
@@ -817,6 +1001,22 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
                 if (value != _startingPointSymbol)
                 {
                     _startingPointSymbol = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the barrier symbol.
+        /// </summary>
+        public Symbol? BarrierSymbol
+        {
+            get => _barrierSymbol;
+            set
+            {
+                if (value != _barrierSymbol)
+                {
+                    _barrierSymbol = value;
                     OnPropertyChanged();
                 }
             }
@@ -939,6 +1139,14 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
                 graphic.Symbol = StartingPointSymbol;
             }
         }
+
+        public void HandleBarrierSymbolChanged()
+        {
+            foreach (var graphic in BarrierGraphicsOverlay.Graphics)
+            {
+                graphic.Symbol = BarrierSymbol ?? _defaultBarrierSymbol;
+            }
+        }
         #endregion Symbology
 
         #region Status
@@ -949,7 +1157,30 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
             {
                 if (value != _isAddingStartingPoints)
                 {
+                    if (value)
+                    {
+                        IsAddingBarriers = false;
+                    }
+
                     _isAddingStartingPoints = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public bool IsAddingBarriers
+        {
+            get => _isAddingBarriers;
+            set
+            {
+                if (value != _isAddingBarriers)
+                {
+                    if (value)
+                    {
+                        IsAddingStartingPoints = false;
+                    }
+
+                    _isAddingBarriers = value;
                     OnPropertyChanged();
                 }
             }
@@ -1064,7 +1295,10 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
             bool hasDuplicated = false;
             foreach (var result in Results)
             {
-                if (result.Configuration == SelectedTraceType && (result.StartingPoints?.SequenceEqual(StartingPoints) ?? false))
+                if (result.Configuration == SelectedTraceType
+                    && (result.StartingPoints?.SequenceEqual(StartingPoints) ?? false)
+                    && result.Barriers.SequenceEqual(Barriers.Where(barrier => !barrier.UseAsFilterBarrier))
+                    && result.FilterBarriers.SequenceEqual(Barriers.Where(barrier => barrier.UseAsFilterBarrier)))
                 {
                     hasDuplicated = true;
                     break;

--- a/src/Toolkit/Toolkit/UI/Controls/UtilityNetworkTraceTool/UtilityNetworkTraceToolController.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/UtilityNetworkTraceTool/UtilityNetworkTraceToolController.cs
@@ -93,6 +93,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
         // Interaction
         private Viewpoint? _viewpoint;
         private Tuple<CalloutDefinition, MapPoint>? _requestedCallout;
+        private int _calloutRequestVersion;
 
         private INotifyCollectionChanged? _lastObservedNetworkCollection;
 
@@ -623,7 +624,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
                     OnPropertyChanged();
 
                     // Update selection and show callout.
-                    RequestedCallout = null;
+                    DismissCallout();
 
                     if (SelectedStartingPoint?.StartingPoint is UtilityElement startingPoint
                      && StartingPointGraphicsOverlay.Graphics.FirstOrDefault(g => g.Attributes["GlobalId"] is Guid guid
@@ -642,6 +643,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
 
         private async Task SetCallout(StartingPointModel selectedStartingPoint, MapPoint location)
         {
+            var calloutRequestVersion = ++_calloutRequestVersion;
             var calloutDefinition = new CalloutDefinition(selectedStartingPoint.StartingPoint.NetworkSource.Name, selectedStartingPoint.StartingPoint.AssetGroup.Name);
             try
             {
@@ -652,7 +654,10 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
                 // Ignore
             }
 
-            RequestedCallout = new Tuple<CalloutDefinition, MapPoint>(calloutDefinition, location);
+            if (calloutRequestVersion == _calloutRequestVersion)
+            {
+                RequestedCallout = new Tuple<CalloutDefinition, MapPoint>(calloutDefinition, location);
+            }
         }
 
         public Tuple<CalloutDefinition, MapPoint>? RequestedCallout
@@ -666,6 +671,13 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
                     OnPropertyChanged();
                 }
             }
+        }
+
+        public void DismissCallout()
+        {
+            _calloutRequestVersion++;
+            _requestedCallout = null;
+            OnPropertyChanged(nameof(RequestedCallout));
         }
         #endregion Starting Points
 
@@ -752,7 +764,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
                     _selectedBarrier = value;
                     OnPropertyChanged();
 
-                    RequestedCallout = null;
+                    DismissCallout();
 
                     if (SelectedBarrier?.Barrier is UtilityElement barrier
                      && BarrierGraphicsOverlay.Graphics.FirstOrDefault(g => g.Attributes["GlobalId"] is Guid guid
@@ -771,6 +783,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
 
         private async Task SetCallout(BarrierModel selectedBarrier, MapPoint location)
         {
+            var calloutRequestVersion = ++_calloutRequestVersion;
             var calloutDefinition = new CalloutDefinition(selectedBarrier.Barrier.NetworkSource.Name, selectedBarrier.Barrier.AssetGroup.Name);
             try
             {
@@ -781,7 +794,10 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
                 // Ignore
             }
 
-            RequestedCallout = new Tuple<CalloutDefinition, MapPoint>(calloutDefinition, location);
+            if (calloutRequestVersion == _calloutRequestVersion)
+            {
+                RequestedCallout = new Tuple<CalloutDefinition, MapPoint>(calloutDefinition, location);
+            }
         }
 
         internal void HandleBarrierChanged()

--- a/src/Toolkit/Toolkit/UI/Controls/UtilityNetworkTraceTool/UtilityTraceOperationResult.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/UtilityNetworkTraceTool/UtilityTraceOperationResult.cs
@@ -97,6 +97,16 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
         internal IList<StartingPointModel> StartingPoints { get; }
 
         /// <summary>
+        /// Gets the regular barrier inputs to the trace.
+        /// </summary>
+        internal IList<BarrierModel> Barriers { get; }
+
+        /// <summary>
+        /// Gets the filter barrier inputs to the trace.
+        /// </summary>
+        internal IList<BarrierModel> FilterBarriers { get; }
+
+        /// <summary>
         /// Gets teh parameters used to create this result.
         /// </summary>
         public UtilityTraceParameters Parameters { get; }
@@ -116,12 +126,14 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
         /// <summary>
         /// Initializes a new instance of the <see cref="UtilityTraceOperationResult"/> class.
         /// </summary>
-        internal UtilityTraceOperationResult(UtilityNetworkTraceToolController controller, UtilityNamedTraceConfiguration configuration, UtilityTraceParameters parameters, IList<StartingPointModel> startingPoints)
+        internal UtilityTraceOperationResult(UtilityNetworkTraceToolController controller, UtilityNamedTraceConfiguration configuration, UtilityTraceParameters parameters, IList<StartingPointModel> startingPoints, IList<BarrierModel> barriers)
         {
             _controller = controller;
             Configuration = configuration;
             Parameters = parameters;
             StartingPoints = startingPoints;
+            Barriers = barriers.Where(barrier => !barrier.UseAsFilterBarrier).ToList();
+            FilterBarriers = barriers.Where(barrier => barrier.UseAsFilterBarrier).ToList();
             AreGraphicsShown = true;
             ZoomToCommand = new DelegateCommand(HandleZoomToResultCommand);
             DeleteCommand = new DelegateCommand(HandleDeleteCommand);


### PR DESCRIPTION
Also addresses enabling non-portal map to use the trace tool #732 with `UtilityNetworkTraceTool.loadAsync(Array<String>?): Future<void>`

This might be easier to review per commit

- Extracted `StartingPointModel` shared logic into `UtilityElementModel` (shared base)
- Added `BarrierModel` that inherits from this same `UtilityElementModel` base class. `UseAsFilterBarrier` is unique to `BarrierModel` which is used to determine `Barriers` or `FilterBarriers` collection.
- Controller (shared logic): Add barrier symbol, methods, graphics when collection changes (identical code to starting points)
- Windows: Add to resources, expose properties and methods
- WPF: UI in theme
- WinUI: UI in theme
- Add `LoadAsync` to filter by named traces
- MAUI: UI in code, fixed bugs in element view (missing terminal picker and fraction along slider, symbol not always visible, ability to zoom and remove all)
