### PR TITLE
UITests: Enforce vertical orientation for Android ci tests

### DIFF
--- a/src/Tests/UITests/cibuild/cibuild.cs
+++ b/src/Tests/UITests/cibuild/cibuild.cs
@@ -382,9 +382,9 @@ internal class Program
         Environment.SetEnvironmentVariable("ANDROID_HOME", androidSdkDirectory);
 
         // Enforce vertical orientation since some tests can fail on phones in landscape mode
-        var adb = Path.Join(androidSdkDirectory, "platform_tools", "adb");
-        RunBinary(adb, "adb shell settings put system accelerometer_rotation 0");
-        RunBinary(adb, "adb shell settings put system user-rotation 0");
+        var adb = Path.Join(androidSdkDirectory, "platform-tools", "adb");
+        RunBinary(adb, "shell settings put system accelerometer_rotation 0");
+        RunBinary(adb, "shell settings put system user-rotation 0");
 
         return buildSettings;
     }

--- a/src/Tests/UITests/cibuild/cibuild.cs
+++ b/src/Tests/UITests/cibuild/cibuild.cs
@@ -381,6 +381,11 @@ internal class Program
         Environment.SetEnvironmentVariable("JAVA_HOME", jdkDirectory);
         Environment.SetEnvironmentVariable("ANDROID_HOME", androidSdkDirectory);
 
+        // Enforce vertical orientation since some tests can fail on phones in landscape mode
+        var adb = Path.Join(androidSdkDirectory, "platform_tools", "adb");
+        RunBinary(adb, "adb shell settings put system accelerometer_rotation 0");
+        RunBinary(adb, "adb shell settings put system user-rotation 0");
+
         return buildSettings;
     }
 


### PR DESCRIPTION
The sdk android tests always reboot the android device which apparently always sets the orientation setting to automatic. This change enforces vertical orientation for the android toolkit tests.

It never turns automatic orientation back on, but that should only help other tests and will get undone as soon as the device is rebooted during the next sdk test run.