### PR TITLE
Avoids a detached subscriber for open map buttons in OfflineMapAreasView

### DIFF
--- a/src/Toolkit/Toolkit/UI/Controls/OfflineMapAreas/OfflineMapAreasView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/OfflineMapAreas/OfflineMapAreasView.cs
@@ -139,7 +139,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             TemplateSettings = new OfflineMapAreasTemplateSettings();
             DefaultStyleKey = typeof(OfflineMapAreasView);
 #endif
-            _openMapCommand = new DelegateCommand((map) => SelectedMap = map as Map, (map) => map != SelectedMap);
+            _openMapCommand = new DelegateCommand((map) => SelectedMap = map as Map);
             _goOnlineCommand = new DelegateCommand((o) => SelectedMap = OnlineMap, () => SelectedMap != OnlineMap && OnlineMap != null);
         }
 
@@ -357,7 +357,6 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
                     onDemand.IsOpen = map is not null && onDemand.Map == map;
                 }
             }
-            _openMapCommand.NotifyCanExecuteChanged();
             _goOnlineCommand.NotifyCanExecuteChanged();
         }
 


### PR DESCRIPTION
When changing web maps and opening different downloaded offline map areas, `OfflineMapAreasView` sometimes throws `InvalidOperationException: Handle is not initialized`. The exception occurs when `SelectedMap` changes and `_openMapCommand.NotifyCanExecuteChanged()` is raised.

Several buttons in the component (for opening each downloaded map area) are subscribed to `CanExecuteChanged`. When a button becomes stale/detached, requerying `CanExecute` triggers `TypedBinding.Apply(...)` on the detached control, causing the handle initialization failure.

### Fix:
•	Removed the `CanExecute` delegate for `_openMapCommand`. Button visibility already controls interaction (`IsVisible` binding based on `IsOpen`), so explicit `CanExecute` calls are redundant.
•	Removed `_openMapCommand.NotifyCanExecuteChanged()` call in `OnSelectedMapPropertyChanged`. This avoids the stale subscriber rebind path that caused the exception.