### PR TITLE
Announce suggestions/ results availability when displayed

### DIFF
--- a/src/Toolkit/Toolkit.UI.Controls/SearchView/SearchView.cs
+++ b/src/Toolkit/Toolkit.UI.Controls/SearchView/SearchView.cs
@@ -51,7 +51,11 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
     [TemplatePart(Name = "QueryEntry", Type = typeof(TextBox))]
     [TemplatePart(Name = "PART_SuggestionList", Type = typeof(ListView))]
     [TemplatePart(Name = "PART_ResultList", Type = typeof(ListView))]
+#if WPF
+    [TemplatePart(Name = "PART_ResultMessage", Type = typeof(Label))]
+#else
     [TemplatePart(Name = "PART_ResultMessage", Type = typeof(TextBlock))]
+#endif
     [TemplatePart(Name = "PART_SearchButton", Type = typeof(Button))]
     [TemplatePart(Name = "PART_SourceSelectToggle", Type = typeof(ToggleButton))]
 #if WINDOWS_XAML
@@ -84,7 +88,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         private TextBox? _queryEntry;
         private ListView? _suggestionList;
         private ListView? _resultList;
-        private TextBlock? _resultMessage;
+        private FrameworkElement? _resultMessage;
         private Button? _searchButton;
         private bool _focusResultsWhenAvailable;
         private bool _sourceSelectionByKeyboard;
@@ -789,7 +793,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             _ungroupedSuggestionList = GetTemplateChild("PART_SuggestionListUnGrouped") as ListView;
 #endif
             _resultList = GetTemplateChild("PART_ResultList") as ListView;
-            _resultMessage = GetTemplateChild("PART_ResultMessage") as TextBlock;
+            _resultMessage = GetTemplateChild("PART_ResultMessage") as FrameworkElement;
             _searchButton = GetTemplateChild("PART_SearchButton") as Button;
             _sourceSelectToggle = GetTemplateChild("PART_SourceSelectToggle") as ToggleButton;
         }

--- a/src/Toolkit/Toolkit.UI.Controls/SearchView/SearchView.cs
+++ b/src/Toolkit/Toolkit.UI.Controls/SearchView/SearchView.cs
@@ -23,6 +23,7 @@ using Esri.ArcGISRuntime.Toolkit.Internal;
 using Esri.ArcGISRuntime.UI;
 
 #if WPF
+using System.Windows.Automation;
 using System.Windows.Automation.Peers;
 using System.Windows.Controls.Primitives;
 #endif
@@ -484,8 +485,11 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         private void ScheduleResultFocus() =>
             _ = DispatcherQueue.TryEnqueue(() => FocusFirstVisibleItem(_resultList));
 
-        private void ScheduleNoResultsAnnouncement() =>
-            _ = DispatcherQueue.TryEnqueue(RaiseNoResultsAnnouncement);
+        private void ScheduleLiveRegionAnnouncement(FrameworkElement element) =>
+            _ = DispatcherQueue.TryEnqueue(() => RaiseLiveRegionChanged(element));
+
+        private void ScheduleNotificationAnnouncement(ListView listView, string announcement) =>
+            _ = DispatcherQueue.TryEnqueue(() => RaiseNotificationAnnouncement(listView, announcement));
 
         private void SuggestionList_SelectionChanged(object? sender, SelectionChangedEventArgs e)
         {
@@ -744,8 +748,11 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         private void ScheduleResultFocus() =>
             _ = Dispatcher.BeginInvoke(new Action(() => FocusListItem(_resultList, 0)), System.Windows.Threading.DispatcherPriority.Loaded);
 
-        private void ScheduleNoResultsAnnouncement() =>
-            _ = Dispatcher.BeginInvoke(new Action(RaiseNoResultsAnnouncement), System.Windows.Threading.DispatcherPriority.Loaded);
+        private void ScheduleLiveRegionAnnouncement(FrameworkElement element) =>
+            _ = Dispatcher.BeginInvoke(new Action(() => RaiseLiveRegionChanged(element)), System.Windows.Threading.DispatcherPriority.Loaded);
+
+        private void ScheduleNotificationAnnouncement(ListView listView, string announcement) =>
+            _ = Dispatcher.BeginInvoke(new Action(() => RaiseNotificationAnnouncement(listView, announcement)), System.Windows.Threading.DispatcherPriority.Loaded);
 
         private bool MoveFocusPastSearchView()
         {
@@ -778,6 +785,9 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             _sourceList = GetTemplateChild("PART_SourceList") as ListView;
             _queryEntry = GetTemplateChild("QueryEntry") as TextBox;
             _suggestionList = GetTemplateChild("PART_SuggestionList") as ListView;
+#if WINDOWS_XAML
+            _ungroupedSuggestionList = GetTemplateChild("PART_SuggestionListUnGrouped") as ListView;
+#endif
             _resultList = GetTemplateChild("PART_ResultList") as ListView;
             _resultMessage = GetTemplateChild("PART_ResultMessage") as TextBlock;
             _searchButton = GetTemplateChild("PART_SearchButton") as Button;
@@ -827,23 +837,73 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         {
             if (SearchViewModel?.Suggestions?.Count == 0 || SearchViewModel?.Results?.Count == 0)
             {
-                ScheduleNoResultsAnnouncement();
+                if (_resultMessage != null)
+                {
+                    ScheduleLiveRegionAnnouncement(_resultMessage);
+                }
             }
         }
 
-        private void RaiseNoResultsAnnouncement()
+        private void AnnounceAvailableItems(ListView? listView, string resourceKey)
         {
-            if (_resultMessage?.Visibility != Visibility.Visible)
+            var announcement = Properties.Resources.GetString(resourceKey);
+            if (listView != null && !string.IsNullOrEmpty(announcement))
+            {
+                ScheduleNotificationAnnouncement(listView, announcement);
+            }
+        }
+
+        private void RaiseLiveRegionChanged(FrameworkElement element)
+        {
+            element.UpdateLayout();
+
+            if (element is ListView listView && listView.Items.Count == 0)
             {
                 return;
             }
 
 #if WPF
-            var peer = UIElementAutomationPeer.FromElement(_resultMessage) ?? UIElementAutomationPeer.CreatePeerForElement(_resultMessage);
+            if (!element.IsVisible)
+            {
+                return;
+            }
+
+            var peer = UIElementAutomationPeer.FromElement(element) ?? UIElementAutomationPeer.CreatePeerForElement(element);
 #elif WINDOWS_XAML
-            var peer = FrameworkElementAutomationPeer.FromElement(_resultMessage) ?? FrameworkElementAutomationPeer.CreatePeerForElement(_resultMessage);
+            if (element.Visibility != Visibility.Visible)
+            {
+                return;
+            }
+
+            var peer = FrameworkElementAutomationPeer.FromElement(element) ?? FrameworkElementAutomationPeer.CreatePeerForElement(element);
 #endif
             peer?.RaiseAutomationEvent(AutomationEvents.LiveRegionChanged);
+        }
+
+        private void RaiseNotificationAnnouncement(ListView listView, string announcement)
+        {
+            listView.UpdateLayout();
+
+#if WPF
+            if (listView.Items.Count == 0 || !listView.IsVisible)
+            {
+                return;
+            }
+
+            var peer = UIElementAutomationPeer.FromElement(listView) ?? UIElementAutomationPeer.CreatePeerForElement(listView);
+#elif WINDOWS_XAML
+            if (listView.Items.Count == 0 || listView.Visibility != Visibility.Visible)
+            {
+                return;
+            }
+
+            var peer = FrameworkElementAutomationPeer.FromElement(listView) ?? FrameworkElementAutomationPeer.CreatePeerForElement(listView);
+#endif
+            peer?.RaiseNotificationEvent(
+                AutomationNotificationKind.Other,
+                AutomationNotificationProcessing.MostRecent,
+                announcement,
+                "SearchViewAvailableItems");
         }
 
         private async Task ConfigureViewModel()
@@ -1134,6 +1194,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             TemplateSettings.OnResultViewVisibilityChanged();
             TemplateSettings.OnResultMessageVisibilityChanged();
             AnnounceNoResults();
+            AnnounceAvailableItems(_resultList, "SearchViewResultsAvailable");
 #if WPF || WINDOWS_XAML
             FocusResultsWhenAvailable();
 #endif
@@ -1411,7 +1472,9 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             AnnounceNoResults();
 #if WINDOWS_XAML
             UpdateGroupingForUWP();
+            AnnounceAvailableItems(_ungroupedSuggestionList, "SearchViewSuggestionsAvailable");
 #endif
+            AnnounceAvailableItems(_suggestionList, "SearchViewSuggestionsAvailable");
         }
 
 #if WINDOWS_XAML

--- a/src/Toolkit/Toolkit.UI.Controls/SearchView/SearchView.cs
+++ b/src/Toolkit/Toolkit.UI.Controls/SearchView/SearchView.cs
@@ -508,8 +508,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
 
             if (e.AddedItems.FirstOrDefault() is SearchSuggestion suggestion)
             {
-                _focusResultsWhenAvailable = IsSuggestionAcceptKeyPressed();
-                SearchViewModel?.AcceptSuggestion(suggestion);
+                AcceptSuggestion(suggestion);
             }
 
             if (_suggestionList != null)
@@ -944,6 +943,16 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
 
         #region Binding support
 
+        private void AcceptSuggestion(SearchSuggestion suggestion)
+        {
+    #if WINDOWS_XAML
+            _focusResultsWhenAvailable = IsSuggestionAcceptKeyPressed();
+    #endif
+            _acceptingSuggestionFlag = true;
+            _ = SearchViewModel?.AcceptSuggestion(suggestion)
+                       .ContinueWith(tt => _acceptingSuggestionFlag = false, TaskScheduler.FromCurrentSynchronizationContext());
+        }
+
         /// <summary>
         /// Gets or sets the selected suggestion, triggering a search.
         /// </summary>
@@ -955,12 +964,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
                 // ListView calls selecteditem binding with null when collection is cleared.
                 if (value is SearchSuggestion userSelection)
                 {
-#if WINDOWS_XAML
-                    _focusResultsWhenAvailable = IsSuggestionAcceptKeyPressed();
-#endif
-                    _acceptingSuggestionFlag = true;
-                    _ = SearchViewModel?.AcceptSuggestion(userSelection)
-                                       .ContinueWith(tt => _acceptingSuggestionFlag = false, TaskScheduler.FromCurrentSynchronizationContext());
+                    AcceptSuggestion(userSelection);
                 }
             }
         }
@@ -1198,7 +1202,10 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             TemplateSettings.OnResultViewVisibilityChanged();
             TemplateSettings.OnResultMessageVisibilityChanged();
             AnnounceNoResults();
-            AnnounceAvailableItems(_resultList, "SearchViewResultsAvailable");
+            if (SearchViewModel.Results?.Count > 0)
+            {
+                AnnounceAvailableItems(_resultList, "SearchViewResultsAvailable");
+            }
 #if WPF || WINDOWS_XAML
             FocusResultsWhenAvailable();
 #endif
@@ -1476,9 +1483,14 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             AnnounceNoResults();
 #if WINDOWS_XAML
             UpdateGroupingForUWP();
-            AnnounceAvailableItems(_ungroupedSuggestionList, "SearchViewSuggestionsAvailable");
 #endif
-            AnnounceAvailableItems(_suggestionList, "SearchViewSuggestionsAvailable");
+            if (SearchViewModel?.Suggestions?.Count > 0)
+            {
+#if WINDOWS_XAML
+                AnnounceAvailableItems(_ungroupedSuggestionList, "SearchViewSuggestionsAvailable");
+#endif
+                AnnounceAvailableItems(_suggestionList, "SearchViewSuggestionsAvailable");
+            }
         }
 
 #if WINDOWS_XAML

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/SearchView/SearchView.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/SearchView/SearchView.Theme.xaml
@@ -565,13 +565,15 @@
                                 BorderThickness="0,1,0,0"
                                 Style="{StaticResource ResultAreaBorderStyle}"
                                 Visibility="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=TemplateSettings.ResultMessageVisibility, Mode=OneWay}">
-                                <TextBlock
+                                <Label
                                     x:Name="PART_ResultMessage"
                                     Margin="8"
+                                    Padding="0"
                                     HorizontalAlignment="Center"
                                     VerticalAlignment="Center"
                                     AutomationProperties.LiveSetting="Polite"
-                                    Text="{TemplateBinding NoResultMessage}" />
+                                    Content="{TemplateBinding NoResultMessage}"
+                                    Focusable="False" />
                             </Border>
                         </Grid>
                     </Border>

--- a/src/Toolkit/Toolkit/LocalizedStrings/Resources.resx
+++ b/src/Toolkit/Toolkit/LocalizedStrings/Resources.resx
@@ -594,7 +594,7 @@
     <comment>The message to show when a geocode search completes with no results</comment>
   </data>
   <data name="SearchViewResultsAvailable" xml:space="preserve">
-    <value>Search results are available</value>
+    <value>Results available</value>
     <comment>The message announced by screen readers when search results become available</comment>
   </data>
   <data name="SearchViewRepeatSearch" xml:space="preserve">
@@ -626,7 +626,7 @@
     <comment>UIA AutomationProperties.Name for the list view control displaying search suggestions, used by screen readers to identify the control</comment>
   </data>
   <data name="SearchViewSuggestionsAvailable" xml:space="preserve">
-    <value>Search suggestions are available</value>
+    <value>Suggestions available</value>
     <comment>The message announced by screen readers when search suggestions become available</comment>
   </data>
   <data name="SearchViewSearchResults" xml:space="preserve">

--- a/src/Toolkit/Toolkit/LocalizedStrings/Resources.resx
+++ b/src/Toolkit/Toolkit/LocalizedStrings/Resources.resx
@@ -593,6 +593,10 @@
     <value>No Results</value>
     <comment>The message to show when a geocode search completes with no results</comment>
   </data>
+  <data name="SearchViewResultsAvailable" xml:space="preserve">
+    <value>Search results are available</value>
+    <comment>The message announced by screen readers when search results become available</comment>
+  </data>
   <data name="SearchViewRepeatSearch" xml:space="preserve">
     <value>Repeat Search Here</value>
     <comment>The text to display in the 'Repeat Search' button.</comment>
@@ -620,6 +624,10 @@
   <data name="SearchViewSearchSuggestions" xml:space="preserve">
     <value>Search suggestions</value>
     <comment>UIA AutomationProperties.Name for the list view control displaying search suggestions, used by screen readers to identify the control</comment>
+  </data>
+  <data name="SearchViewSuggestionsAvailable" xml:space="preserve">
+    <value>Search suggestions are available</value>
+    <comment>The message announced by screen readers when search suggestions become available</comment>
   </data>
   <data name="SearchViewSearchResults" xml:space="preserve">
     <value>Search results</value>


### PR DESCRIPTION
Follow up based on the PR comment [here ](https://github.com/Esri/arcgis-maps-sdk-dotnet-toolkit/pull/851)
- Added logic so that the automation events are raised and the screen reader announces that suggestions/ results are available
- Did not add it for sources list intentionally because the screen would say, expanded/ collapsed state so it would be repetitive
- Noticed that No results is not being announced in WPF because the Textblock is not able raise the right automation event, so changed it to label.

Note: The behavior may slightly vary based on the screen reader which is used. For the video below I am using NVDA. The default windows narrator announces it a bit differently. 

WPF:
 

https://github.com/user-attachments/assets/657b5c3f-6b4b-4f89-b219-1aed2616db4c

