### PR TITLE
[a11y] [SearchView] Improves the keyboard and narrator accessibility in Maui WinUI

### DIFF
--- a/src/Toolkit/Toolkit.Maui/SearchView/SearchView.Windows.cs
+++ b/src/Toolkit/Toolkit.Maui/SearchView/SearchView.Windows.cs
@@ -1,4 +1,5 @@
 #if WINDOWS
+using System.Linq;
 using Microsoft.UI.Input;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -16,29 +17,26 @@ public partial class SearchView
 {
     private NativeButton? _nativeSourceSelectButton;
     private NativeButton? _nativeSearchButton;
-    private TextBox? _nativeEntry;
     private ListViewBase? _nativeSourcesView;
     private ListViewBase? _nativeSuggestionsView;
-    private ListViewBase? _nativeResultView;
     private UIElement? _focusTargetAfterSuggestions;
     private ListViewItem? _focusSourceSuggestion;
+    private KeyEventHandler? _sourcesViewKeyDownHandler;
     private KeyEventHandler? _suggestionsViewKeyDownHandler;
     private PointerEventHandler? _sourceSelectButtonPointerPressedHandler;
     private bool _sourceSelectOpenedByPointer;
-    private bool _sourceSelectionByKeyboard;
 
     partial void ConnectKeyboardNavigation()
     {
-        SubscribeToHandlerChanges();
+        SetHandlerChangedSubscriptions(true);
         WireNativeControls();
     }
 
     partial void DisconnectKeyboardNavigation()
     {
-        UnsubscribeFromHandlerChanges();
+        SetHandlerChangedSubscriptions(false);
         UnwireNativeControls();
         _sourceSelectOpenedByPointer = false;
-        _sourceSelectionByKeyboard = false;
     }
 
     partial void OnSourceListOpened()
@@ -52,82 +50,45 @@ public partial class SearchView
         _ = _nativeSourceSelectButton?.DispatcherQueue.TryEnqueue(() => FocusFirstItem(_nativeSourcesView));
     }
 
-    partial void OnSourceSelected()
+    partial void OnResultFocusRequested() => Dispatcher.Dispatch(() =>
+        FocusFirstItem(PART_ResultView?.Handler?.PlatformView as ListViewBase));
+
+    partial void UpdateSourceSelectAutomationState()
     {
-        if (!_sourceSelectionByKeyboard)
+        if (_nativeSourceSelectButton != null)
         {
-            return;
-        }
-
-        _sourceSelectionByKeyboard = false;
-        Dispatcher.Dispatch(() => _nativeEntry?.Focus(FocusState.Keyboard));
-    }
-
-    partial void OnResultFocusRequested() => Dispatcher.Dispatch(() => FocusFirstItem(_nativeResultView));
-
-    private void SubscribeToHandlerChanges()
-    {
-        if (PART_SourceSelectButton != null)
-        {
-            PART_SourceSelectButton.HandlerChanged += TemplatePart_HandlerChanged;
-        }
-
-        if (PART_SearchButton != null)
-        {
-            PART_SearchButton.HandlerChanged += TemplatePart_HandlerChanged;
-        }
-
-        if (PART_Entry != null)
-        {
-            PART_Entry.HandlerChanged += TemplatePart_HandlerChanged;
-        }
-
-        if (PART_SourcesView != null)
-        {
-            PART_SourcesView.HandlerChanged += TemplatePart_HandlerChanged;
-        }
-
-        if (PART_SuggestionsView != null)
-        {
-            PART_SuggestionsView.HandlerChanged += TemplatePart_HandlerChanged;
-        }
-
-        if (PART_ResultView != null)
-        {
-            PART_ResultView.HandlerChanged += TemplatePart_HandlerChanged;
+            var name = Properties.Resources.GetString("SearchViewSelectSearchSource");
+            var state = Properties.Resources.GetString(SourcePopupVisibility
+                ? "SearchViewExpandedAutomationState"
+                : "SearchViewCollapsedAutomationState");
+            NativeAutomationProperties.SetName(_nativeSourceSelectButton, $"{name}, {state}");
         }
     }
 
-    private void UnsubscribeFromHandlerChanges()
+    private void SetHandlerChangedSubscriptions(bool subscribe)
     {
-        if (PART_SourceSelectButton != null)
+        foreach (var part in new VisualElement?[]
         {
-            PART_SourceSelectButton.HandlerChanged -= TemplatePart_HandlerChanged;
-        }
+            PART_SourceSelectButton,
+            PART_SearchButton,
+            PART_SourcesView,
+            PART_SuggestionsView,
+            PART_ResultView,
+        })
+        {
+            if (part == null)
+            {
+                continue;
+            }
 
-        if (PART_SearchButton != null)
-        {
-            PART_SearchButton.HandlerChanged -= TemplatePart_HandlerChanged;
-        }
-
-        if (PART_Entry != null)
-        {
-            PART_Entry.HandlerChanged -= TemplatePart_HandlerChanged;
-        }
-
-        if (PART_SourcesView != null)
-        {
-            PART_SourcesView.HandlerChanged -= TemplatePart_HandlerChanged;
-        }
-
-        if (PART_SuggestionsView != null)
-        {
-            PART_SuggestionsView.HandlerChanged -= TemplatePart_HandlerChanged;
-        }
-
-        if (PART_ResultView != null)
-        {
-            PART_ResultView.HandlerChanged -= TemplatePart_HandlerChanged;
+            if (subscribe)
+            {
+                part.HandlerChanged += TemplatePart_HandlerChanged;
+            }
+            else
+            {
+                part.HandlerChanged -= TemplatePart_HandlerChanged;
+            }
         }
     }
 
@@ -139,15 +100,14 @@ public partial class SearchView
 
         _nativeSourceSelectButton = PART_SourceSelectButton?.Handler?.PlatformView as NativeButton;
         _nativeSearchButton = PART_SearchButton?.Handler?.PlatformView as NativeButton;
-        _nativeEntry = PART_Entry?.Handler?.PlatformView as TextBox;
         _nativeSourcesView = PART_SourcesView?.Handler?.PlatformView as ListViewBase;
         _nativeSuggestionsView = PART_SuggestionsView?.Handler?.PlatformView as ListViewBase;
-        _nativeResultView = PART_ResultView?.Handler?.PlatformView as ListViewBase;
 
         if (_nativeSourceSelectButton != null)
         {
             _sourceSelectButtonPointerPressedHandler ??= SourceSelectButton_PointerPressed;
             _nativeSourceSelectButton.AddHandler(UIElement.PointerPressedEvent, _sourceSelectButtonPointerPressedHandler, true);
+            UpdateSourceSelectAutomationState();
         }
 
         if (_nativeSearchButton != null)
@@ -158,21 +118,22 @@ public partial class SearchView
         if (_nativeSourcesView != null)
         {
             NativeAutomationProperties.SetName(_nativeSourcesView, Properties.Resources.GetString("SearchViewSearchSources"));
-            _nativeSourcesView.KeyDown += SourcesView_KeyDown;
-            _nativeSourcesView.PointerPressed += SourcesView_PointerPressed;
+            _sourcesViewKeyDownHandler ??= SourcesView_KeyDown;
+            _nativeSourcesView.AddHandler(UIElement.KeyDownEvent, _sourcesViewKeyDownHandler, true);
         }
 
         if (_nativeSuggestionsView != null)
         {
             NativeAutomationProperties.SetName(_nativeSuggestionsView, Properties.Resources.GetString("SearchViewSearchSuggestions"));
             _nativeSuggestionsView.IsTabStop = false;
+            _nativeSuggestionsView.ChoosingGroupHeaderContainer += SuggestionsView_ChoosingGroupHeaderContainer;
             _suggestionsViewKeyDownHandler ??= SuggestionsView_KeyDown;
             _nativeSuggestionsView.AddHandler(UIElement.KeyDownEvent, _suggestionsViewKeyDownHandler, true);
         }
 
-        if (_nativeResultView != null)
+        if (PART_ResultView?.Handler?.PlatformView is ListViewBase resultView)
         {
-            NativeAutomationProperties.SetName(_nativeResultView, Properties.Resources.GetString("SearchViewSearchResults"));
+            NativeAutomationProperties.SetName(resultView, Properties.Resources.GetString("SearchViewSearchResults"));
         }
     }
 
@@ -195,12 +156,15 @@ public partial class SearchView
 
         if (_nativeSourcesView != null)
         {
-            _nativeSourcesView.KeyDown -= SourcesView_KeyDown;
-            _nativeSourcesView.PointerPressed -= SourcesView_PointerPressed;
+            if (_sourcesViewKeyDownHandler != null)
+            {
+                _nativeSourcesView.RemoveHandler(UIElement.KeyDownEvent, _sourcesViewKeyDownHandler);
+            }
         }
 
         if (_nativeSuggestionsView != null)
         {
+            _nativeSuggestionsView.ChoosingGroupHeaderContainer -= SuggestionsView_ChoosingGroupHeaderContainer;
             if (_suggestionsViewKeyDownHandler != null)
             {
                 _nativeSuggestionsView.RemoveHandler(UIElement.KeyDownEvent, _suggestionsViewKeyDownHandler);
@@ -209,10 +173,8 @@ public partial class SearchView
 
         _nativeSourceSelectButton = null;
         _nativeSearchButton = null;
-        _nativeEntry = null;
         _nativeSourcesView = null;
         _nativeSuggestionsView = null;
-        _nativeResultView = null;
     }
 
     private void SourceSelectButton_PointerPressed(object sender, PointerRoutedEventArgs e) =>
@@ -236,31 +198,48 @@ public partial class SearchView
 
         if (e.Key == VirtualKey.Tab)
         {
-            e.Handled = CloseSourcesAndFocus(IsShiftPressed() ? _nativeSourceSelectButton : _nativeEntry);
+            e.Handled = CloseSourcesAndFocus(IsShiftPressed() ? _nativeSourceSelectButton : GetNativeEntry());
             return;
         }
 
-        _sourceSelectionByKeyboard = true;
         if (e.Key is VirtualKey.Enter or VirtualKey.Space)
         {
-            _ = _nativeSourcesView?.DispatcherQueue.TryEnqueue(() =>
-            {
-                if (_sourceSelectionByKeyboard)
-                {
-                    CloseSourcesAndFocus(_nativeEntry);
-                }
-            });
+            e.Handled = true;
+            _ = _nativeSourcesView?.DispatcherQueue.TryEnqueue(() => CloseSourcesAndFocus(GetNativeEntry()));
         }
     }
 
-    private void SourcesView_PointerPressed(object sender, PointerRoutedEventArgs e) => _sourceSelectionByKeyboard = false;
+    private TextBox? GetNativeEntry() => PART_Entry?.Handler?.PlatformView as TextBox;
 
     private bool CloseSourcesAndFocus(NativeControl? target)
     {
         _sourceSelectToggled = false;
         UpdateVisibility();
-        _sourceSelectionByKeyboard = false;
         return target?.Focus(FocusState.Keyboard) == true;
+    }
+
+    private void SuggestionsView_ChoosingGroupHeaderContainer(ListViewBase sender, ChoosingGroupHeaderContainerEventArgs args)
+    {
+        args.GroupHeaderContainer ??= new ListViewHeaderItem();
+        args.GroupHeaderContainer.IsTabStop = false;
+
+        if (PART_SuggestionsView?.ItemsSource?.Cast<object>().ElementAtOrDefault(args.GroupIndex) is IGrouping<ISearchSource, SearchSuggestion> group &&
+            !string.IsNullOrEmpty(group.Key?.DisplayName))
+        {
+            var header = args.GroupHeaderContainer;
+            NativeAutomationProperties.SetName(header, group.Key.DisplayName);
+            _ = sender.DispatcherQueue.TryEnqueue(() => SetSuggestionGroupAccessibilityView(sender, args.Group));
+        }
+    }
+
+    private static void SetSuggestionGroupAccessibilityView(ListViewBase suggestionsView, object group)
+    {
+        if (suggestionsView.ContainerFromItem(group) is GroupItem groupItem)
+        {
+            NativeAutomationProperties.SetAccessibilityView(
+                groupItem,
+                Microsoft.UI.Xaml.Automation.Peers.AccessibilityView.Raw);
+        }
     }
 
     private void SuggestionsView_KeyDown(object sender, KeyRoutedEventArgs e)
@@ -288,7 +267,7 @@ public partial class SearchView
 
     private bool MoveFocusPastSuggestions(ListViewItem suggestionItem)
     {
-        if (_nativeSuggestionsView == null)
+        if (_nativeSuggestionsView?.XamlRoot?.Content is not FrameworkElement searchRoot || !searchRoot.IsLoaded)
         {
             return false;
         }
@@ -301,7 +280,10 @@ public partial class SearchView
 
         try
         {
-            var moved = FocusManager.TryMoveFocus(FocusNavigationDirection.Next);
+            var moved = _nativeSearchButton?.Focus(FocusState.Programmatic) == true &&
+                FocusManager.TryMoveFocus(
+                    FocusNavigationDirection.Next,
+                    new FindNextElementOptions { SearchRoot = searchRoot });
             ClearFocusTargetAfterSuggestions();
             if (moved && FocusManager.GetFocusedElement(_nativeSuggestionsView.XamlRoot) is UIElement focusTarget)
             {

--- a/src/Toolkit/Toolkit.Maui/SearchView/SearchView.Windows.cs
+++ b/src/Toolkit/Toolkit.Maui/SearchView/SearchView.Windows.cs
@@ -1,0 +1,391 @@
+#if WINDOWS
+using Microsoft.UI.Input;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+using Windows.System;
+using Windows.UI.Core;
+using NativeAutomationProperties = Microsoft.UI.Xaml.Automation.AutomationProperties;
+using NativeButton = Microsoft.UI.Xaml.Controls.Button;
+using NativeControl = Microsoft.UI.Xaml.Controls.Control;
+using NativeVisibility = Microsoft.UI.Xaml.Visibility;
+
+namespace Esri.ArcGISRuntime.Toolkit.Maui;
+
+public partial class SearchView
+{
+    private NativeButton? _nativeSourceSelectButton;
+    private NativeButton? _nativeSearchButton;
+    private TextBox? _nativeEntry;
+    private ListViewBase? _nativeSourcesView;
+    private ListViewBase? _nativeSuggestionsView;
+    private ListViewBase? _nativeResultView;
+    private UIElement? _focusTargetAfterSuggestions;
+    private ListViewItem? _focusSourceSuggestion;
+    private KeyEventHandler? _suggestionsViewKeyDownHandler;
+    private PointerEventHandler? _sourceSelectButtonPointerPressedHandler;
+    private bool _sourceSelectOpenedByPointer;
+    private bool _sourceSelectionByKeyboard;
+
+    partial void ConnectKeyboardNavigation()
+    {
+        SubscribeToHandlerChanges();
+        WireNativeControls();
+    }
+
+    partial void DisconnectKeyboardNavigation()
+    {
+        UnsubscribeFromHandlerChanges();
+        UnwireNativeControls();
+        _sourceSelectOpenedByPointer = false;
+        _sourceSelectionByKeyboard = false;
+    }
+
+    partial void OnSourceListOpened()
+    {
+        if (_sourceSelectOpenedByPointer)
+        {
+            _sourceSelectOpenedByPointer = false;
+            return;
+        }
+
+        _ = _nativeSourceSelectButton?.DispatcherQueue.TryEnqueue(() => FocusFirstItem(_nativeSourcesView));
+    }
+
+    partial void OnSourceSelected()
+    {
+        if (!_sourceSelectionByKeyboard)
+        {
+            return;
+        }
+
+        _sourceSelectionByKeyboard = false;
+        Dispatcher.Dispatch(() => _nativeEntry?.Focus(FocusState.Keyboard));
+    }
+
+    partial void OnResultFocusRequested() => Dispatcher.Dispatch(() => FocusFirstItem(_nativeResultView));
+
+    private void SubscribeToHandlerChanges()
+    {
+        if (PART_SourceSelectButton != null)
+        {
+            PART_SourceSelectButton.HandlerChanged += TemplatePart_HandlerChanged;
+        }
+
+        if (PART_SearchButton != null)
+        {
+            PART_SearchButton.HandlerChanged += TemplatePart_HandlerChanged;
+        }
+
+        if (PART_Entry != null)
+        {
+            PART_Entry.HandlerChanged += TemplatePart_HandlerChanged;
+        }
+
+        if (PART_SourcesView != null)
+        {
+            PART_SourcesView.HandlerChanged += TemplatePart_HandlerChanged;
+        }
+
+        if (PART_SuggestionsView != null)
+        {
+            PART_SuggestionsView.HandlerChanged += TemplatePart_HandlerChanged;
+        }
+
+        if (PART_ResultView != null)
+        {
+            PART_ResultView.HandlerChanged += TemplatePart_HandlerChanged;
+        }
+    }
+
+    private void UnsubscribeFromHandlerChanges()
+    {
+        if (PART_SourceSelectButton != null)
+        {
+            PART_SourceSelectButton.HandlerChanged -= TemplatePart_HandlerChanged;
+        }
+
+        if (PART_SearchButton != null)
+        {
+            PART_SearchButton.HandlerChanged -= TemplatePart_HandlerChanged;
+        }
+
+        if (PART_Entry != null)
+        {
+            PART_Entry.HandlerChanged -= TemplatePart_HandlerChanged;
+        }
+
+        if (PART_SourcesView != null)
+        {
+            PART_SourcesView.HandlerChanged -= TemplatePart_HandlerChanged;
+        }
+
+        if (PART_SuggestionsView != null)
+        {
+            PART_SuggestionsView.HandlerChanged -= TemplatePart_HandlerChanged;
+        }
+
+        if (PART_ResultView != null)
+        {
+            PART_ResultView.HandlerChanged -= TemplatePart_HandlerChanged;
+        }
+    }
+
+    private void TemplatePart_HandlerChanged(object? sender, EventArgs e) => WireNativeControls();
+
+    private void WireNativeControls()
+    {
+        UnwireNativeControls();
+
+        _nativeSourceSelectButton = PART_SourceSelectButton?.Handler?.PlatformView as NativeButton;
+        _nativeSearchButton = PART_SearchButton?.Handler?.PlatformView as NativeButton;
+        _nativeEntry = PART_Entry?.Handler?.PlatformView as TextBox;
+        _nativeSourcesView = PART_SourcesView?.Handler?.PlatformView as ListViewBase;
+        _nativeSuggestionsView = PART_SuggestionsView?.Handler?.PlatformView as ListViewBase;
+        _nativeResultView = PART_ResultView?.Handler?.PlatformView as ListViewBase;
+
+        if (_nativeSourceSelectButton != null)
+        {
+            _sourceSelectButtonPointerPressedHandler ??= SourceSelectButton_PointerPressed;
+            _nativeSourceSelectButton.AddHandler(UIElement.PointerPressedEvent, _sourceSelectButtonPointerPressedHandler, true);
+        }
+
+        if (_nativeSearchButton != null)
+        {
+            _nativeSearchButton.KeyDown += SearchButton_KeyDown;
+        }
+
+        if (_nativeSourcesView != null)
+        {
+            NativeAutomationProperties.SetName(_nativeSourcesView, Properties.Resources.GetString("SearchViewSearchSources"));
+            _nativeSourcesView.KeyDown += SourcesView_KeyDown;
+            _nativeSourcesView.PointerPressed += SourcesView_PointerPressed;
+        }
+
+        if (_nativeSuggestionsView != null)
+        {
+            NativeAutomationProperties.SetName(_nativeSuggestionsView, Properties.Resources.GetString("SearchViewSearchSuggestions"));
+            _nativeSuggestionsView.IsTabStop = false;
+            _suggestionsViewKeyDownHandler ??= SuggestionsView_KeyDown;
+            _nativeSuggestionsView.AddHandler(UIElement.KeyDownEvent, _suggestionsViewKeyDownHandler, true);
+        }
+
+        if (_nativeResultView != null)
+        {
+            NativeAutomationProperties.SetName(_nativeResultView, Properties.Resources.GetString("SearchViewSearchResults"));
+        }
+    }
+
+    private void UnwireNativeControls()
+    {
+        ClearFocusTargetAfterSuggestions();
+
+        if (_nativeSourceSelectButton != null)
+        {
+            if (_sourceSelectButtonPointerPressedHandler != null)
+            {
+                _nativeSourceSelectButton.RemoveHandler(UIElement.PointerPressedEvent, _sourceSelectButtonPointerPressedHandler);
+            }
+        }
+
+        if (_nativeSearchButton != null)
+        {
+            _nativeSearchButton.KeyDown -= SearchButton_KeyDown;
+        }
+
+        if (_nativeSourcesView != null)
+        {
+            _nativeSourcesView.KeyDown -= SourcesView_KeyDown;
+            _nativeSourcesView.PointerPressed -= SourcesView_PointerPressed;
+        }
+
+        if (_nativeSuggestionsView != null)
+        {
+            if (_suggestionsViewKeyDownHandler != null)
+            {
+                _nativeSuggestionsView.RemoveHandler(UIElement.KeyDownEvent, _suggestionsViewKeyDownHandler);
+            }
+        }
+
+        _nativeSourceSelectButton = null;
+        _nativeSearchButton = null;
+        _nativeEntry = null;
+        _nativeSourcesView = null;
+        _nativeSuggestionsView = null;
+        _nativeResultView = null;
+    }
+
+    private void SourceSelectButton_PointerPressed(object sender, PointerRoutedEventArgs e) =>
+        _sourceSelectOpenedByPointer = !_sourceSelectToggled;
+
+    private void SearchButton_KeyDown(object sender, KeyRoutedEventArgs e)
+    {
+        if (e.Key == VirtualKey.Tab && !IsShiftPressed() && FocusFirstItem(_nativeSuggestionsView))
+        {
+            e.Handled = true;
+        }
+    }
+
+    private void SourcesView_KeyDown(object sender, KeyRoutedEventArgs e)
+    {
+        if (e.Key == VirtualKey.Escape)
+        {
+            e.Handled = CloseSourcesAndFocus(_nativeSourceSelectButton);
+            return;
+        }
+
+        if (e.Key == VirtualKey.Tab)
+        {
+            e.Handled = CloseSourcesAndFocus(IsShiftPressed() ? _nativeSourceSelectButton : _nativeEntry);
+            return;
+        }
+
+        _sourceSelectionByKeyboard = true;
+        if (e.Key is VirtualKey.Enter or VirtualKey.Space)
+        {
+            _ = _nativeSourcesView?.DispatcherQueue.TryEnqueue(() =>
+            {
+                if (_sourceSelectionByKeyboard)
+                {
+                    CloseSourcesAndFocus(_nativeEntry);
+                }
+            });
+        }
+    }
+
+    private void SourcesView_PointerPressed(object sender, PointerRoutedEventArgs e) => _sourceSelectionByKeyboard = false;
+
+    private bool CloseSourcesAndFocus(NativeControl? target)
+    {
+        _sourceSelectToggled = false;
+        UpdateVisibility();
+        _sourceSelectionByKeyboard = false;
+        return target?.Focus(FocusState.Keyboard) == true;
+    }
+
+    private void SuggestionsView_KeyDown(object sender, KeyRoutedEventArgs e)
+    {
+        if (e.Key is VirtualKey.Enter or VirtualKey.Space)
+        {
+            _focusResultsWhenAvailable = true;
+            return;
+        }
+
+        if (e.Key != VirtualKey.Tab)
+        {
+            return;
+        }
+
+        if (IsShiftPressed())
+        {
+            e.Handled = _nativeSearchButton?.Focus(FocusState.Keyboard) == true;
+        }
+        else if (FindAncestor<ListViewItem>(e.OriginalSource as DependencyObject) is ListViewItem suggestionItem)
+        {
+            e.Handled = MoveFocusPastSuggestions(suggestionItem);
+        }
+    }
+
+    private bool MoveFocusPastSuggestions(ListViewItem suggestionItem)
+    {
+        if (_nativeSuggestionsView == null)
+        {
+            return false;
+        }
+
+        var tabStops = GetRealizedTabStops(_nativeSuggestionsView);
+        foreach (var item in tabStops)
+        {
+            item.IsTabStop = false;
+        }
+
+        try
+        {
+            var moved = FocusManager.TryMoveFocus(FocusNavigationDirection.Next);
+            ClearFocusTargetAfterSuggestions();
+            if (moved && FocusManager.GetFocusedElement(_nativeSuggestionsView.XamlRoot) is UIElement focusTarget)
+            {
+                _focusSourceSuggestion = suggestionItem;
+                _focusTargetAfterSuggestions = focusTarget;
+                focusTarget.KeyDown += FocusTargetAfterSuggestions_KeyDown;
+            }
+
+            return moved;
+        }
+        finally
+        {
+            foreach (var item in tabStops)
+            {
+                item.IsTabStop = true;
+            }
+        }
+    }
+
+    private void FocusTargetAfterSuggestions_KeyDown(object sender, KeyRoutedEventArgs e)
+    {
+        if (e.Key == VirtualKey.Tab && IsShiftPressed() &&
+            ReferenceEquals(sender, _focusTargetAfterSuggestions) &&
+            _focusSourceSuggestion?.Visibility == NativeVisibility.Visible &&
+            _focusSourceSuggestion.Focus(FocusState.Keyboard))
+        {
+            e.Handled = true;
+        }
+    }
+
+    private void ClearFocusTargetAfterSuggestions()
+    {
+        if (_focusTargetAfterSuggestions != null)
+        {
+            _focusTargetAfterSuggestions.KeyDown -= FocusTargetAfterSuggestions_KeyDown;
+        }
+
+        _focusTargetAfterSuggestions = null;
+        _focusSourceSuggestion = null;
+    }
+
+    private static bool FocusFirstItem(ListViewBase? listView)
+    {
+        if (listView?.Visibility != NativeVisibility.Visible || !listView.IsEnabled || listView.Items.Count == 0)
+        {
+            return false;
+        }
+
+        listView.ScrollIntoView(listView.Items[0]);
+        listView.UpdateLayout();
+        return listView.ContainerFromIndex(0) is ListViewItem item && item.Focus(FocusState.Keyboard);
+    }
+
+    private static List<ListViewItem> GetRealizedTabStops(ListViewBase listView)
+    {
+        var items = new List<ListViewItem>();
+        for (var index = 0; index < listView.Items.Count; index++)
+        {
+            if (listView.ContainerFromIndex(index) is ListViewItem item && item.IsTabStop)
+            {
+                items.Add(item);
+            }
+        }
+
+        return items;
+    }
+
+    private static T? FindAncestor<T>(DependencyObject? element)
+        where T : DependencyObject
+    {
+        while (element != null)
+        {
+            if (element is T match)
+            {
+                return match;
+            }
+
+            element = Microsoft.UI.Xaml.Media.VisualTreeHelper.GetParent(element);
+        }
+
+        return null;
+    }
+
+    private static bool IsShiftPressed() =>
+        InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down);
+}
+#endif

--- a/src/Toolkit/Toolkit.Maui/SearchView/SearchView.Windows.cs
+++ b/src/Toolkit/Toolkit.Maui/SearchView/SearchView.Windows.cs
@@ -118,6 +118,7 @@ public partial class SearchView
         if (_nativeSourcesView != null)
         {
             NativeAutomationProperties.SetName(_nativeSourcesView, Properties.Resources.GetString("SearchViewSearchSources"));
+            _nativeSourcesView.SingleSelectionFollowsFocus = false;
             _sourcesViewKeyDownHandler ??= SourcesView_KeyDown;
             _nativeSourcesView.AddHandler(UIElement.KeyDownEvent, _sourcesViewKeyDownHandler, true);
         }
@@ -126,6 +127,7 @@ public partial class SearchView
         {
             NativeAutomationProperties.SetName(_nativeSuggestionsView, Properties.Resources.GetString("SearchViewSearchSuggestions"));
             _nativeSuggestionsView.IsTabStop = false;
+            _nativeSuggestionsView.SingleSelectionFollowsFocus = false;
             _nativeSuggestionsView.ChoosingGroupHeaderContainer += SuggestionsView_ChoosingGroupHeaderContainer;
             _suggestionsViewKeyDownHandler ??= SuggestionsView_KeyDown;
             _nativeSuggestionsView.AddHandler(UIElement.KeyDownEvent, _suggestionsViewKeyDownHandler, true);
@@ -134,6 +136,7 @@ public partial class SearchView
         if (PART_ResultView?.Handler?.PlatformView is ListViewBase resultView)
         {
             NativeAutomationProperties.SetName(resultView, Properties.Resources.GetString("SearchViewSearchResults"));
+            resultView.SingleSelectionFollowsFocus = false;
         }
     }
 

--- a/src/Toolkit/Toolkit.Maui/SearchView/SearchView.cs
+++ b/src/Toolkit/Toolkit.Maui/SearchView/SearchView.cs
@@ -751,6 +751,7 @@ public partial class SearchView : TemplatedView, INotifyPropertyChanged
             return;
         }
 
+        await Task.Yield();
         UpdateVisibility();
         AnnounceSearchItems(
             SearchViewModel.Results,

--- a/src/Toolkit/Toolkit.Maui/SearchView/SearchView.cs
+++ b/src/Toolkit/Toolkit.Maui/SearchView/SearchView.cs
@@ -643,7 +643,8 @@ public partial class SearchView : TemplatedView, INotifyPropertyChanged
                 UpdateVisibility();
                 AnnounceSearchItems(
                     SearchViewModel.Suggestions,
-                    Properties.Resources.GetString("SearchViewSuggestionsAvailable"));
+                    Properties.Resources.GetString("SearchViewSuggestionsAvailable"),
+                    PART_SuggestionsView);
                 break;
             case nameof(SearchViewModel.Results):
                 PART_ResultView?.SetValue(CollectionView.ItemsSourceProperty, SearchViewModel.Results ?? new List<SearchResult>());
@@ -753,7 +754,8 @@ public partial class SearchView : TemplatedView, INotifyPropertyChanged
         UpdateVisibility();
         AnnounceSearchItems(
             SearchViewModel.Results,
-            Properties.Resources.GetString("SearchViewResultsAvailable"));
+            Properties.Resources.GetString("SearchViewResultsAvailable"),
+            PART_ResultView);
 
         if (_focusResultsWhenAvailable && SearchViewModel.Results != null)
         {
@@ -798,17 +800,21 @@ public partial class SearchView : TemplatedView, INotifyPropertyChanged
         }
     }
 
-    private void AnnounceSearchItems<T>(IList<T>? items, string availableMessage)
+    private void AnnounceSearchItems<T>(IList<T>? items, string availableMessage, VisualElement? itemsView)
     {
         if (items == null)
         {
             return;
         }
 
-        var announcement = items.Count > 0 ? availableMessage : NoResultMessage;
+        var announcement = items.Count > 0 && itemsView?.IsVisible == true
+            ? availableMessage
+            : items.Count == 0 && PART_ResultLabel?.IsVisible == true
+                ? NoResultMessage
+                : null;
         if (!string.IsNullOrEmpty(announcement))
         {
-            Dispatcher.Dispatch(() => Microsoft.Maui.ApplicationModel.SemanticScreenReader.Default.Announce(announcement));
+            Dispatcher.Dispatch(() => Microsoft.Maui.Accessibility.SemanticScreenReader.Default.Announce(announcement));
         }
     }
 

--- a/src/Toolkit/Toolkit.Maui/SearchView/SearchView.cs
+++ b/src/Toolkit/Toolkit.Maui/SearchView/SearchView.cs
@@ -16,7 +16,6 @@
 using System;
 using System.Collections.Specialized;
 using System.ComponentModel;
-using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -62,9 +61,9 @@ public partial class SearchView : TemplatedView, INotifyPropertyChanged
 
     partial void OnSourceListOpened();
 
-    partial void OnSourceSelected();
-
     partial void OnResultFocusRequested();
+
+    partial void UpdateSourceSelectAutomationState();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SearchView"/> class.
@@ -255,7 +254,6 @@ public partial class SearchView : TemplatedView, INotifyPropertyChanged
         }
 
         UpdateVisibility();
-        UpdateSourceButtonAccessibility();
         ConnectKeyboardNavigation();
     }
 
@@ -290,8 +288,6 @@ public partial class SearchView : TemplatedView, INotifyPropertyChanged
 
         _sourceSelectToggled = false;
         UpdateVisibility();
-        UpdateSourceButtonAccessibility();
-        OnSourceSelected();
     }
 
     private void PART_RepeatButton_Clicked(object? sender, EventArgs e) => _ = RepeatSearchAndFocusResults();
@@ -400,20 +396,6 @@ public partial class SearchView : TemplatedView, INotifyPropertyChanged
         {
             OnResultFocusRequested();
         }
-    }
-
-    private void UpdateSourceButtonAccessibility()
-    {
-        if (PART_SourceSelectButton == null)
-        {
-            return;
-        }
-
-        var prompt = Properties.Resources.GetString("SearchViewSelectSearchSource");
-        var selectedSource = SearchViewModel?.ActiveSource?.DisplayName ?? AllSourcesSelectText;
-        var selectedFormat = Properties.Resources.GetString("SearchViewSelectedAutomationName") ?? "{0}, selected";
-        var selectedDescription = string.Format(CultureInfo.CurrentCulture, selectedFormat, selectedSource);
-        PART_SourceSelectButton.SetValue(SemanticProperties.DescriptionProperty, $"{prompt}. {selectedDescription}");
     }
 
     private void AddResultToGeoView(SearchResult result)
@@ -630,9 +612,6 @@ public partial class SearchView : TemplatedView, INotifyPropertyChanged
 
         switch (e.PropertyName)
         {
-            case nameof(SearchViewModel.ActiveSource):
-                UpdateSourceButtonAccessibility();
-                break;
             case nameof(SearchViewModel.ActivePlaceholder):
                 PART_Entry?.SetValue(Entry.PlaceholderProperty, SearchViewModel.ActivePlaceholder);
                 UpdateVisibility();
@@ -662,6 +641,9 @@ public partial class SearchView : TemplatedView, INotifyPropertyChanged
                 }
 
                 UpdateVisibility();
+                AnnounceSearchItems(
+                    SearchViewModel.Suggestions,
+                    Properties.Resources.GetString("SearchViewSuggestionsAvailable"));
                 break;
             case nameof(SearchViewModel.Results):
                 PART_ResultView?.SetValue(CollectionView.ItemsSourceProperty, SearchViewModel.Results ?? new List<SearchResult>());
@@ -769,6 +751,9 @@ public partial class SearchView : TemplatedView, INotifyPropertyChanged
         }
 
         UpdateVisibility();
+        AnnounceSearchItems(
+            SearchViewModel.Results,
+            Properties.Resources.GetString("SearchViewResultsAvailable"));
 
         if (_focusResultsWhenAvailable && SearchViewModel.Results != null)
         {
@@ -813,6 +798,20 @@ public partial class SearchView : TemplatedView, INotifyPropertyChanged
         }
     }
 
+    private void AnnounceSearchItems<T>(IList<T>? items, string availableMessage)
+    {
+        if (items == null)
+        {
+            return;
+        }
+
+        var announcement = items.Count > 0 ? availableMessage : NoResultMessage;
+        if (!string.IsNullOrEmpty(announcement))
+        {
+            Dispatcher.Dispatch(() => Microsoft.Maui.ApplicationModel.SemanticScreenReader.Default.Announce(announcement));
+        }
+    }
+
     private void UpdateVisibility()
     {
         PART_SuggestionsView?.SetValue(View.IsVisibleProperty, SuggestionsViewVisibility);
@@ -823,6 +822,7 @@ public partial class SearchView : TemplatedView, INotifyPropertyChanged
         PART_RepeatButton?.SetValue(View.IsVisibleProperty, RepeatSearchButtonVisibility);
         PART_RepeatButtonContainer?.SetValue(View.IsVisibleProperty, RepeatSearchButtonVisibility);
         PART_SourcesView?.SetValue(View.IsVisibleProperty, SourcePopupVisibility);
+        UpdateSourceSelectAutomationState();
     }
 
     #endregion events

--- a/src/Toolkit/Toolkit.Maui/SearchView/SearchView.cs
+++ b/src/Toolkit/Toolkit.Maui/SearchView/SearchView.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -52,6 +53,18 @@ public partial class SearchView : TemplatedView, INotifyPropertyChanged
     private bool _acceptingSuggestionFlag;
 
     private bool _sourceSelectToggled;
+
+    private bool _focusResultsWhenAvailable;
+
+    partial void ConnectKeyboardNavigation();
+
+    partial void DisconnectKeyboardNavigation();
+
+    partial void OnSourceListOpened();
+
+    partial void OnSourceSelected();
+
+    partial void OnResultFocusRequested();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SearchView"/> class.
@@ -123,6 +136,8 @@ public partial class SearchView : TemplatedView, INotifyPropertyChanged
     /// <inheritdoc/>
     protected override void OnApplyTemplate()
     {
+        DisconnectKeyboardNavigation();
+
         if (PART_SourceSelectButton != null)
         {
             PART_SourceSelectButton.Clicked -= PART_SourceSelectButton_Clicked;
@@ -240,6 +255,8 @@ public partial class SearchView : TemplatedView, INotifyPropertyChanged
         }
 
         UpdateVisibility();
+        UpdateSourceButtonAccessibility();
+        ConnectKeyboardNavigation();
     }
 
     private void HandleClearSearchCommand()
@@ -253,21 +270,16 @@ public partial class SearchView : TemplatedView, INotifyPropertyChanged
         SearchViewModel?.CommitSearch();
     }
 
-    private void HandleRepeatSearchHereCommand()
-    {
-        SearchViewModel?.RepeatSearchHere();
-    }
+    private void HandleRepeatSearchHereCommand() => _ = RepeatSearchAndFocusResults();
 
     private void PART_SourcesView_SelectionChanged(object? sender, SelectionChangedEventArgs e)
     {
-        if (SearchViewModel == null)
+        if (SearchViewModel == null || e.CurrentSelection.FirstOrDefault() is not string selectedSource)
         {
             return;
         }
 
-        var selectedSource = e.CurrentSelection.FirstOrDefault() as string;
-
-        if (selectedSource == null || selectedSource == AllSourcesSelectText || (AllSourcesSelectText == null && selectedSource == "All"))
+        if (selectedSource == AllSourcesSelectText || (AllSourcesSelectText == null && selectedSource == "All"))
         {
             SearchViewModel.ActiveSource = null;
         }
@@ -278,9 +290,11 @@ public partial class SearchView : TemplatedView, INotifyPropertyChanged
 
         _sourceSelectToggled = false;
         UpdateVisibility();
+        UpdateSourceButtonAccessibility();
+        OnSourceSelected();
     }
 
-    private void PART_RepeatButton_Clicked(object? sender, EventArgs e) => SearchViewModel?.RepeatSearchHere();
+    private void PART_RepeatButton_Clicked(object? sender, EventArgs e) => _ = RepeatSearchAndFocusResults();
 
     private void PART_SuggestionsView_ItemSelected(object? sender, SelectionChangedEventArgs e)
     {
@@ -311,6 +325,10 @@ public partial class SearchView : TemplatedView, INotifyPropertyChanged
         }
 
         UpdateVisibility();
+        if (_sourceSelectToggled)
+        {
+            OnSourceListOpened();
+        }
     }
 
     private void PART_Entry_TextChanged(object? sender, TextChangedEventArgs e)
@@ -368,6 +386,34 @@ public partial class SearchView : TemplatedView, INotifyPropertyChanged
         {
             _acceptingSuggestionFlag = false;
         }
+    }
+
+    private async Task RepeatSearchAndFocusResults()
+    {
+        if (SearchViewModel == null)
+        {
+            return;
+        }
+
+        await SearchViewModel.RepeatSearchHere();
+        if (SearchViewModel.Results?.Count > 0)
+        {
+            OnResultFocusRequested();
+        }
+    }
+
+    private void UpdateSourceButtonAccessibility()
+    {
+        if (PART_SourceSelectButton == null)
+        {
+            return;
+        }
+
+        var prompt = Properties.Resources.GetString("SearchViewSelectSearchSource");
+        var selectedSource = SearchViewModel?.ActiveSource?.DisplayName ?? AllSourcesSelectText;
+        var selectedFormat = Properties.Resources.GetString("SearchViewSelectedAutomationName") ?? "{0}, selected";
+        var selectedDescription = string.Format(CultureInfo.CurrentCulture, selectedFormat, selectedSource);
+        PART_SourceSelectButton.SetValue(SemanticProperties.DescriptionProperty, $"{prompt}. {selectedDescription}");
     }
 
     private void AddResultToGeoView(SearchResult result)
@@ -584,6 +630,9 @@ public partial class SearchView : TemplatedView, INotifyPropertyChanged
 
         switch (e.PropertyName)
         {
+            case nameof(SearchViewModel.ActiveSource):
+                UpdateSourceButtonAccessibility();
+                break;
             case nameof(SearchViewModel.ActivePlaceholder):
                 PART_Entry?.SetValue(Entry.PlaceholderProperty, SearchViewModel.ActivePlaceholder);
                 UpdateVisibility();
@@ -720,6 +769,15 @@ public partial class SearchView : TemplatedView, INotifyPropertyChanged
         }
 
         UpdateVisibility();
+
+        if (_focusResultsWhenAvailable && SearchViewModel.Results != null)
+        {
+            _focusResultsWhenAvailable = false;
+            if (SearchViewModel.Results.Count > 0)
+            {
+                OnResultFocusRequested();
+            }
+        }
 
         if (SearchViewModel.Results == null)
         {

--- a/src/Toolkit/Toolkit/LocalizedStrings/Resources.resx
+++ b/src/Toolkit/Toolkit/LocalizedStrings/Resources.resx
@@ -613,6 +613,14 @@
     <value>Select search source</value>
     <comment>UIA AutomationProperties.Name for the button to display search sources, used by screen readers to identify the control</comment>
   </data>
+  <data name="SearchViewCollapsedAutomationState" xml:space="preserve">
+    <value>collapsed</value>
+    <comment>UIA accessible state announced when the search source list is closed</comment>
+  </data>
+  <data name="SearchViewExpandedAutomationState" xml:space="preserve">
+    <value>expanded</value>
+    <comment>UIA accessible state announced when the search source list is open</comment>
+  </data>
   <data name="SearchViewSelectedAutomationName" xml:space="preserve">
     <value>{0}, selected</value>
     <comment>UIA accessible name for the selected search source; {0} is the source name</comment>


### PR DESCRIPTION
I tried to keep the behavior of Maui Winui consistent with WinUI. Will be raising a stacked PR for android

- Enables complete Tab/ Shift+Tab/ arrow keys navigation across source, suggestion, and result popups.
- Moves focus to results after keyboard suggestion selection and completed repeat searches.
- Enables the screen reader to announce the availability of suggestions, results and conveys no results message. 

