### PR TITLE
Improves WPF SearchView keyboard and screen-reader accessibility

### DIFF
--- a/src/Toolkit/Toolkit.UI.Controls/SearchView/SearchView.cs
+++ b/src/Toolkit/Toolkit.UI.Controls/SearchView/SearchView.cs
@@ -164,6 +164,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         private Button? _searchButton;
         private IInputElement? _focusTargetAfterSuggestions;
         private bool _focusResultsWhenAvailable;
+        private bool _sourceSelectionByKeyboard;
 
         /// <inheritdoc/>
         public override void OnApplyTemplate()
@@ -182,11 +183,15 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             if (_allSourcesButton != null)
             {
                 _allSourcesButton.PreviewKeyDown -= AllSourcesButton_PreviewKeyDown;
+                _allSourcesButton.Click -= AllSourcesButton_Click;
+                _allSourcesButton.PreviewMouseDown -= SourceSelection_PreviewMouseDown;
             }
 
             if (_sourceList != null)
             {
                 _sourceList.PreviewKeyDown -= SourceList_PreviewKeyDown;
+                _sourceList.SelectionChanged -= SourceList_SelectionChanged;
+                _sourceList.PreviewMouseDown -= SourceSelection_PreviewMouseDown;
             }
 
             if (_searchButton != null)
@@ -224,11 +229,15 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             if (_allSourcesButton != null)
             {
                 _allSourcesButton.PreviewKeyDown += AllSourcesButton_PreviewKeyDown;
+                _allSourcesButton.Click += AllSourcesButton_Click;
+                _allSourcesButton.PreviewMouseDown += SourceSelection_PreviewMouseDown;
             }
 
             if (_sourceList != null)
             {
                 _sourceList.PreviewKeyDown += SourceList_PreviewKeyDown;
+                _sourceList.SelectionChanged += SourceList_SelectionChanged;
+                _sourceList.PreviewMouseDown += SourceSelection_PreviewMouseDown;
             }
 
             if (_searchButton != null)
@@ -257,6 +266,11 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
 
         private void AllSourcesButton_PreviewKeyDown(object sender, KeyEventArgs e)
         {
+            if (e.Key == Key.Enter || e.Key == Key.Space)
+            {
+                _sourceSelectionByKeyboard = true;
+            }
+
             // Enter the list by focusing the first item container so keyboard navigation starts on an actual option.
             if (e.Key == Key.Tab && (Keyboard.Modifiers & ModifierKeys.Shift) == 0 && FocusListItem(_sourceList, 0))
             {
@@ -264,22 +278,51 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             }
         }
 
-        private void SourceList_PreviewKeyDown(object sender, KeyEventArgs e)
+        private void AllSourcesButton_Click(object sender, RoutedEventArgs e)
         {
-            if (e.Key != Key.Tab)
+            if (!_sourceSelectionByKeyboard)
             {
                 return;
             }
 
-            // Keep Tab traversal inside the popup region: Shift+Tab returns to All sources; Tab exits to query.
-            var focused = (Keyboard.Modifiers & ModifierKeys.Shift) != 0
-                ? _allSourcesButton?.Focus() == true
-                : CloseSourcePopupAndFocusQuery();
+            _sourceSelectionByKeyboard = false;
+            _ = Dispatcher.BeginInvoke(new Action(() => _queryEntry?.Focus()), System.Windows.Threading.DispatcherPriority.Loaded);
+        }
 
-            if (focused)
+        private void SourceList_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Tab)
             {
-                e.Handled = true;
+                // Keep Tab traversal inside the popup region: Shift+Tab returns to All sources; Tab exits to query.
+                var focused = (Keyboard.Modifiers & ModifierKeys.Shift) != 0
+                    ? _allSourcesButton?.Focus() == true
+                    : CloseSourcePopupAndFocusQuery();
+
+                if (focused)
+                {
+                    e.Handled = true;
+                }
+
+                return;
             }
+
+            _sourceSelectionByKeyboard = true;
+        }
+
+        private void SourceList_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (e.AddedItems.Count == 0 || !_sourceSelectionByKeyboard)
+            {
+                return;
+            }
+
+            _sourceSelectionByKeyboard = false;
+            _ = Dispatcher.BeginInvoke(new Action(() => _queryEntry?.Focus()), System.Windows.Threading.DispatcherPriority.Loaded);
+        }
+
+        private void SourceSelection_PreviewMouseDown(object sender, MouseButtonEventArgs e)
+        {
+            _sourceSelectionByKeyboard = false;
         }
 
         private bool CloseSourcePopupAndFocusQuery()

--- a/src/Toolkit/Toolkit.UI.Controls/SearchView/SearchView.cs
+++ b/src/Toolkit/Toolkit.UI.Controls/SearchView/SearchView.cs
@@ -22,6 +22,10 @@ using Esri.ArcGISRuntime.Mapping;
 using Esri.ArcGISRuntime.Toolkit.Internal;
 using Esri.ArcGISRuntime.UI;
 
+#if WPF
+using System.Windows.Controls.Primitives;
+#endif
+
 #if WINDOWS_XAML
 using Microsoft.UI.Xaml.Automation;
 using Windows.Foundation;
@@ -37,6 +41,15 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
     /// </note></remarks>
 #if WINDOWS_XAML
     [TemplatePart(Name = "PART_SuggestionList", Type = typeof(ListView))]
+#elif WPF
+    [TemplatePart(Name = "PART_SourceSelectToggle", Type = typeof(ToggleButton))]
+    [TemplatePart(Name = "PART_SourcePopup", Type = typeof(Popup))]
+    [TemplatePart(Name = "PART_AllSourcesButton", Type = typeof(ToggleButton))]
+    [TemplatePart(Name = "PART_SourceList", Type = typeof(ListView))]
+    [TemplatePart(Name = "QueryEntry", Type = typeof(TextBox))]
+    [TemplatePart(Name = "PART_SuggestionList", Type = typeof(ListView))]
+    [TemplatePart(Name = "PART_ResultList", Type = typeof(ListView))]
+    [TemplatePart(Name = "PART_SearchButton", Type = typeof(Button))]
 #endif
 #pragma warning disable IDE0079
 #pragma warning disable CA1001
@@ -137,6 +150,229 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             if (_suggestionList != null)
             {
                 _suggestionList.SelectedIndex = -1;
+            }
+        }
+#elif WPF
+        // These template parts are wired for manual keyboard traversal because WPF Popup creates a separate focus scope.
+        private ToggleButton? _sourceSelectToggle;
+        private Popup? _sourcePopup;
+        private ToggleButton? _allSourcesButton;
+        private ListView? _sourceList;
+        private TextBox? _queryEntry;
+        private ListView? _suggestionList;
+        private ListView? _resultList;
+        private Button? _searchButton;
+        private IInputElement? _focusTargetAfterSuggestions;
+        private bool _focusResultsWhenAvailable;
+
+        /// <inheritdoc/>
+        public override void OnApplyTemplate()
+        {
+            // OnApplyTemplate can run multiple times; remove old handlers before attaching to new template instances.
+            if (_sourceSelectToggle != null)
+            {
+                _sourceSelectToggle.Checked -= SourceSelectToggle_Checked;
+            }
+
+            if (_sourcePopup != null)
+            {
+                _sourcePopup.Closed -= SourcePopup_Closed;
+            }
+
+            if (_allSourcesButton != null)
+            {
+                _allSourcesButton.PreviewKeyDown -= AllSourcesButton_PreviewKeyDown;
+            }
+
+            if (_sourceList != null)
+            {
+                _sourceList.PreviewKeyDown -= SourceList_PreviewKeyDown;
+            }
+
+            if (_searchButton != null)
+            {
+                _searchButton.PreviewKeyDown -= SearchButton_PreviewKeyDown;
+                _searchButton.PreviewGotKeyboardFocus -= SearchButton_PreviewGotKeyboardFocus;
+            }
+
+            if (_suggestionList != null)
+            {
+                _suggestionList.PreviewKeyDown -= SuggestionList_PreviewKeyDown;
+            }
+
+            base.OnApplyTemplate();
+
+            _sourceSelectToggle = GetTemplateChild("PART_SourceSelectToggle") as ToggleButton;
+            _sourcePopup = GetTemplateChild("PART_SourcePopup") as Popup;
+            _allSourcesButton = GetTemplateChild("PART_AllSourcesButton") as ToggleButton;
+            _sourceList = GetTemplateChild("PART_SourceList") as ListView;
+            _queryEntry = GetTemplateChild("QueryEntry") as TextBox;
+            _searchButton = GetTemplateChild("PART_SearchButton") as Button;
+            _suggestionList = GetTemplateChild("PART_SuggestionList") as ListView;
+            _resultList = GetTemplateChild("PART_ResultList") as ListView;
+
+            if (_sourceSelectToggle != null)
+            {
+                _sourceSelectToggle.Checked += SourceSelectToggle_Checked;
+            }
+
+            if (_sourcePopup != null)
+            {
+                _sourcePopup.Closed += SourcePopup_Closed;
+            }
+
+            if (_allSourcesButton != null)
+            {
+                _allSourcesButton.PreviewKeyDown += AllSourcesButton_PreviewKeyDown;
+            }
+
+            if (_sourceList != null)
+            {
+                _sourceList.PreviewKeyDown += SourceList_PreviewKeyDown;
+            }
+
+            if (_searchButton != null)
+            {
+                _searchButton.PreviewKeyDown += SearchButton_PreviewKeyDown;
+                _searchButton.PreviewGotKeyboardFocus += SearchButton_PreviewGotKeyboardFocus;
+            }
+
+            if (_suggestionList != null)
+            {
+                _suggestionList.PreviewKeyDown += SuggestionList_PreviewKeyDown;
+            }
+        }
+
+        private void SourceSelectToggle_Checked(object sender, RoutedEventArgs e)
+        {
+            // When the popup opens, move focus explicitly to its first action; Tab does not automatically cross into Popup.
+            _ = Dispatcher.BeginInvoke(new Action(() => _allSourcesButton?.Focus()), System.Windows.Threading.DispatcherPriority.Input);
+        }
+
+        private void SourcePopup_Closed(object? sender, EventArgs e)
+        {
+            // Light-dismiss can close the popup directly, so force the bound IsSourceSelectOpen state back to false.
+            IsSourceSelectOpen = false;
+        }
+
+        private void AllSourcesButton_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            // Enter the list by focusing the first item container so keyboard navigation starts on an actual option.
+            if (e.Key == Key.Tab && (Keyboard.Modifiers & ModifierKeys.Shift) == 0 && FocusListItem(_sourceList, 0))
+            {
+                e.Handled = true;
+            }
+        }
+
+        private void SourceList_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key != Key.Tab)
+            {
+                return;
+            }
+
+            // Keep Tab traversal inside the popup region: Shift+Tab returns to All sources; Tab exits to query.
+            var focused = (Keyboard.Modifiers & ModifierKeys.Shift) != 0
+                ? _allSourcesButton?.Focus() == true
+                : CloseSourcePopupAndFocusQuery();
+
+            if (focused)
+            {
+                e.Handled = true;
+            }
+        }
+
+        private bool CloseSourcePopupAndFocusQuery()
+        {
+            IsSourceSelectOpen = false;
+            return _queryEntry?.Focus() == true;
+        }
+
+        private void SearchButton_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            // Suggestions are rendered in a Popup, so move focus directly to the first suggestion container.
+            if (e.Key == Key.Tab && (Keyboard.Modifiers & ModifierKeys.Shift) == 0 && FocusListItem(_suggestionList, 0))
+            {
+                e.Handled = true;
+            }
+        }
+
+        private void SearchButton_PreviewGotKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
+        {
+            // If Shift+Tab comes from the element after SearchView, re-enter suggestions instead of skipping the popup.
+            if ((Keyboard.Modifiers & ModifierKeys.Shift) != 0 &&
+                ReferenceEquals(e.OldFocus, _focusTargetAfterSuggestions) &&
+                FocusListItem(_suggestionList, 0))
+            {
+                e.Handled = true;
+            }
+        }
+
+        private void SuggestionList_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Enter || e.Key == Key.Space)
+            {
+                // Remember intent to move to results after suggestion acceptance triggers async result generation.
+                _focusResultsWhenAvailable = true;
+                return;
+            }
+
+            if (e.Key != Key.Tab)
+            {
+                return;
+            }
+
+            e.Handled = (Keyboard.Modifiers & ModifierKeys.Shift) != 0
+                ? _searchButton?.Focus() == true
+                : MoveFocusPastSearchView();
+        }
+
+        private static bool FocusListItem(ListView? listView, int index)
+        {
+            if (listView == null || !listView.IsVisible || !listView.IsEnabled || index < 0 || index >= listView.Items.Count)
+            {
+                return false;
+            }
+
+            var item = listView.Items[index];
+            listView.ScrollIntoView(item);
+            // Realize virtualized item containers before focusing, otherwise ContainerFromItem can return null.
+            listView.UpdateLayout();
+            return (listView.ItemContainerGenerator.ContainerFromItem(item) as ListViewItem)?.Focus() == true;
+        }
+
+        private void FocusResultsWhenAvailable()
+        {
+            if (!_focusResultsWhenAvailable || SearchViewModel?.Results?.Count < 1)
+            {
+                return;
+            }
+
+            _focusResultsWhenAvailable = false;
+            // Defer until layout completes so the first result container exists and can receive focus.
+            _ = Dispatcher.BeginInvoke(new Action(() => FocusListItem(_resultList, 0)), System.Windows.Threading.DispatcherPriority.Loaded);
+        }
+
+        private bool MoveFocusPastSearchView()
+        {
+            if (_searchButton == null)
+            {
+                return false;
+            }
+
+            // Temporarily disable internal tab cycling so Tab leaves SearchView, then restore the original navigation mode.
+            var tabNavigation = KeyboardNavigation.GetTabNavigation(this);
+            KeyboardNavigation.SetTabNavigation(this, KeyboardNavigationMode.None);
+            try
+            {
+                var moved = _searchButton.MoveFocus(new TraversalRequest(FocusNavigationDirection.Next));
+                // Store the external destination so reverse traversal can re-enter suggestions from that exact element.
+                _focusTargetAfterSuggestions = moved ? Keyboard.FocusedElement : null;
+                return moved;
+            }
+            finally
+            {
+                KeyboardNavigation.SetTabNavigation(this, tabNavigation);
             }
         }
 #endif
@@ -425,6 +661,9 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
 
             TemplateSettings.OnResultViewVisibilityChanged();
             TemplateSettings.OnResultMessageVisibilityChanged();
+#if WPF
+            FocusResultsWhenAvailable();
+#endif
 
             if (SearchViewModel.Results == null)
             {

--- a/src/Toolkit/Toolkit.UI.Controls/SearchView/SearchView.cs
+++ b/src/Toolkit/Toolkit.UI.Controls/SearchView/SearchView.cs
@@ -353,6 +353,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             _ = Dispatcher.BeginInvoke(new Action(() => FocusListItem(_resultList, 0)), System.Windows.Threading.DispatcherPriority.Loaded);
         }
 
+        private async Task RepeatSearchAndFocusResults()
         {
             if (SearchViewModel == null)
             {

--- a/src/Toolkit/Toolkit.UI.Controls/SearchView/SearchView.cs
+++ b/src/Toolkit/Toolkit.UI.Controls/SearchView/SearchView.cs
@@ -343,12 +343,17 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
 
         private void FocusResultsWhenAvailable()
         {
-            if (!_focusResultsWhenAvailable || SearchViewModel?.Results?.Count < 1)
+            if (!_focusResultsWhenAvailable || SearchViewModel?.Results == null)
             {
                 return;
             }
 
             _focusResultsWhenAvailable = false;
+
+            if (SearchViewModel.Results.Count == 0)
+            {
+                return;
+            }
             // Defer until layout completes so the first result container exists and can receive focus.
             _ = Dispatcher.BeginInvoke(new Action(() => FocusListItem(_resultList, 0)), System.Windows.Threading.DispatcherPriority.Loaded);
         }

--- a/src/Toolkit/Toolkit.UI.Controls/SearchView/SearchView.cs
+++ b/src/Toolkit/Toolkit.UI.Controls/SearchView/SearchView.cs
@@ -353,6 +353,20 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             _ = Dispatcher.BeginInvoke(new Action(() => FocusListItem(_resultList, 0)), System.Windows.Threading.DispatcherPriority.Loaded);
         }
 
+        {
+            if (SearchViewModel == null)
+            {
+                return;
+            }
+
+            await SearchViewModel.RepeatSearchHere();
+            if (SearchViewModel.Results?.Count > 0)
+            {
+                // The search has completed; now wait for bindings and item containers before moving focus.
+                await Dispatcher.InvokeAsync(() => FocusListItem(_resultList, 0), System.Windows.Threading.DispatcherPriority.Loaded);
+            }
+        }
+
         private bool MoveFocusPastSearchView()
         {
             if (_searchButton == null)
@@ -720,7 +734,11 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
 
         private void HandleRepeatSearchHereCommand()
         {
+#if WPF
+            _ = RepeatSearchAndFocusResults();
+#else
             SearchViewModel?.RepeatSearchHere();
+#endif
         }
 #endregion commands
 

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/SearchView/SearchView.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/SearchView/SearchView.Theme.xaml
@@ -604,5 +604,6 @@
         <Setter Property="VerticalAlignment" Value="Top" />
         <Setter Property="Width" Value="256" />
         <Setter Property="Margin" Value="4" />
+        <Setter Property="IsTabStop" Value="False" />
     </Style>
 </ResourceDictionary>

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/SearchView/SearchView.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/SearchView/SearchView.Theme.xaml
@@ -175,8 +175,11 @@
         <Border
             x:Name="Border"
             Margin="0,0,0,0"
-            Background="{StaticResource DefaultControlBackgroundBrush}"
             SnapsToDevicePixels="true">
+            <Border.Background>
+                <!-- Storyboards cannot animate the shared frozen brush resource; each item needs its own brush. -->
+                <SolidColorBrush Color="White" />
+            </Border.Background>
             <ContentPresenter />
             <VisualStateManager.VisualStateGroups>
                 <VisualStateGroup x:Name="CommonStates">
@@ -204,7 +207,6 @@
         </Border>
         <ControlTemplate.Triggers>
             <Trigger Property="IsSelected" Value="True">
-                <Setter TargetName="Border" Property="Background" Value="{StaticResource HoverBrush}" />
                 <Setter TargetName="Border" Property="BorderThickness" Value="2,0,0,0" />
                 <Setter TargetName="Border" Property="BorderBrush" Value="{StaticResource BlueButtonBrush}" />
             </Trigger>
@@ -321,8 +323,8 @@
                         HorizontalAlignment="Left"
                         VerticalAlignment="Bottom"
                         Visibility="Hidden" />
-                    <ToggleButton
-                        x:Name="SourceSelectToggle"
+                    <controls:SourceSelectToggleButton
+                        x:Name="PART_SourceSelectToggle"
                         Grid.Column="0"
                         BorderThickness="0,0,1,0"
                         IsChecked="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=IsSourceSelectOpen, Mode=TwoWay}"
@@ -337,8 +339,9 @@
                             Stretch="Uniform"
                             Stroke="{StaticResource CommonGrayBrush}"
                             StrokeThickness="1" />
-                    </ToggleButton>
+                    </controls:SourceSelectToggleButton>
                     <Popup
+                        x:Name="PART_SourcePopup"
                         Width="{Binding ElementName=Self, Path=ActualWidth, Mode=OneWay}"
                         HorizontalOffset="-1"
                         IsOpen="{TemplateBinding IsSourceSelectOpen}"
@@ -347,16 +350,17 @@
                         StaysOpen="False">
                         <Border Style="{StaticResource ResultAreaBorderStyle}">
                             <StackPanel>
-                                <ToggleButton
-                                    Width="{Binding ElementName=sourceList, Path=ActualWidth, Mode=OneWay}"
+                                <controls:AllSourcesToggleButton
+                                    x:Name="PART_AllSourcesButton"
+                                    Width="{Binding ElementName=PART_SourceList, Path=ActualWidth, Mode=OneWay}"
                                     HorizontalContentAlignment="Left"
                                     BorderThickness="0"
                                     IsChecked="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=SearchViewModel.ActiveSource, Mode=TwoWay, Converter={StaticResource NullToBoolSelectionConverter}}"
                                     Style="{StaticResource ProminentButtonStyle}" AutomationProperties.AutomationId="AllSourcesButton">
                                     <TextBlock Text="{TemplateBinding AllSourceSelectText}" />
-                                </ToggleButton>
+                                </controls:AllSourcesToggleButton>
                                 <ListView
-                                    x:Name="sourceList"
+                                    x:Name="PART_SourceList"
                                     ItemContainerStyle="{StaticResource SearchSourcesStyle}"
                                     ItemTemplate="{StaticResource SourceTemplate}"
                                     ItemsSource="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=SearchViewModel.Sources, Mode=OneWay}"
@@ -413,6 +417,7 @@
                         </Popup.Resources>
                         <Border BorderThickness="1,1,1,0" Style="{StaticResource ResultAreaBorderStyle}">
                             <ListView
+                                x:Name="PART_SuggestionList"
                                 ItemContainerStyle="{StaticResource ListContainerStyle}"
                                 ItemsSource="{Binding Source={StaticResource GroupedSuggestions}}"
                                 SelectedItem="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=SelectedSuggestion, Mode=OneWayToSource}"
@@ -488,6 +493,7 @@
                         </Border>
                     </Popup>
                     <Button
+                        x:Name="PART_SearchButton"
                         Grid.Column="3"
                         BorderThickness="1,0,0,0"
                         Command="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=TemplateSettings.SearchCommand, Mode=OneTime}"
@@ -511,6 +517,7 @@
                         Visibility="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=TemplateSettings.ResultViewVisibility, Mode=OneWay}">
                         <Grid>
                             <ListView
+                                x:Name="PART_ResultList"
                                 MaxHeight="300"
                                 IsEnabled="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=SearchViewModel.Results.Count, Mode=OneWay, Converter={StaticResource CollectionIsSingletonToBoolConverter}, ConverterParameter='Inverse'}"
                                 ItemContainerStyle="{StaticResource ListContainerStyle}"

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/SearchView/SearchView.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/SearchView/SearchView.Theme.xaml
@@ -366,6 +366,7 @@
                                     ItemsSource="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=SearchViewModel.Sources, Mode=OneWay}"
                                     SelectedItem="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=SearchViewModel.ActiveSource, Mode=TwoWay}"
                                     SelectionMode="Single"
+                                    KeyboardNavigation.AcceptsReturn="True"
                                     Style="{StaticResource ListStyle}" 
                                     AutomationProperties.Name="{converter:LocalizedString Key=SearchViewSearchSources}"
                                     AutomationProperties.AutomationId="SearchSourcesList"/>
@@ -420,6 +421,7 @@
                                 x:Name="PART_SuggestionList"
                                 ItemContainerStyle="{StaticResource ListContainerStyle}"
                                 ItemsSource="{Binding Source={StaticResource GroupedSuggestions}}"
+                                KeyboardNavigation.AcceptsReturn="True"
                                 SelectedItem="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=SelectedSuggestion, Mode=OneWayToSource}"
                                 Style="{StaticResource ListStyle}"
                                 AutomationProperties.Name="{converter:LocalizedString Key=SearchViewSearchSuggestions}"
@@ -524,6 +526,7 @@
                                 ItemsSource="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=SearchViewModel.Results, Mode=OneWay}"
                                 SelectedItem="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=SearchViewModel.SelectedResult, Mode=OneWayToSource}"
                                 SelectionMode="Single"
+                                KeyboardNavigation.AcceptsReturn="True"
                                 Style="{StaticResource ListStyle}"
                                 AutomationProperties.Name="{converter:LocalizedString Key=SearchViewSearchResults}"
                                 AutomationProperties.AutomationId="SearchResultsList">

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/SearchView/SourceSelectToggleButton.cs
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/SearchView/SourceSelectToggleButton.cs
@@ -1,0 +1,148 @@
+using System.Globalization;
+using System.Windows.Automation;
+using System.Windows.Automation.Peers;
+using System.Windows.Automation.Provider;
+using System.Windows.Controls.Primitives;
+
+#pragma warning disable CS1591
+
+namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
+{
+    // Keeps ToggleButton styling/binding from XAML while reporting button-style automation behavior.
+    public sealed class AllSourcesToggleButton : ToggleButton
+    {
+        // We cache the prior state because Checked/Unchecked handlers only expose the new state.
+        private bool _lastIsSelected;
+
+        public AllSourcesToggleButton()
+        {
+            Checked += AllSourcesToggleButton_CheckedChanged;
+            Unchecked += AllSourcesToggleButton_CheckedChanged;
+        }
+
+        internal void Invoke() => OnClick();
+
+        private void AllSourcesToggleButton_CheckedChanged(object sender, RoutedEventArgs e)
+        {
+            var isSelected = IsChecked == true;
+            if (isSelected != _lastIsSelected && UIElementAutomationPeer.FromElement(this) is AllSourcesToggleButtonAutomationPeer peer)
+            {
+                peer.RaiseSelectionNameChanged(_lastIsSelected, isSelected);
+            }
+
+            _lastIsSelected = isSelected;
+        }
+
+        protected override AutomationPeer OnCreateAutomationPeer() => new AllSourcesToggleButtonAutomationPeer(this);
+    }
+
+    internal sealed class AllSourcesToggleButtonAutomationPeer : ToggleButtonAutomationPeer, IInvokeProvider
+    {
+        internal AllSourcesToggleButtonAutomationPeer(AllSourcesToggleButton owner)
+            : base(owner)
+        {
+        }
+
+        public void Invoke() => ((AllSourcesToggleButton)Owner).Invoke();
+
+        internal void RaiseSelectionNameChanged(bool oldValue, bool newValue)
+        {
+            RaisePropertyChangedEvent(
+                AutomationElementIdentifiers.NameProperty,
+                GetAccessibleName(oldValue),
+                GetAccessibleName(newValue));
+        }
+
+        protected override string GetNameCore() => GetAccessibleName(((ToggleButton)Owner).IsChecked == true);
+
+        public override object? GetPattern(PatternInterface patternInterface)
+        {
+            // Expose Invoke and hide Toggle so Narrator does not read the control as a toggle switch.
+            return patternInterface switch
+            {
+                PatternInterface.Invoke => this,
+                PatternInterface.Toggle => null,
+                _ => base.GetPattern(patternInterface),
+            };
+        }
+
+        protected override AutomationControlType GetAutomationControlTypeCore() => AutomationControlType.Button;
+
+        private string GetAccessibleName(bool isSelected)
+        {
+            var name = base.GetNameCore();
+            if (!isSelected)
+            {
+                return name;
+            }
+
+            // Appending "selected" to the Name property produces consistent speech across screen readers.
+            var format = Properties.Resources.GetString("SearchViewSelectedAutomationName") ?? "{0}, selected";
+            return string.Format(CultureInfo.CurrentCulture, format, name);
+        }
+    }
+
+    // The source button opens/closes popup content, so automation should expose Expand/Collapse semantics.
+    public sealed class SourceSelectToggleButton : ToggleButton
+    {
+        // We cache the prior state because Checked/Unchecked handlers only expose the new state.
+        private ExpandCollapseState _lastExpandCollapseState = ExpandCollapseState.Collapsed;
+
+        public SourceSelectToggleButton()
+        {
+            Checked += SourceSelectToggleButton_CheckedChanged;
+            Unchecked += SourceSelectToggleButton_CheckedChanged;
+        }
+
+        private void SourceSelectToggleButton_CheckedChanged(object sender, RoutedEventArgs e)
+        {
+            var newState = GetExpandCollapseState(IsChecked);
+            if (newState != _lastExpandCollapseState && UIElementAutomationPeer.FromElement(this) is SourceSelectToggleButtonAutomationPeer peer)
+            {
+                peer.RaiseExpandCollapseStateChanged(_lastExpandCollapseState, newState);
+            }
+
+            _lastExpandCollapseState = newState;
+        }
+
+        protected override AutomationPeer OnCreateAutomationPeer() => new SourceSelectToggleButtonAutomationPeer(this);
+
+        internal static ExpandCollapseState GetExpandCollapseState(bool? isChecked) => isChecked == true
+            ? ExpandCollapseState.Expanded
+            : ExpandCollapseState.Collapsed;
+    }
+
+    internal sealed class SourceSelectToggleButtonAutomationPeer : ToggleButtonAutomationPeer, IExpandCollapseProvider
+    {
+        internal SourceSelectToggleButtonAutomationPeer(SourceSelectToggleButton owner)
+            : base(owner)
+        {
+        }
+
+        public ExpandCollapseState ExpandCollapseState => SourceSelectToggleButton.GetExpandCollapseState(((ToggleButton)Owner).IsChecked);
+
+        public void Collapse() => ((ToggleButton)Owner).IsChecked = false;
+
+        public void Expand() => ((ToggleButton)Owner).IsChecked = true;
+
+        internal void RaiseExpandCollapseStateChanged(ExpandCollapseState oldState, ExpandCollapseState newState)
+        {
+            RaisePropertyChangedEvent(ExpandCollapsePatternIdentifiers.ExpandCollapseStateProperty, oldState, newState);
+        }
+
+        public override object? GetPattern(PatternInterface patternInterface)
+        {
+            // Expose ExpandCollapse and hide Toggle so assistive tech treats this as a popup opener.
+            return patternInterface switch
+            {
+                PatternInterface.ExpandCollapse => this,
+                PatternInterface.Toggle => null,
+                _ => base.GetPattern(patternInterface),
+            };
+        }
+
+        protected override AutomationControlType GetAutomationControlTypeCore() => AutomationControlType.Button;
+    }
+}
+
+#pragma warning restore CS1591

--- a/src/Toolkit/Toolkit/LocalizedStrings/Resources.resx
+++ b/src/Toolkit/Toolkit/LocalizedStrings/Resources.resx
@@ -609,6 +609,10 @@
     <value>Select search source</value>
     <comment>UIA AutomationProperties.Name for the button to display search sources, used by screen readers to identify the control</comment>
   </data>
+  <data name="SearchViewSelectedAutomationName" xml:space="preserve">
+    <value>{0}, selected</value>
+    <comment>UIA accessible name for the selected search source; {0} is the source name</comment>
+  </data>
   <data name="SearchViewSearchSources" xml:space="preserve">
     <value>Search sources</value>
     <comment>UIA AutomationProperties.Name for the list view control displaying search sources, used by screen readers to identify the control</comment>


### PR DESCRIPTION
Creating small feature/ platform wise PRs so that it is easier to review.

- Enables complete Tab/Shift+Tab navigation across source, suggestion, and result popups.
- Moves focus to results after keyboard suggestion selection and completed repeat searches.
- Corrects Narrator announcements for source selector, All sources, and selected state.