### PR TITLE
[a11y] [WPF] [WinUI]: Search View text scaling

### DIFF
--- a/src/Toolkit/Toolkit.WPF/Internal/TextScaledFontSizeExtension.cs
+++ b/src/Toolkit/Toolkit.WPF/Internal/TextScaledFontSizeExtension.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Windows.Markup;
+using Windows.UI.ViewManagement;
+
+namespace Esri.ArcGISRuntime.Toolkit.Internal
+{
+    /// <summary>
+    /// Provides a font size adjusted by the Windows text scale factor.
+    /// </summary>
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public sealed class TextScaledFontSizeExtension : MarkupExtension
+    {
+        /// <summary>
+        /// Gets or sets the unscaled font size.
+        /// </summary>
+        public double FontSize { get; set; }
+
+        /// <inheritdoc/>
+        public override object ProvideValue(IServiceProvider serviceProvider) =>
+            FontSize * new UISettings().TextScaleFactor;
+    }
+}

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/SearchView/SearchView.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/SearchView/SearchView.Theme.xaml
@@ -216,7 +216,7 @@
         <Setter Property="Padding" Value="0" />
         <Setter Property="Background" Value="{StaticResource DefaultControlBackgroundBrush}" />
         <Setter Property="Width" Value="32" />
-        <Setter Property="Height" Value="32" />
+        <Setter Property="MinHeight" Value="32" />
         <Setter Property="BorderThickness" Value="0,0,0,0" />
         <Setter Property="BorderBrush" Value="{StaticResource CommonGrayBrush}" />
         <Setter Property="OverridesDefaultStyle" Value="True" />
@@ -232,7 +232,7 @@
         <Border BorderBrush="{StaticResource ItemSeparatorBrush}" BorderThickness="0,1,0,0">
             <TextBlock
                 Padding="8"
-                FontSize="12"
+                FontSize="{DynamicResource {x:Static SystemFonts.MessageFontSizeKey}}"
                 Text="{Binding DisplayName, Mode=OneWay}"
                 TextWrapping="Wrap" />
         </Border>
@@ -258,14 +258,14 @@
     </Style>
     <Style x:Key="QueryEntryStyle" TargetType="TextBox">
         <Setter Property="Padding" Value="8,0,0,0" />
-        <Setter Property="FontSize" Value="14" />
+        <Setter Property="FontSize" Value="{converter:TextScaledFontSize FontSize=14}" />
         <Setter Property="MaxLines" Value="1" />
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
     </Style>
     <Style x:Key="QueryPlaceholderStyle" TargetType="TextBlock">
         <Setter Property="Padding" Value="8,4,4,4" />
-        <Setter Property="FontSize" Value="14" />
+        <Setter Property="FontSize" Value="{converter:TextScaledFontSize FontSize=14}" />
         <Setter Property="Foreground" Value="{StaticResource CommonGrayBrush}" />
         <Setter Property="VerticalAlignment" Value="Center" />
         <Setter Property="IsHitTestVisible" Value="False" />
@@ -384,6 +384,7 @@
                         Grid.Column="1"
                         Style="{StaticResource QueryPlaceholderStyle}"
                         Text="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=SearchViewModel.ActivePlaceholder, Mode=OneWay}"
+                        TextWrapping="Wrap"
                         Visibility="{Binding ElementName=QueryEntry, Path=Text, Converter={StaticResource PlaceholderVisibilityConverter}}" />
                     <Button
                         Grid.Column="2"
@@ -481,7 +482,7 @@
                                                     Visibility="{Binding ElementName=Self, Path=DataContext.SourceSelectVisibility, Mode=OneWay}">
                                                     <TextBlock
                                                         Margin="8"
-                                                        FontSize="11"
+                                                        FontSize="{converter:TextScaledFontSize FontSize=11}"
                                                         FontWeight="SemiBold"
                                                         Foreground="White"
                                                         Text="{Binding Name.DisplayName}"

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/SearchView/SearchView.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/SearchView/SearchView.Theme.xaml
@@ -349,9 +349,10 @@
                         PlacementTarget="{Binding ElementName=PopupTarget}"
                         StaysOpen="False">
                         <Border Style="{StaticResource ResultAreaBorderStyle}">
-                            <StackPanel>
+                            <DockPanel LastChildFill="True">
                                 <controls:AllSourcesToggleButton
                                     x:Name="PART_AllSourcesButton"
+                                    DockPanel.Dock="Top"
                                     Width="{Binding ElementName=PART_SourceList, Path=ActualWidth, Mode=OneWay}"
                                     HorizontalContentAlignment="Left"
                                     BorderThickness="0"
@@ -370,7 +371,7 @@
                                     Style="{StaticResource ListStyle}" 
                                     AutomationProperties.Name="{converter:LocalizedString Key=SearchViewSearchSources}"
                                     AutomationProperties.AutomationId="SearchSourcesList"/>
-                            </StackPanel>
+                                    </DockPanel>
                         </Border>
                     </Popup>
                     <TextBox

--- a/src/Toolkit/Toolkit.WinUI/UI/Controls/SearchView/SearchView.Theme.xaml
+++ b/src/Toolkit/Toolkit.WinUI/UI/Controls/SearchView/SearchView.Theme.xaml
@@ -229,7 +229,7 @@
                     <TextBlock
                         Style="{ThemeResource Search.SecondaryTextBlockStyle}"
                         Text="{Binding Path=DisplaySubtitle}"
-                        TextTrimming="CharacterEllipsis"
+                        TextWrapping="Wrap"
                         Visibility="{Binding Path=DisplaySubtitle, Mode=OneWay, Converter={StaticResource PlaceholderVisibilityConverter}, ConverterParameter='NotEmpty'}" />
                 </StackPanel>
             </Grid>
@@ -283,7 +283,8 @@
     </Style>
     <Style x:Key="BarActionButtonStyle" TargetType="ButtonBase">
         <Setter Property="Width" Value="32" />
-        <Setter Property="Height" Value="32" />
+        <Setter Property="MinHeight" Value="32" />
+        <Setter Property="VerticalAlignment" Value="Stretch" />
         <Setter Property="Padding" Value="0" />
         <Setter Property="Template">
             <Setter.Value>
@@ -513,17 +514,6 @@
                 </Style>
             </Setter.Value>
         </Setter>
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="ListView">
-                    <Border Name="Border">
-                        <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
-                            <ItemsPresenter />
-                        </ScrollViewer>
-                    </Border>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
     </Style>
     <Style x:Key="ActionButtonPathStyle" TargetType="Path">
         <Setter Property="Width" Value="12" />
@@ -576,6 +566,7 @@
                         VerticalAlignment="Center"
                         Style="{StaticResource QueryPlaceholderStyle}"
                         Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=SearchViewModel.ActivePlaceholder, Mode=OneWay}"
+                        TextWrapping="Wrap"
                         Visibility="{Binding ElementName=QueryEntry, Path=Text, Converter={StaticResource PlaceholderVisibilityConverter}}" />
                     <Button
                         Grid.Column="2"
@@ -606,7 +597,10 @@
                         Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=SearchViewModel.IsWaiting, Mode=OneWay}" />
                 </Grid>
             </Border>
-            <Popup IsOpen="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=SearchViewModel.Suggestions.Count, Mode=OneWay, Converter={StaticResource CollectionIsEmptyToBoolConverter}, ConverterParameter='NotEmpty'}" VerticalOffset="34">
+            <Popup
+                Grid.Row="1"
+                IsOpen="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=SearchViewModel.Suggestions.Count, Mode=OneWay, Converter={StaticResource CollectionIsEmptyToBoolConverter}, ConverterParameter='NotEmpty'}"
+                VerticalOffset="0.5">
                 <Popup.Resources>
                     <CollectionViewSource
                         x:Key="GroupedSuggestionsEx"
@@ -615,6 +609,7 @@
                 </Popup.Resources>
                 <Border
                     Width="{TemplateBinding Width}"
+                    MaxHeight="300"
                     BorderThickness="1,0,1,1"
                     Style="{StaticResource ResultAreaBorderStyle}"
                     Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=SearchViewModel.Results.Count, Mode=OneWay, Converter={StaticResource CollectionIsEmptyToBoolConverter}, ConverterParameter='Empty'}">
@@ -696,11 +691,19 @@
             </Border>
             <Popup
                 x:Name="PART_SourcePopup"
+                Grid.Row="1"
                 IsLightDismissEnabled="True"
                 IsOpen="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsSourceSelectOpen, Mode=TwoWay}"
-                VerticalOffset="34">
-                <Border Width="{TemplateBinding Width}" Style="{StaticResource ResultAreaBorderStyle}">
-                    <StackPanel>
+                VerticalOffset="0.5">
+                <Border
+                    Width="{TemplateBinding Width}"
+                    MaxHeight="300"
+                    Style="{StaticResource ResultAreaBorderStyle}">
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="*" />
+                        </Grid.RowDefinitions>
                         <controls:AllSourcesToggleButton
                             x:Name="PART_AllSourcesButton"
                             Content="{TemplateBinding AllSourceSelectText}"
@@ -709,6 +712,7 @@
                             AutomationProperties.AutomationId="AllSourcesButton"/>
                         <ListView
                             x:Name="PART_SourceList"
+                            Grid.Row="1"
                             ItemTemplate="{StaticResource SourceTemplate}"
                             ItemsSource="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=SearchViewModel.Sources, Mode=OneWay}"
                             SelectedItem="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=SearchViewModel.ActiveSource, Mode=TwoWay}"
@@ -717,7 +721,7 @@
                             AutomationProperties.AutomationId="SearchSourcesList"
                             SelectionMode="Single"
                             SingleSelectionFollowsFocus="False"/>
-                    </StackPanel>
+                    </Grid>
                 </Border>
             </Popup>
             <StackPanel


### PR DESCRIPTION
According to [WCAG guidelines](https://www.w3.org/WAI/WCAG21/Understanding/resize-text.html) any text displayed should be scalable up to 200% without any loss/ truncation of information.

Note: Winui automatically scales up the fontsize even if it is set to a hard coded value like 12px. WPF scales up, if nothing is set for fontsize or if we are using system resources. Explicit scaling is required for WPF, if none of the above scenarios meet.

Observed that some of the listviews in both wpf and winui were not scrollable, so fixed them as well

WPF:

https://github.com/user-attachments/assets/ae8af13d-e21c-46f4-ad5e-5f140b009790

WinUI:


https://github.com/user-attachments/assets/1796a4bf-cdc5-46c1-80d7-5dac2b7ea50e

